### PR TITLE
Add config env selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
 
    - `DB_CONN_STRING` – SQLAlchemy connection string for your database.
    - `OPENAI_API_KEY` – API key used by the OpenAI integration.
+   - `CONFIG_ENV` – which config to load: `dev`, `staging`, or `prod` (default `dev`).
 
-   They can be provided in the shell environment or in a `.env` file in the project root.
+   They can be provided in the shell environment or in a `.env` file in the project root.  
+   OpenAI model parameters such as model name and timeouts are defined in the selected config file.
 
 ## Running the API
 
@@ -25,6 +27,12 @@ Start the development server with Uvicorn:
 
 ```bash
 uvicorn main:app --reload
+```
+
+Select a configuration by setting `CONFIG_ENV`:
+
+```bash
+CONFIG_ENV=prod uvicorn main:app
 ```
 
 ## Running tests

--- a/ai/openai_agent.py
+++ b/ai/openai_agent.py
@@ -1,6 +1,10 @@
 import openai
 from openai import OpenAIError, APITimeoutError
-from config import OPENAI_API_KEY
+from config import (
+    OPENAI_API_KEY,
+    OPENAI_MODEL_NAME,
+    OPENAI_TIMEOUT,
+)
 
 
 def suggest_ticket_response(ticket: dict, context: str = "") -> str:
@@ -16,9 +20,9 @@ def suggest_ticket_response(ticket: dict, context: str = "") -> str:
     )
     try:
         response = openai.ChatCompletion.create(
-            model="gpt-4o",
+            model=OPENAI_MODEL_NAME,
             messages=[{"role": "system", "content": prompt}],
-            timeout=15,
+            timeout=OPENAI_TIMEOUT,
         )
         return response["choices"][0]["message"]["content"]
     except APITimeoutError:

--- a/config.py
+++ b/config.py
@@ -1,8 +1,15 @@
+import importlib
 import os
-from dotenv import load_dotenv
 
-load_dotenv()
+CONFIG_ENV = os.getenv("CONFIG_ENV", "dev").lower()
+module_name = f"config_{CONFIG_ENV}"
+try:
+    _config = importlib.import_module(module_name)
+except ImportError as exc:
+    raise ImportError(f"Unknown CONFIG_ENV: {CONFIG_ENV}") from exc
 
-DB_CONN_STRING = os.getenv("DB_CONN_STRING")
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+for name in dir(_config):
+    if name.isupper():
+        globals()[name] = getattr(_config, name)
 
+__all__ = [name for name in globals() if name.isupper()]

--- a/config_dev.py
+++ b/config_dev.py
@@ -1,0 +1,9 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_CONN_STRING = os.getenv("DB_CONN_STRING")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_MODEL_NAME = "gpt-4o"
+OPENAI_TIMEOUT = 15  # seconds

--- a/config_prod.py
+++ b/config_prod.py
@@ -1,0 +1,9 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_CONN_STRING = os.getenv("DB_CONN_STRING")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_MODEL_NAME = "gpt-4o"
+OPENAI_TIMEOUT = 15

--- a/config_staging.py
+++ b/config_staging.py
@@ -1,0 +1,9 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_CONN_STRING = os.getenv("DB_CONN_STRING")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_MODEL_NAME = "gpt-4o"
+OPENAI_TIMEOUT = 15


### PR DESCRIPTION
## Summary
- add `CONFIG_ENV` to dynamically choose config files
- create `config_dev.py`, `config_staging.py` and `config_prod.py`
- use config constants for OpenAI model and timeout
- document how to select the config

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863fa07a054832b95f62f8898366015