### PR TITLE
Add rate limit to AI suggestion endpoint

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 from db.mssql import SessionLocal
 
@@ -19,6 +19,7 @@ from tools.category_tools import list_categories
 from tools.status_tools import list_statuses
 from tools.message_tools import get_ticket_messages, post_ticket_message
 from tools.ai_tools import ai_suggest_response
+from limiter import limiter
 from tools.analysis_tools import (
     tickets_by_status,
     open_tickets_by_site,
@@ -185,7 +186,8 @@ def api_post_ticket_message(
 
 
 @router.post("/ai/suggest_response")
-def api_ai_suggest_response(ticket: TicketOut, context: str = ""):
+@limiter.limit("10/minute")
+def api_ai_suggest_response(request: Request, ticket: TicketOut, context: str = ""):
     return {"response": ai_suggest_response(ticket.dict(), context)}
 
 

--- a/limiter.py
+++ b/limiter.py
@@ -1,0 +1,4 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,15 @@
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from api.routes import router
+from limiter import limiter
 
 app = FastAPI(title="Truck Stop MCP Helpdesk API")
+app.state.limiter = limiter
+app.add_exception_handler(
+    RateLimitExceeded,
+    lambda request, exc: JSONResponse(status_code=429, content={"detail": "Rate limit exceeded"}),
+)
+app.add_middleware(SlowAPIMiddleware)
 app.include_router(router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ openai==1.93.0
 pytest==8.4.1
 email-validator==2.2.0
 httpx<0.28
+slowapi==0.1.9

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,33 @@
+import openai
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def _patch_openai(monkeypatch):
+    def fake_create(*args, **kwargs):
+        return {"choices": [{"message": {"content": "ok"}}]}
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+def _create_ticket():
+    payload = {
+        "Subject": "Rate", "Ticket_Body": "body",
+        "Ticket_Contact_Name": "Tester", "Ticket_Contact_Email": "t@example.com"
+    }
+    resp = client.post("/ticket", json=payload)
+    assert resp.status_code == 200
+    return resp.json()
+
+def test_ai_suggest_response_rate_limit(monkeypatch):
+    _patch_openai(monkeypatch)
+    from limiter import limiter
+    limiter.reset()
+    ticket = _create_ticket()
+    # First 10 requests succeed
+    for _ in range(10):
+        r = client.post("/ai/suggest_response", json=ticket)
+        assert r.status_code == 200
+    # 11th request is blocked
+    r = client.post("/ai/suggest_response", json=ticket)
+    assert r.status_code == 429
+


### PR DESCRIPTION
## Summary
- add `slowapi` dependency
- configure global request limiter
- rate-limit AI suggestion endpoint
- test that 10 requests per minute per IP are allowed

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863fa31eac8832baea206cb3f546b65