### PR TITLE
Refactor tests for async httpx

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -28,6 +28,8 @@ from tools.site_tools import get_site, list_sites
 from tools.category_tools import list_categories
 from tools.status_tools import list_statuses
 from tools.message_tools import get_ticket_messages, post_ticket_message
+from services.ticket_service import TicketService
+from services.analytics_service import AnalyticsService
 from tools.ai_tools import ai_suggest_response
 
 
@@ -59,8 +61,9 @@ logger = logging.getLogger(__name__)
 def get_db() -> Generator[Session, None, None]:
     db = SessionLocal()
     try:
-
         yield db
+    finally:
+        db.close()
 
 
 def get_ticket_service(db: Session = Depends(get_db)) -> TicketService:
@@ -112,13 +115,9 @@ def api_list_tickets(
 
 
 @router.get("/tickets/search", response_model=List[TicketOut])
-
 def api_search_tickets(
     q: str, limit: int = 10, db: Session = Depends(get_db)
 ) -> list[Ticket]:
-
-
-def api_search_tickets(q: str, limit: int = 10, db: Session = Depends(get_db)):
     logger.info("API search tickets query=%s limit=%s", q, limit)
     return search_tickets(db, q, limit)
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime, timedelta
 
 import pytest
-from httpx import AsyncClient
+import httpx
 from main import app
 from db.models import Ticket
 from db.mssql import SessionLocal
@@ -17,7 +17,7 @@ import pytest_asyncio
 
 @pytest_asyncio.fixture
 async def client():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
         yield ac
 
 async def _add_ticket(**kwargs):
@@ -38,7 +38,7 @@ async def _add_ticket(**kwargs):
         return ticket
 
 @pytest.mark.asyncio
-async def test_analytics_status(client: AsyncClient):
+async def test_analytics_status(client: httpx.AsyncClient):
     await _add_ticket(Ticket_Status_ID=1)
     await _add_ticket(Ticket_Status_ID=1)
     await _add_ticket(Ticket_Status_ID=2)
@@ -49,7 +49,7 @@ async def test_analytics_status(client: AsyncClient):
     assert data == {1: 2, 2: 1}
 
 @pytest.mark.asyncio
-async def test_analytics_open_by_site(client: AsyncClient):
+async def test_analytics_open_by_site(client: httpx.AsyncClient):
     await _add_ticket(Site_ID=1, Ticket_Status_ID=1)
     await _add_ticket(Site_ID=1, Ticket_Status_ID=2)
     await _add_ticket(Site_ID=2, Ticket_Status_ID=1)
@@ -61,7 +61,7 @@ async def test_analytics_open_by_site(client: AsyncClient):
     assert data == {1: 2, 2: 1}
 
 @pytest.mark.asyncio
-async def test_analytics_sla_breaches(client: AsyncClient):
+async def test_analytics_sla_breaches(client: httpx.AsyncClient):
     old = datetime.utcnow() - timedelta(days=3)
     await _add_ticket(Created_Date=old)
     await _add_ticket()
@@ -70,7 +70,7 @@ async def test_analytics_sla_breaches(client: AsyncClient):
     assert resp.json() == {"breaches": 1}
 
 @pytest.mark.asyncio
-async def test_analytics_open_by_user(client: AsyncClient):
+async def test_analytics_open_by_user(client: httpx.AsyncClient):
     await _add_ticket(Assigned_Email="tech@example.com", Ticket_Status_ID=1)
     await _add_ticket(Assigned_Email="tech@example.com", Ticket_Status_ID=1)
     await _add_ticket(Assigned_Email="other@example.com", Ticket_Status_ID=1)
@@ -82,7 +82,7 @@ async def test_analytics_open_by_user(client: AsyncClient):
     assert data == {"tech@example.com": 2, "other@example.com": 1}
 
 @pytest.mark.asyncio
-async def test_analytics_waiting_on_user(client: AsyncClient):
+async def test_analytics_waiting_on_user(client: httpx.AsyncClient):
     await _add_ticket(Ticket_Status_ID=4, Ticket_Contact_Email="user1@example.com")
     await _add_ticket(Ticket_Status_ID=4, Ticket_Contact_Email="user1@example.com")
     await _add_ticket(Ticket_Status_ID=4, Ticket_Contact_Email="user2@example.com")
@@ -94,7 +94,7 @@ async def test_analytics_waiting_on_user(client: AsyncClient):
     assert data == {"user1@example.com": 2, "user2@example.com": 1}
 
 @pytest.mark.asyncio
-async def test_ai_suggest_response(client: AsyncClient, monkeypatch):
+async def test_ai_suggest_response(client: httpx.AsyncClient, monkeypatch):
     def fake_create(*args, **kwargs):
         class Msg:
             content = "ok"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,11 +1,18 @@
-from fastapi.testclient import TestClient
+import pytest
+import pytest_asyncio
+import httpx
 from main import app
 
-client = TestClient(app)
+
+@pytest_asyncio.fixture
+async def client():
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac
 
 
-def test_health_ok():
-    resp = client.get("/health")
+@pytest.mark.asyncio
+async def test_health_ok(client: httpx.AsyncClient):
+    resp = await client.get("/health")
     assert resp.status_code == 200
     data = resp.json()
     assert data["db"] == "ok"

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,33 +1,40 @@
 import openai
-from fastapi.testclient import TestClient
+import pytest
+import pytest_asyncio
+import httpx
 from main import app
 
-client = TestClient(app)
+
+@pytest_asyncio.fixture
+async def client():
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac
 
 def _patch_openai(monkeypatch):
     def fake_create(*args, **kwargs):
         return {"choices": [{"message": {"content": "ok"}}]}
     monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
 
-def _create_ticket():
+async def _create_ticket(client: httpx.AsyncClient):
     payload = {
         "Subject": "Rate", "Ticket_Body": "body",
         "Ticket_Contact_Name": "Tester", "Ticket_Contact_Email": "t@example.com"
     }
-    resp = client.post("/ticket", json=payload)
+    resp = await client.post("/ticket", json=payload)
     assert resp.status_code == 200
     return resp.json()
 
-def test_ai_suggest_response_rate_limit(monkeypatch):
+@pytest.mark.asyncio
+async def test_ai_suggest_response_rate_limit(client: httpx.AsyncClient, monkeypatch):
     _patch_openai(monkeypatch)
     from limiter import limiter
     limiter.reset()
-    ticket = _create_ticket()
+    ticket = await _create_ticket(client)
     # First 10 requests succeed
     for _ in range(10):
-        r = client.post("/ai/suggest_response", json=ticket)
+        r = await client.post("/ai/suggest_response", json=ticket)
         assert r.status_code == 200
     # 11th request is blocked
-    r = client.post("/ai/suggest_response", json=ticket)
+    r = await client.post("/ai/suggest_response", json=ticket)
     assert r.status_code == 429
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 from db.models import Base, Ticket
 from db.mssql import engine, SessionLocal
-from services.ticket_service import TicketService
+from tools.ticket_tools import create_ticket, search_tickets
 from datetime import datetime
 
 os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")

--- a/tests/test_ticket_lifecycle.py
+++ b/tests/test_ticket_lifecycle.py
@@ -1,71 +1,83 @@
 import pytest
-from fastapi.testclient import TestClient
+import pytest_asyncio
+import httpx
 from fastapi import HTTPException
 from main import app
 
-client = TestClient(app)
+
+@pytest_asyncio.fixture
+async def client():
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac
 
 
-def create_sample_ticket():
+async def create_sample_ticket(client: httpx.AsyncClient):
     payload = {
         "Subject": "Lifecycle",
         "Ticket_Body": "Testing lifecycle",
         "Ticket_Contact_Name": "Tester",
         "Ticket_Contact_Email": "tester@example.com",
     }
-    response = client.post("/ticket", json=payload)
+    response = await client.post("/ticket", json=payload)
     assert response.status_code == 200
     return response.json()
 
 
-def test_ticket_full_lifecycle():
-    ticket = create_sample_ticket()
+@pytest.mark.asyncio
+async def test_ticket_full_lifecycle(client: httpx.AsyncClient):
+    ticket = await create_sample_ticket(client)
     tid = ticket["Ticket_ID"]
 
-    update_resp = client.put(f"/ticket/{tid}", json={"Assigned_Name": "Agent", "Ticket_Status_ID": 2})
+    update_resp = await client.put(
+        f"/ticket/{tid}", json={"Assigned_Name": "Agent", "Ticket_Status_ID": 2}
+    )
     assert update_resp.status_code == 200
     assert update_resp.json()["Assigned_Name"] == "Agent"
 
     msg_payload = {"message": "hello", "sender_code": "u1", "sender_name": "User"}
-    msg_resp = client.post(f"/ticket/{tid}/messages", json=msg_payload)
+    msg_resp = await client.post(f"/ticket/{tid}/messages", json=msg_payload)
     assert msg_resp.status_code == 200
     assert msg_resp.json()["Message"] == "hello"
 
-    msgs = client.get(f"/ticket/{tid}/messages")
+    msgs = await client.get(f"/ticket/{tid}/messages")
     assert msgs.status_code == 200
     assert msgs.json()[0]["Message"] == "hello"
 
-    close_resp = client.put(f"/ticket/{tid}", json={"Ticket_Status_ID": 3})
+    close_resp = await client.put(f"/ticket/{tid}", json={"Ticket_Status_ID": 3})
     assert close_resp.status_code == 200
     assert close_resp.json()["Ticket_Status_ID"] == 3
 
-    delete_resp = client.delete(f"/ticket/{tid}")
+    delete_resp = await client.delete(f"/ticket/{tid}")
     assert delete_resp.status_code == 200
     assert delete_resp.json() == {"deleted": True}
 
 
-def test_update_ticket_not_found():
-    resp = client.put("/ticket/99999", json={"Subject": "none"})
+@pytest.mark.asyncio
+async def test_update_ticket_not_found(client: httpx.AsyncClient):
+    resp = await client.put("/ticket/99999", json={"Subject": "none"})
     assert resp.status_code == 404
 
 
-def test_delete_ticket_not_found():
-    resp = client.delete("/ticket/99999")
+@pytest.mark.asyncio
+async def test_delete_ticket_not_found(client: httpx.AsyncClient):
+    resp = await client.delete("/ticket/99999")
     assert resp.status_code == 404
 
 
-def test_create_ticket_validation_error():
+@pytest.mark.asyncio
+async def test_create_ticket_validation_error(client: httpx.AsyncClient):
     bad_payload = {
         "Subject": "Bad",
         "Ticket_Body": "Bad",
         "Ticket_Contact_Name": "Tester",
         "Ticket_Contact_Email": "not-an-email",
     }
-    resp = client.post("/ticket", json=bad_payload)
+    resp = await client.post("/ticket", json=bad_payload)
     assert resp.status_code == 422
 
 
-def test_create_ticket_db_failure(monkeypatch):
+@pytest.mark.asyncio
+async def test_create_ticket_db_failure(client: httpx.AsyncClient, monkeypatch):
     def fail_create(db, obj):
         raise HTTPException(status_code=500, detail="fail")
 
@@ -76,5 +88,5 @@ def test_create_ticket_db_failure(monkeypatch):
         "Ticket_Contact_Name": "Tester",
         "Ticket_Contact_Email": "tester@example.com",
     }
