### PR TITLE
Implement custom error handling

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from db.mssql import SessionLocal
 
@@ -29,12 +29,12 @@ from tools.analysis_tools import (
 
 from pydantic import BaseModel
 from typing import List
+from errors import NotFoundError
 
 
 from schemas.ticket import TicketOut, TicketCreate
 
 from datetime import datetime
-from typing import List
 
 
 router = APIRouter()
@@ -58,7 +58,7 @@ class MessageIn(BaseModel):
 def api_get_ticket(ticket_id: int, db: Session = Depends(get_db)):
     ticket = get_ticket(db, ticket_id)
     if not ticket:
-        raise HTTPException(status_code=404, detail="Ticket not found")
+        raise NotFoundError("Ticket not found")
     return ticket
 
 
@@ -92,14 +92,14 @@ def api_update_ticket(
 ):
     ticket = update_ticket(db, ticket_id, updates)
     if not ticket:
-        raise HTTPException(status_code=404, detail="Ticket not found")
+        raise NotFoundError("Ticket not found")
     return ticket
 
 
 @router.delete("/ticket/{ticket_id}")
 def api_delete_ticket(ticket_id: int, db: Session = Depends(get_db)):
     if not delete_ticket(db, ticket_id):
-        raise HTTPException(status_code=404, detail="Ticket not found")
+        raise NotFoundError("Ticket not found")
     return {"deleted": True}
 
 
@@ -107,7 +107,7 @@ def api_delete_ticket(ticket_id: int, db: Session = Depends(get_db)):
 def api_get_asset(asset_id: int, db: Session = Depends(get_db)):
     asset = get_asset(db, asset_id)
     if not asset:
-        raise HTTPException(status_code=404, detail="Asset not found")
+        raise NotFoundError("Asset not found")
     return asset
 
 
@@ -122,7 +122,7 @@ def api_list_assets(
 def api_get_vendor(vendor_id: int, db: Session = Depends(get_db)):
     vendor = get_vendor(db, vendor_id)
     if not vendor:
-        raise HTTPException(status_code=404, detail="Vendor not found")
+        raise NotFoundError("Vendor not found")
     return vendor
 
 
@@ -137,7 +137,7 @@ def api_list_vendors(
 def api_get_site(site_id: int, db: Session = Depends(get_db)):
     site = get_site(db, site_id)
     if not site:
-        raise HTTPException(status_code=404, detail="Site not found")
+        raise NotFoundError("Site not found")
     return site
 
 

--- a/errors.py
+++ b/errors.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    error_code: str
+    message: str
+    details: Optional[str] = None
+    timestamp: datetime
+
+
+class AppError(Exception):
+    """Base class for application errors."""
+
+    error_code: str = "APP_ERROR"
+
+    def __init__(self, message: str, details: Optional[str] = None):
+        self.message = message
+        self.details = details
+        super().__init__(message)
+
+
+class NotFoundError(AppError):
+    error_code = "NOT_FOUND"
+
+
+class ValidationError(AppError):
+    error_code = "VALIDATION_ERROR"
+
+
+class DatabaseError(AppError):
+    error_code = "DB_ERROR"

--- a/main.py
+++ b/main.py
@@ -1,5 +1,42 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from api.routes import router
+from datetime import datetime
+from errors import ErrorResponse, NotFoundError, ValidationError, DatabaseError
 
 app = FastAPI(title="Truck Stop MCP Helpdesk API")
 app.include_router(router)
+
+
+@app.exception_handler(NotFoundError)
+async def handle_not_found(request: Request, exc: NotFoundError):
+    resp = ErrorResponse(
+        error_code=exc.error_code,
+        message=exc.message,
+        details=exc.details,
+        timestamp=datetime.utcnow(),
+    )
+    return JSONResponse(status_code=404, content=jsonable_encoder(resp))
+
+
+@app.exception_handler(ValidationError)
+async def handle_validation(request: Request, exc: ValidationError):
+    resp = ErrorResponse(
+        error_code=exc.error_code,
+        message=exc.message,
+        details=exc.details,
+        timestamp=datetime.utcnow(),
+    )
+    return JSONResponse(status_code=400, content=jsonable_encoder(resp))
+
+
+@app.exception_handler(DatabaseError)
+async def handle_database(request: Request, exc: DatabaseError):
+    resp = ErrorResponse(
+        error_code=exc.error_code,
+        message=exc.message,
+        details=exc.details,
+        timestamp=datetime.utcnow(),
+    )
+    return JSONResponse(status_code=500, content=jsonable_encoder(resp))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -32,3 +32,5 @@ def test_create_and_get_ticket():
 def test_get_ticket_not_found():
     resp = client.get("/ticket/999")
     assert resp.status_code == 404
+    data = resp.json()
+    assert data["error_code"] == "NOT_FOUND"

--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
-from fastapi import HTTPException
+from errors import DatabaseError
 from db.models import TicketMessage
 from datetime import datetime
 
@@ -31,5 +31,5 @@ def post_ticket_message(
         db.refresh(msg)
     except SQLAlchemyError as e:
         db.rollback()
-        raise HTTPException(status_code=500, detail=f"Failed to save message: {e}")
+        raise DatabaseError("Failed to save message", str(e))
     return msg

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
-from fastapi import HTTPException
+from errors import DatabaseError
 from db.models import Ticket
 
 
@@ -20,7 +20,7 @@ def create_ticket(db: Session, ticket_obj: Ticket):
         db.refresh(ticket_obj)
     except SQLAlchemyError as e:
         db.rollback()
-        raise HTTPException(status_code=500, detail=f"Failed to create ticket: {e}")
+        raise DatabaseError("Failed to create ticket", str(e))
     return ticket_obj
 
 


### PR DESCRIPTION
## Summary
- add a standardized `ErrorResponse` model and custom exceptions
- install global exception handlers to return these errors
- update routes and tools to raise the new exceptions
- verify 404 case includes `error_code`

## Testing
- `pip install httpx==0.27.0`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863fa1221f8832b82d24a9627de1b83