### PR TITLE
Fix list typing style in routes

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -58,7 +58,7 @@ def api_list_tickets(skip: int = 0, limit: int = 10, db: Session = Depends(get_d
 
 
 
-@router.get("/tickets/search", response_model=list[TicketOut])
+@router.get("/tickets/search", response_model=List[TicketOut])
 def api_search_tickets(q: str, limit: int = 10, db: Session = Depends(get_db)):
     return search_tickets(db, q, limit)
 


### PR DESCRIPTION
## Summary
- use `List[...]` consistently for list responses
- run flake8

## Testing
- `flake8 | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_6863f169b22c832b99143302e21ba10f