### PR TITLE
Fix ForwardRef patch check

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -28,6 +28,7 @@ from tools.analysis_tools import (
 )
 
 from pydantic import BaseModel
+from typing import List
 
 
 from schemas.ticket import TicketOut, TicketCreate

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,7 @@ import typing
 import inspect
 
 sig = inspect.signature(typing.ForwardRef._evaluate)
-if 'recursive_guard' in sig.parameters:
+if 'type_params' in sig.parameters:
     original = typing.ForwardRef._evaluate
 
     def _evaluate(self, globalns, localns, type_params=None, *, recursive_guard=frozenset()):


### PR DESCRIPTION
## Summary
- guard patching `ForwardRef._evaluate` by checking for `type_params`
- import `List` in routes so tests collect

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f4ee0cdc832b95218b755cbe92c5