### PR TITLE
Clean duplicate import and endpoint

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2,8 +2,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from db.mssql import SessionLocal
 
-from tools.ticket_tools import get_ticket, list_tickets, create_ticket
-
 from tools.ticket_tools import (
     get_ticket,
     list_tickets,
@@ -60,9 +58,6 @@ def api_list_tickets(skip: int = 0, limit: int = 10, db: Session = Depends(get_d
     return list_tickets(db, skip, limit)
 
 
-@router.get("/tickets", response_model=list[TicketOut])
-def api_list_tickets(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
-    return list_tickets(db, skip, limit)
 
 @router.get("/tickets/search", response_model=list[TicketOut])
 def api_search_tickets(q: str, limit: int = 10, db: Session = Depends(get_db)):


### PR DESCRIPTION
## Summary
- tidy imports in `api/routes.py`
- remove duplicate `api_list_tickets` handler

## Testing
- `python -m py_compile api/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6863e7647cd0832bb866f439144cb845