### PR TITLE
Make OpenAI key optional

### DIFF
--- a/ai/openai_agent.py
+++ b/ai/openai_agent.py
@@ -1,15 +1,18 @@
 import openai
-from openai.error import OpenAIError, Timeout
-from config import OPENAI_API_KEY
+from openai import OpenAIError, Timeout
+from config import require_openai_key
 
-if not OPENAI_API_KEY:
-    raise RuntimeError("OPENAI_API_KEY environment variable not set")
 
-openai.api_key = OPENAI_API_KEY
+def _set_api_key() -> None:
+    """Configure the OpenAI client with the API key."""
+    openai.api_key = require_openai_key()
+
 
 def suggest_ticket_response(ticket: dict, context: str = "") -> str:
+    """Return a suggested response for a help desk ticket using OpenAI."""
+    _set_api_key()
     prompt = (
-        f"You are a Tier 1 help desk agent for a truck stop. Here is the ticket:\n"
+        "You are a Tier 1 help desk agent for a truck stop. Here is the ticket:\n"
         f"{ticket}\n"
         f"Context: {context}\n"
         "Suggest the best response, including troubleshooting or assignment if possible."
@@ -17,7 +20,6 @@ def suggest_ticket_response(ticket: dict, context: str = "") -> str:
     try:
         response = openai.ChatCompletion.create(
             model="gpt-4o",
-
             messages=[{"role": "system", "content": prompt}],
             timeout=15,
         )
@@ -26,11 +28,4 @@ def suggest_ticket_response(ticket: dict, context: str = "") -> str:
         return "OpenAI request timed out."
     except OpenAIError as e:
         return f"OpenAI API error: {e}"
-
-            messages=[{"role": "system", "content": prompt}]
-        )
-    except openai.error.OpenAIError as exc:
-        return f"OpenAI API error: {exc}"
-
-    return response['choices'][0]['message']['content']
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -27,10 +27,8 @@ from pydantic import BaseModel
 
 from typing import List
 
-from schemas.ticket import TicketIn, TicketOut
-
 from datetime import datetime
-from schemas import TicketCreate, TicketOut
+from schemas import TicketCreate, TicketOut, TicketIn
 
 
 router = APIRouter()

--- a/config.py
+++ b/config.py
@@ -6,5 +6,8 @@ load_dotenv()
 DB_CONN_STRING = os.getenv("DB_CONN_STRING")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
-if not OPENAI_API_KEY:
-    raise EnvironmentError("OPENAI_API_KEY environment variable is required")
+def require_openai_key() -> str:
+    """Return the OpenAI API key or raise if it is missing."""
+    if not OPENAI_API_KEY:
+        raise EnvironmentError("OPENAI_API_KEY environment variable is required")
+    return OPENAI_API_KEY

--- a/schemas.py
+++ b/schemas.py
@@ -26,3 +26,20 @@ class TicketOut(TicketBase):
 
     class Config:
         orm_mode = True
+
+
+class TicketIn(BaseModel):
+    Subject: Optional[str] = None
+    Ticket_Body: Optional[str] = None
+    Ticket_Status_ID: Optional[int] = None
+    Ticket_Contact_Name: Optional[str] = None
+    Ticket_Contact_Email: Optional[str] = None
+    Asset_ID: Optional[int] = None
+    Site_ID: Optional[int] = None
+    Ticket_Category_ID: Optional[int] = None
+    Created_Date: Optional[datetime] = None
+    Assigned_Name: Optional[str] = None
+    Assigned_Email: Optional[EmailStr] = None
+    Severity_ID: Optional[int] = None
+    Assigned_Vendor_ID: Optional[int] = None
+    Resolution: Optional[str] = None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,26 +1,9 @@
 import os
 
-
-# Provide defaults so importing the app doesn't fail
-os.environ.setdefault("DB_CONN_STRING", "mssql+pyodbc://user:pass@localhost/testdb?driver=ODBC+Driver+17+for+SQL+Server")
-os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("DB_CONN_STRING", "sqlite:///:memory:")
 
 from main import app
+
 
 def test_app_import():
     assert app.title == "Truck Stop MCP Helpdesk API"
-
-import sys
-from pathlib import Path
-
-os.environ.setdefault("OPENAI_API_KEY", "test")
-os.environ.setdefault("DB_CONN_STRING", "sqlite:///:memory:")
-
-root = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(root))
-
-from main import app
-
-def test_app_loads():
-    assert app.title
-

--- a/tests/test_openai_agent.py
+++ b/tests/test_openai_agent.py
@@ -1,0 +1,13 @@
+import os
+import pytest
+
+from ai import openai_agent
+import config
+import importlib
+
+
+def test_require_api_key_missing(monkeypatch):
+    monkeypatch.setattr(config, "OPENAI_API_KEY", None)
+    importlib.reload(openai_agent)
+    with pytest.raises(EnvironmentError):
+        openai_agent.suggest_ticket_response({"Subject": "Test"})


### PR DESCRIPTION
## Summary
- defer OPENAI_API_KEY validation until utilities use it
- fix `openai_agent` to check for key when called
- consolidate schema imports and add missing `TicketIn`
- simplify app test and add coverage for missing API key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e76395b8832bb266feaebf17b3ae