### PR TITLE
Fix NameError in routes import

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel
 from schemas.ticket import TicketOut, TicketCreate
 
 from datetime import datetime
+from typing import List
 
 
 router = APIRouter()


### PR DESCRIPTION
## Summary
- add missing `List` import for search endpoint

## Testing
- `pytest -q`
- `python -m py_compile api/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_6863f4f02f74832b9930b414e3967268