### PR TITLE
Maintain Ticket list typing style

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -19,18 +19,24 @@ from tools.category_tools import list_categories
 from tools.status_tools import list_statuses
 from tools.message_tools import get_ticket_messages, post_ticket_message
 from tools.ai_tools import ai_suggest_response
-from tools.analysis_tools import tickets_by_status, open_tickets_by_site, sla_breaches, open_tickets_by_user, tickets_waiting_on_user
+from tools.analysis_tools import (
+    tickets_by_status,
+    open_tickets_by_site,
+    sla_breaches,
+    open_tickets_by_user,
+    tickets_waiting_on_user,
+)
 
 from pydantic import BaseModel
 
-from typing import List
 
-from schemas.ticket import TicketIn, TicketOut, TicketCreate
+from schemas.ticket import TicketOut, TicketCreate
 
 from datetime import datetime
 
 
 router = APIRouter()
+
 
 def get_db():
     db = SessionLocal()
@@ -39,10 +45,12 @@ def get_db():
     finally:
         db.close()
 
+
 class MessageIn(BaseModel):
     message: str
     sender_code: str
     sender_name: str
+
 
 @router.get("/ticket/{ticket_id}", response_model=TicketOut)
 def api_get_ticket(ticket_id: int, db: Session = Depends(get_db)):
@@ -52,15 +60,19 @@ def api_get_ticket(ticket_id: int, db: Session = Depends(get_db)):
     return ticket
 
 
-@router.get("/tickets", response_model=List[TicketOut])
-def api_list_tickets(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+@router.get("/tickets", response_model=list[TicketOut])
+def api_list_tickets(
+    skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
+):
     return list_tickets(db, skip, limit)
 
 
-
 @router.get("/tickets/search", response_model=list[TicketOut])
-def api_search_tickets(q: str, limit: int = 10, db: Session = Depends(get_db)):
+def api_search_tickets(
+    q: str, limit: int = 10, db: Session = Depends(get_db)
+):
     return search_tickets(db, q, limit)
+
 
 @router.post("/ticket", response_model=TicketOut)
 def api_create_ticket(ticket: TicketCreate, db: Session = Depends(get_db)):
@@ -69,12 +81,16 @@ def api_create_ticket(ticket: TicketCreate, db: Session = Depends(get_db)):
     created = create_ticket(db, obj)
     return created
 
+
 @router.put("/ticket/{ticket_id}", response_model=TicketOut)
-def api_update_ticket(ticket_id: int, updates: dict, db: Session = Depends(get_db)):
+def api_update_ticket(
+    ticket_id: int, updates: dict, db: Session = Depends(get_db)
+):
     ticket = update_ticket(db, ticket_id, updates)
     if not ticket:
         raise HTTPException(status_code=404, detail="Ticket not found")
     return ticket
+
 
 @router.delete("/ticket/{ticket_id}")
 def api_delete_ticket(ticket_id: int, db: Session = Depends(get_db)):
@@ -90,9 +106,13 @@ def api_get_asset(asset_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Asset not found")
     return asset
 
+
 @router.get("/assets")
-def api_list_assets(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+def api_list_assets(
+    skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
+):
     return list_assets(db, skip, limit)
+
 
 @router.get("/vendor/{vendor_id}")
 def api_get_vendor(vendor_id: int, db: Session = Depends(get_db)):
@@ -101,9 +121,13 @@ def api_get_vendor(vendor_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Vendor not found")
     return vendor
 
+
 @router.get("/vendors")
-def api_list_vendors(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+def api_list_vendors(
+    skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
+):
     return list_vendors(db, skip, limit)
+
 
 @router.get("/site/{site_id}")
 def api_get_site(site_id: int, db: Session = Depends(get_db)):
@@ -112,50 +136,75 @@ def api_get_site(site_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Site not found")
     return site
 
+
 @router.get("/sites")
-def api_list_sites(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+def api_list_sites(
+    skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
+):
     return list_sites(db, skip, limit)
+
 
 @router.get("/categories")
 def api_list_categories(db: Session = Depends(get_db)):
     return list_categories(db)
 
+
 @router.get("/statuses")
 def api_list_statuses(db: Session = Depends(get_db)):
     return list_statuses(db)
 
+
 @router.get("/ticket/{ticket_id}/attachments")
-def api_get_ticket_attachments(ticket_id: int, db: Session = Depends(get_db)):
+def api_get_ticket_attachments(
+    ticket_id: int, db: Session = Depends(get_db)
+):
     return get_ticket_attachments(db, ticket_id)
 
+
 @router.get("/ticket/{ticket_id}/messages")
-def api_get_ticket_messages(ticket_id: int, db: Session = Depends(get_db)):
+def api_get_ticket_messages(
+    ticket_id: int, db: Session = Depends(get_db)
+):
     return get_ticket_messages(db, ticket_id)
 
+
 @router.post("/ticket/{ticket_id}/messages")
-def api_post_ticket_message(ticket_id: int, msg: MessageIn, db: Session = Depends(get_db)):
-    return post_ticket_message(db, ticket_id, msg.message, msg.sender_code, msg.sender_name)
+def api_post_ticket_message(
+    ticket_id: int,
+    msg: MessageIn,
+    db: Session = Depends(get_db),
+):
+    return post_ticket_message(
+        db, ticket_id, msg.message, msg.sender_code, msg.sender_name
+    )
+
 
 @router.post("/ai/suggest_response")
 def api_ai_suggest_response(ticket: TicketOut, context: str = ""):
     return {"response": ai_suggest_response(ticket.dict(), context)}
 
 # Analysis endpoints
+
+
 @router.get("/analytics/status")
 def api_tickets_by_status(db: Session = Depends(get_db)):
     return tickets_by_status(db)
+
 
 @router.get("/analytics/open_by_site")
 def api_open_tickets_by_site(db: Session = Depends(get_db)):
     return open_tickets_by_site(db)
 
+
 @router.get("/analytics/sla_breaches")
 def api_sla_breaches(sla_days: int = 2, db: Session = Depends(get_db)):
     return {"breaches": sla_breaches(db, sla_days)}
 
+
 @router.get("/analytics/open_by_user")
 def api_open_tickets_by_user(db: Session = Depends(get_db)):
     return open_tickets_by_user(db)
+
 
 @router.get("/analytics/waiting_on_user")
 def api_tickets_waiting_on_user(db: Session = Depends(get_db)):


### PR DESCRIPTION
## Summary
- keep typing consistent for list responses
- tidy `api/routes.py` to pass flake8

## Testing
- `flake8 api/routes.py`
- `flake8` *(fails: E501, E302, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6863f01d280c832b8c74b5c507186a89