### PR TITLE
Fix redundant return in analysis tools

### DIFF
--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -58,11 +58,5 @@ def tickets_waiting_on_user(db: Session):
                 .group_by(Ticket.Ticket_Contact_Email).all()
     return [(row[0], row[1]) for row in results]
 
-    return (
-        db.query(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID))
-        .filter(Ticket.Ticket_Status_ID != 3)
-        .group_by(Ticket.Assigned_Email)
-        .all()
-    )
 
 


### PR DESCRIPTION
## Summary
- remove stray return statement from `tools/analysis_tools.py`

## Testing
- `python -m py_compile tools/analysis_tools.py`
- `pytest -q` *(fails: NameError: name 'List' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6863f4ef2c20832bb9a2e8381add890e