### PR TITLE
Add ticket search and update endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# HelpDesk AI Agent
+
+This project exposes a FastAPI service for managing help desk tickets and querying OpenAI for suggested responses.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set environment variables:
+   - `DB_CONN_STRING` - SQLAlchemy connection string for the MS SQL database.
+   - `OPENAI_API_KEY` - API key for OpenAI.
+
+3. Run the API:
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+### API Highlights
+
+- `POST /ticket` - create a ticket
+- `GET /tickets` - list tickets
+- `GET /tickets/search?q=term` - search tickets by subject or body
+- `PUT /ticket/{id}` - update an existing ticket
+- `DELETE /ticket/{id}` - remove a ticket
+
+## Tests
+
+Tests use `pytest`. Run them with:
+
+```bash
+pytest
+```

--- a/ai/openai_agent.py
+++ b/ai/openai_agent.py
@@ -1,6 +1,9 @@
 import openai
 from config import OPENAI_API_KEY
 
+if not OPENAI_API_KEY:
+    raise RuntimeError("OPENAI_API_KEY environment variable not set")
+
 openai.api_key = OPENAI_API_KEY
 
 def suggest_ticket_response(ticket: dict, context: str = "") -> str:
@@ -10,8 +13,12 @@ def suggest_ticket_response(ticket: dict, context: str = "") -> str:
         f"Context: {context}\n"
         "Suggest the best response, including troubleshooting or assignment if possible."
     )
-    response = openai.ChatCompletion.create(
-        model="gpt-4o",
-        messages=[{"role": "system", "content": prompt}]
-    )
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-4o",
+            messages=[{"role": "system", "content": prompt}]
+        )
+    except openai.error.OpenAIError as exc:
+        return f"OpenAI API error: {exc}"
+
     return response['choices'][0]['message']['content']

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,7 +1,14 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from db.session import SessionLocal
-from tools.ticket_tools import get_ticket, list_tickets, create_ticket
+from db.mssql import SessionLocal
+from tools.ticket_tools import (
+    get_ticket,
+    list_tickets,
+    create_ticket,
+    update_ticket,
+    delete_ticket,
+    search_tickets,
+)
 from tools.asset_tools import get_asset, list_assets
 from tools.vendor_tools import get_vendor, list_vendors
 from tools.attachment_tools import get_ticket_attachments
@@ -14,6 +21,7 @@ from tools.analysis_tools import tickets_by_status, open_tickets_by_site, sla_br
 
 from pydantic import BaseModel
 from datetime import datetime
+from schemas import TicketCreate, TicketOut
 
 router = APIRouter()
 
@@ -29,23 +37,40 @@ class MessageIn(BaseModel):
     sender_code: str
     sender_name: str
 
-@router.get("/ticket/{ticket_id}")
+@router.get("/ticket/{ticket_id}", response_model=TicketOut)
 def api_get_ticket(ticket_id: int, db: Session = Depends(get_db)):
     ticket = get_ticket(db, ticket_id)
     if not ticket:
         raise HTTPException(status_code=404, detail="Ticket not found")
     return ticket
 
