### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv
 __pycache__/
 .pytest_cache/
+.env


### PR DESCRIPTION
## Summary
- avoid accidental commits of environment files by ignoring `.env`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863eab32e90832ba057ae69d18bd777