### PR TITLE
Add httpx requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.1.1
 openai==1.93.0
 pytest==8.4.1
 email-validator==2.2.0
+httpx<0.28


### PR DESCRIPTION
## Summary
- add `httpx<0.28` to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f18fc284832ba1a6513f94fa324e