### PR TITLE
Add paginated response model and update list endpoints

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -29,6 +29,7 @@ from tools.analysis_tools import (
 
 from pydantic import BaseModel
 from typing import List
+from schemas.paginated import PaginatedResponse
 
 
 from schemas.ticket import TicketOut, TicketCreate
@@ -62,11 +63,14 @@ def api_get_ticket(ticket_id: int, db: Session = Depends(get_db)):
     return ticket
 
 
-@router.get("/tickets", response_model=list[TicketOut])
+@router.get("/tickets", response_model=PaginatedResponse[TicketOut])
 def api_list_tickets(
     skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
 ):
-    return list_tickets(db, skip, limit)
+    items, total = list_tickets(db, skip, limit)
+    return PaginatedResponse[TicketOut](
+        items=items, total=total, skip=skip, limit=limit
+    )
 
 
 
@@ -111,11 +115,14 @@ def api_get_asset(asset_id: int, db: Session = Depends(get_db)):
     return asset
 
 
-@router.get("/assets")
+@router.get("/assets", response_model=PaginatedResponse[dict])
 def api_list_assets(
     skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
 ):
-    return list_assets(db, skip, limit)
+    items, total = list_assets(db, skip, limit)
+    return PaginatedResponse(
+        items=items, total=total, skip=skip, limit=limit
+    )
 
 
 @router.get("/vendor/{vendor_id}")
@@ -126,11 +133,14 @@ def api_get_vendor(vendor_id: int, db: Session = Depends(get_db)):
     return vendor
 
 
-@router.get("/vendors")
+@router.get("/vendors", response_model=PaginatedResponse[dict])
 def api_list_vendors(
     skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
 ):
-    return list_vendors(db, skip, limit)
+    items, total = list_vendors(db, skip, limit)
+    return PaginatedResponse(
+        items=items, total=total, skip=skip, limit=limit
+    )
 
 
 @router.get("/site/{site_id}")
@@ -141,11 +151,14 @@ def api_get_site(site_id: int, db: Session = Depends(get_db)):
     return site
 
 
-@router.get("/sites")
+@router.get("/sites", response_model=PaginatedResponse[dict])
 def api_list_sites(
     skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
 ):
-    return list_sites(db, skip, limit)
+    items, total = list_sites(db, skip, limit)
+    return PaginatedResponse(
+        items=items, total=total, skip=skip, limit=limit
+    )
 
 
 @router.get("/categories")

--- a/schemas/paginated.py
+++ b/schemas/paginated.py
@@ -1,0 +1,10 @@
+from typing import Generic, List, TypeVar
+from pydantic.generics import GenericModel
+
+T = TypeVar('T')
+
+class PaginatedResponse(GenericModel, Generic[T]):
+    items: List[T]
+    total: int
+    skip: int
+    limit: int

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -22,7 +22,11 @@ def test_create_and_get_ticket():
 
     list_resp = client.get("/tickets")
     assert list_resp.status_code == 200
-    assert list_resp.json()[0]["Ticket_ID"] == tid
+    data = list_resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["Ticket_ID"] == tid
+    assert data["skip"] == 0
+    assert data["limit"] == 10
 
     get_resp = client.get(f"/ticket/{tid}")
     assert get_resp.status_code == 200

--- a/tools/asset_tools.py
+++ b/tools/asset_tools.py
@@ -7,4 +7,7 @@ def get_asset(db: Session, asset_id: int):
 
 
 def list_assets(db: Session, skip: int = 0, limit: int = 10):
-    return db.query(Asset).offset(skip).limit(limit).all()
+    query = db.query(Asset)
+    total = query.count()
+    items = query.offset(skip).limit(limit).all()
+    return items, total

--- a/tools/site_tools.py
+++ b/tools/site_tools.py
@@ -7,4 +7,7 @@ def get_site(db: Session, site_id: int):
 
 
 def list_sites(db: Session, skip: int = 0, limit: int = 10):
-    return db.query(Site).offset(skip).limit(limit).all()
+    query = db.query(Site)
+    total = query.count()
+    items = query.offset(skip).limit(limit).all()
+    return items, total

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -9,7 +9,10 @@ def get_ticket(db: Session, ticket_id: int):
 
 
 def list_tickets(db: Session, skip: int = 0, limit: int = 10):
-    return db.query(Ticket).offset(skip).limit(limit).all()
+    query = db.query(Ticket)
+    total = query.count()
+    items = query.offset(skip).limit(limit).all()
+    return items, total
 
 
 def create_ticket(db: Session, ticket_obj: Ticket):

--- a/tools/vendor_tools.py
+++ b/tools/vendor_tools.py
@@ -7,4 +7,7 @@ def get_vendor(db: Session, vendor_id: int):
 
 
 def list_vendors(db: Session, skip: int = 0, limit: int = 10):
-    return db.query(Vendor).offset(skip).limit(limit).all()
+    query = db.query(Vendor)
+    total = query.count()
+    items = query.offset(skip).limit(limit).all()
+    return items, total


### PR DESCRIPTION
## Summary
- create generic `PaginatedResponse[T]` model
- return pagination metadata from list endpoints
- adjust helper functions for totals
- update tests for new output format

## Testing
- `pip install -q 'httpx<0.28'`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863fa0a76ec832ba29ebc9b65e0aed4