### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,8 @@ Install the testing dependencies and run `pytest`:
 
 ```bash
 pip install -r requirements.txt
-
-This project exposes a FastAPI service for managing help desk tickets and querying OpenAI for suggested responses.
-
-## Setup
-
-1. Install dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
-2. Set environment variables:
-   - `DB_CONN_STRING` - SQLAlchemy connection string for the MS SQL database.
-   - `OPENAI_API_KEY` - API key for OpenAI.
-
-3. Run the API:
-   ```bash
-   uvicorn main:app --reload
-   ```
+pytest
+```
 
 ### API Highlights
 
@@ -58,12 +43,3 @@ This project exposes a FastAPI service for managing help desk tickets and queryi
 - `GET /tickets/search?q=term` - search tickets by subject or body
 - `PUT /ticket/{id}` - update an existing ticket
 - `DELETE /ticket/{id}` - remove a ticket
-
-## Tests
-
-Tests use `pytest`. Run them with:
-
-```bash
-
-pytest
-```


### PR DESCRIPTION
## Summary
- close unclosed code block in README
- remove duplicated setup instructions
- keep API highlights section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863e764a9d4832bb7b9a7ef2b2d6219