-    resp = client.post("/ticket", json=payload)
+    resp = await client.post("/ticket", json=payload)
     assert resp.status_code == 500

--- a/tools/ai_tools.py
+++ b/tools/ai_tools.py
@@ -1,6 +1,7 @@
 
 from typing import Any, Dict
 
+import logging
 from ai.openai_agent import suggest_ticket_response
 
 logger = logging.getLogger(__name__)

--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -1,30 +1,39 @@
-from sqlalchemy.ext.asyncio import AsyncSession
+"""Async helpers for ticket message operations."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Sequence
+
+from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from errors import DatabaseError
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from db.models import TicketMessage
-from datetime import datetime
-import logging
+
 
 logger = logging.getLogger(__name__)
 
 
-
-def get_ticket_messages(db: Session, ticket_id: int) -> list[TicketMessage]:
-
-    return (
-        db.query(TicketMessage)
-
-        .filter(TicketMessage.Ticket_ID == ticket_id)
+async def get_ticket_messages(db: AsyncSession, ticket_id: int) -> Sequence[TicketMessage]:
+    stmt = (
+        select(TicketMessage)
+        .where(TicketMessage.Ticket_ID == ticket_id)
         .order_by(TicketMessage.DateTimeStamp)
     )
+    result = await db.execute(stmt)
     return result.scalars().all()
 
 
-def post_ticket_message(
-    db: Session, ticket_id: int, message: str, sender_code: str, sender_name: str
+async def post_ticket_message(
+    db: AsyncSession,
+    ticket_id: int,
+    message: str,
+    sender_code: str,
+    sender_name: str,
 ) -> TicketMessage:
-
     msg = TicketMessage(
         Ticket_ID=ticket_id,
         Message=message,
@@ -32,20 +41,14 @@ def post_ticket_message(
         SenderUserName=sender_name,
         DateTimeStamp=datetime.utcnow(),
     )
-
     db.add(msg)
     try:
-
-        db.commit()
-        db.refresh(msg)
+        await db.commit()
+        await db.refresh(msg)
         logger.info("Posted message to ticket %s", ticket_id)
-
-    except SQLAlchemyError as e:
-
-        db.rollback()
-
+        return msg
+    except SQLAlchemyError as exc:
+        await db.rollback()
         logger.exception("Failed to save ticket message for %s", ticket_id)
-        raise HTTPException(status_code=500, detail=f"Failed to save message: {e}")
-
-    return msg
+        raise HTTPException(status_code=500, detail=f"Failed to save message: {exc}")
 


### PR DESCRIPTION
## Summary
- switch test clients to `httpx.AsyncClient`
- adjust helper imports and async fixtures
- implement async versions of ticket and message helpers
- update FastAPI app imports

## Testing
- `pytest -q` *(fails: ResponseValidationError, missing definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686407c9c358832bb82dc55b3a54f0c2