### PR TITLE
Validate DB connection on startup

### DIFF
--- a/db/mssql.py
+++ b/db/mssql.py
@@ -6,5 +6,11 @@ engine_args = {}
 if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):
     engine_args["fast_executemany"] = True
 
-engine = create_engine(DB_CONN_STRING or "sqlite:///:memory:", **engine_args)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+engine = (
+    create_engine(DB_CONN_STRING, **engine_args) if DB_CONN_STRING else None
+)
+SessionLocal = (
+    sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    if engine
+    else None
+)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,20 @@
 from fastapi import FastAPI
 from api.routes import router
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from db.mssql import engine
+from config import DB_CONN_STRING
 
 app = FastAPI(title="Truck Stop MCP Helpdesk API")
 app.include_router(router)
+
+
+@app.on_event("startup")
+def verify_database_connection():
+    if not DB_CONN_STRING:
+        raise RuntimeError("DB_CONN_STRING environment variable not set")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+    except SQLAlchemyError as exc:
+        raise RuntimeError(f"Database connection failed: {exc}")


### PR DESCRIPTION
## Summary
- remove `sqlite:///:memory:` fallback when creating the DB engine
- verify `DB_CONN_STRING` is defined and test the connection on startup

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863fa0c9b6c832b807c370895bce050