-@router.get("/tickets")
+@router.get("/tickets", response_model=list[TicketOut])
 def api_list_tickets(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
     return list_tickets(db, skip, limit)
 
-@router.post("/ticket")
-def api_create_ticket(ticket: dict, db: Session = Depends(get_db)):
+@router.get("/tickets/search", response_model=list[TicketOut])
+def api_search_tickets(q: str, limit: int = 10, db: Session = Depends(get_db)):
+    return search_tickets(db, q, limit)
+
+@router.post("/ticket", response_model=TicketOut)
+def api_create_ticket(ticket: TicketCreate, db: Session = Depends(get_db)):
     from db.models import Ticket
-    obj = Ticket(**ticket)
+    obj = Ticket(**ticket.dict(), Created_Date=datetime.utcnow())
     created = create_ticket(db, obj)
-    return {"Ticket_ID": created.Ticket_ID}
+    return created
+
+@router.put("/ticket/{ticket_id}", response_model=TicketOut)
+def api_update_ticket(ticket_id: int, updates: dict, db: Session = Depends(get_db)):
+    ticket = update_ticket(db, ticket_id, updates)
+    if not ticket:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    return ticket
+
+@router.delete("/ticket/{ticket_id}")
+def api_delete_ticket(ticket_id: int, db: Session = Depends(get_db)):
+    if not delete_ticket(db, ticket_id):
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    return {"deleted": True}
 
 @router.get("/asset/{asset_id}")
 def api_get_asset(asset_id: int, db: Session = Depends(get_db)):

--- a/db/models.py
+++ b/db/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, Boolean, Float, Text
+from sqlalchemy import Column, Integer, String, DateTime, Text
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()

--- a/db/mssql.py
+++ b/db/mssql.py
@@ -2,5 +2,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from config import DB_CONN_STRING
 
-engine = create_engine(DB_CONN_STRING, fast_executemany=True)
+engine_args = {}
+if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):
+    engine_args["fast_executemany"] = True
+
+engine = create_engine(DB_CONN_STRING or "sqlite:///:memory:", **engine_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/db/session.py
+++ b/db/session.py
@@ -1,4 +1,0 @@
-from sqlalchemy.orm import sessionmaker
-from db.mssql import engine
-
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pydantic
 pyodbc
 python-dotenv
 openai
+pytest
+email-validator

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, EmailStr
+from datetime import datetime
+from typing import Optional
+
+class TicketBase(BaseModel):
+    Subject: str
+    Ticket_Body: str
+    Ticket_Status_ID: Optional[int] = 1
+    Ticket_Contact_Name: str
+    Ticket_Contact_Email: EmailStr
+    Asset_ID: Optional[int] = None
+    Site_ID: Optional[int] = None
+    Ticket_Category_ID: Optional[int] = None
+    Assigned_Name: Optional[str] = None
+    Assigned_Email: Optional[EmailStr] = None
+    Severity_ID: Optional[int] = None
+    Assigned_Vendor_ID: Optional[int] = None
+    Resolution: Optional[str] = None
+
+class TicketCreate(TicketBase):
+    pass
+
+class TicketOut(TicketBase):
+    Ticket_ID: int
+    Created_Date: Optional[datetime] = None
+
+    class Config:
+        orm_mode = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,14 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("DB_CONN_STRING", "sqlite:///:memory:")
+
+root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))
+
+from main import app
+
+def test_app_loads():
+    assert app.title

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,24 @@
+import os
+from sqlalchemy.orm import Session
+from db.models import Base, Ticket
+from db.mssql import engine, SessionLocal
+from tools.ticket_tools import search_tickets, create_ticket
+from datetime import datetime
+
+os.environ.setdefault("DB_CONN_STRING", "sqlite:///:memory:")
+
+Base.metadata.create_all(engine)
+
+def test_search_tickets():
+    db: Session = SessionLocal()
+    try:
+        t = Ticket(
+            Subject="Network issue",
+            Ticket_Body="Cannot connect",
+            Created_Date=datetime.utcnow(),
+        )
+        create_ticket(db, t)
+        results = search_tickets(db, "Network")
+        assert results and results[0].Subject == "Network issue"
+    finally:
+        db.close()

--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -18,7 +18,11 @@ def post_ticket_message(db: Session, ticket_id: int, message: str, sender_code: 
         SenderUserName=sender_name,
         DateTimeStamp=datetime.utcnow()
     )
-    db.add(msg)
-    db.commit()
-    db.refresh(msg)
-    return msg
+    try:
+        db.add(msg)
+        db.commit()
+        db.refresh(msg)
+        return msg
+    except Exception:
+        db.rollback()
+        raise

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -8,7 +8,47 @@ def list_tickets(db: Session, skip: int = 0, limit: int = 10):
     return db.query(Ticket).offset(skip).limit(limit).all()
 
 def create_ticket(db: Session, ticket_obj: Ticket):
-    db.add(ticket_obj)
-    db.commit()
-    db.refresh(ticket_obj)
-    return ticket_obj
+    try:
+        db.add(ticket_obj)
+        db.commit()
+        db.refresh(ticket_obj)
+        return ticket_obj
+    except Exception:
+        db.rollback()
+        raise
+
+def update_ticket(db: Session, ticket_id: int, updates: dict) -> Ticket | None:
+    ticket = get_ticket(db, ticket_id)
+    if not ticket:
+        return None
+    for key, value in updates.items():
+        if hasattr(ticket, key):
+            setattr(ticket, key, value)
+    try:
+        db.commit()
+        db.refresh(ticket)
+        return ticket
+    except Exception:
+        db.rollback()
+        raise
+
+def delete_ticket(db: Session, ticket_id: int) -> bool:
+    ticket = get_ticket(db, ticket_id)
+    if not ticket:
+        return False
+    try:
+        db.delete(ticket)
+        db.commit()
+        return True
+    except Exception:
+        db.rollback()
+        raise
+
+def search_tickets(db: Session, query: str, limit: int = 10):
+    like = f"%{query}%"
+    return (
+        db.query(Ticket)
+        .filter((Ticket.Subject.ilike(like)) | (Ticket.Ticket_Body.ilike(like)))
+        .limit(limit)
+        .all()
+    )


### PR DESCRIPTION
## Summary
- add REST endpoints for ticket search, update and delete
- implement search and management helpers
- document new routes in README
- add regression test for search functionality

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686352be334c832baf95fff5a9ca3306