### PR TITLE
Improve error handling and API key validation

### DIFF
--- a/ai/openai_agent.py
+++ b/ai/openai_agent.py
@@ -1,4 +1,5 @@
 import openai
+from openai.error import OpenAIError, Timeout
 from config import OPENAI_API_KEY
 
 openai.api_key = OPENAI_API_KEY
@@ -10,8 +11,14 @@ def suggest_ticket_response(ticket: dict, context: str = "") -> str:
         f"Context: {context}\n"
         "Suggest the best response, including troubleshooting or assignment if possible."
     )
-    response = openai.ChatCompletion.create(
-        model="gpt-4o",
-        messages=[{"role": "system", "content": prompt}]
-    )
-    return response['choices'][0]['message']['content']
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-4o",
+            messages=[{"role": "system", "content": prompt}],
+            timeout=15,
+        )
+        return response["choices"][0]["message"]["content"]
+    except Timeout:
+        return "OpenAI request timed out."
+    except OpenAIError as e:
+        return f"OpenAI API error: {e}"

--- a/config.py
+++ b/config.py
@@ -5,3 +5,6 @@ load_dotenv()
 
 DB_CONN_STRING = os.getenv("DB_CONN_STRING")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+if not OPENAI_API_KEY:
+    raise EnvironmentError("OPENAI_API_KEY environment variable is required")

--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -1,4 +1,6 @@
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+from fastapi import HTTPException
 from db.models import TicketMessage
 from datetime import datetime
 
@@ -19,6 +21,10 @@ def post_ticket_message(db: Session, ticket_id: int, message: str, sender_code: 
         DateTimeStamp=datetime.utcnow()
     )
     db.add(msg)
-    db.commit()
-    db.refresh(msg)
+    try:
+        db.commit()
+        db.refresh(msg)
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to save message: {e}")
     return msg

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -1,4 +1,6 @@
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+from fastapi import HTTPException
 from db.models import Ticket
 
 def get_ticket(db: Session, ticket_id: int):
@@ -9,6 +11,10 @@ def list_tickets(db: Session, skip: int = 0, limit: int = 10):
 
 def create_ticket(db: Session, ticket_obj: Ticket):
     db.add(ticket_obj)
-    db.commit()
-    db.refresh(ticket_obj)
+    try:
+        db.commit()
+        db.refresh(ticket_obj)
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to create ticket: {e}")
     return ticket_obj


### PR DESCRIPTION
## Summary
- enforce presence of `OPENAI_API_KEY`
- handle OpenAI API errors and timeouts
- wrap DB commit operations with try/except and return helpful errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68635ec1cca0832bbeee383a03c47411