### PR TITLE
Convert data utilities to async

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,15 +1,16 @@
-
-from typing import Any, Generator, List
-
-from fastapi import APIRouter, Depends, HTTPException
-
-from sqlalchemy.orm import Session
+from __future__ import annotations
 
 import logging
+from datetime import datetime
+from typing import Any, AsyncGenerator, List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.mssql import SessionLocal
-
-
+from db.models import Ticket
+from schemas.ticket import TicketCreate, TicketOut
 from tools.ticket_tools import (
     get_ticket,
     list_tickets,
@@ -17,58 +18,30 @@ from tools.ticket_tools import (
     update_ticket,
     delete_ticket,
     search_tickets,
-    _escape_wildcards,
 )
-
-
 from tools.asset_tools import get_asset, list_assets
 from tools.vendor_tools import get_vendor, list_vendors
-from tools.attachment_tools import get_ticket_attachments
 from tools.site_tools import get_site, list_sites
 from tools.category_tools import list_categories
 from tools.status_tools import list_statuses
+from tools.attachment_tools import get_ticket_attachments
 from tools.message_tools import get_ticket_messages, post_ticket_message
-from tools.ai_tools import ai_suggest_response
-
-
-from pydantic import BaseModel
-
-from schemas.ticket import TicketCreate, TicketOut
-from db.models import (
-    Asset,
-    Site,
-    Vendor,
-    Ticket,
-    TicketAttachment,
-    TicketMessage,
-    TicketCategory,
-    TicketStatus,
+from tools.analysis_tools import (
+    tickets_by_status,
+    open_tickets_by_site,
+    sla_breaches,
+    open_tickets_by_user,
+    tickets_waiting_on_user,
 )
-
-
-from datetime import datetime
-
-
-
+from tools.ai_tools import ai_suggest_response
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-
-def get_db() -> Generator[Session, None, None]:
-    db = SessionLocal()
-    try:
-
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with SessionLocal() as db:
         yield db
-
-
-def get_ticket_service(db: Session = Depends(get_db)) -> TicketService:
-    return TicketService(db)
-
-
-def get_analytics_service(db: Session = Depends(get_db)) -> AnalyticsService:
-    return AnalyticsService(db)
 
 
 class MessageIn(BaseModel):
@@ -87,245 +60,181 @@ class MessageIn(BaseModel):
 
 
 @router.get("/ticket/{ticket_id}", response_model=TicketOut)
-
-def api_get_ticket(ticket_id: int, db: Session = Depends(get_db)) -> Ticket:
-
-    ticket = get_ticket(db, ticket_id)
+async def api_get_ticket(
+    ticket_id: int, db: AsyncSession = Depends(get_db)
+) -> Ticket:
+    ticket = await get_ticket(db, ticket_id)
     if not ticket:
         logger.warning("Ticket %s not found", ticket_id)
         raise HTTPException(status_code=404, detail="Ticket not found")
-
     return ticket
 
 
-
 @router.get("/tickets", response_model=list[TicketOut])
-
-def api_list_tickets(
-    skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
+async def api_list_tickets(
+    skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
 ) -> list[Ticket]:
-
-    return list_tickets(db, skip, limit)
-
-
-
+    return await list_tickets(db, skip, limit)
 
 
 @router.get("/tickets/search", response_model=List[TicketOut])
-
-def api_search_tickets(
-    q: str, limit: int = 10, db: Session = Depends(get_db)
+async def api_search_tickets(
+    q: str, limit: int = 10, db: AsyncSession = Depends(get_db)
 ) -> list[Ticket]:
-
-
-def api_search_tickets(q: str, limit: int = 10, db: Session = Depends(get_db)):
     logger.info("API search tickets query=%s limit=%s", q, limit)
-    return search_tickets(db, q, limit)
-
+    return await search_tickets(db, q, limit)
 
 
 @router.post("/ticket", response_model=TicketOut)
-
-def api_create_ticket(ticket: TicketCreate, db: Session = Depends(get_db)) -> Ticket:
-
+async def api_create_ticket(
+    ticket: TicketCreate, db: AsyncSession = Depends(get_db)
+) -> Ticket:
     obj = Ticket(**ticket.dict(), Created_Date=datetime.utcnow())
-
     logger.info("API create ticket")
-    created = create_ticket(db, obj)
-
+    created = await create_ticket(db, obj)
     return created
 
 
 @router.put("/ticket/{ticket_id}", response_model=TicketOut)
-
-def api_update_ticket(
-
-    ticket_id: int, updates: dict, db: Session = Depends(get_db)
+async def api_update_ticket(
+    ticket_id: int, updates: dict, db: AsyncSession = Depends(get_db)
 ) -> Ticket:
-
-    ticket = update_ticket(db, ticket_id, updates)
+    ticket = await update_ticket(db, ticket_id, updates)
     if not ticket:
         logger.warning("Ticket %s not found for update", ticket_id)
         raise HTTPException(status_code=404, detail="Ticket not found")
-
     return ticket
 
 
-
 @router.delete("/ticket/{ticket_id}")
-
-def api_delete_ticket(ticket_id: int, db: Session = Depends(get_db)) -> dict:
-
-    if not delete_ticket(db, ticket_id):
-
+async def api_delete_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> dict:
+    if not await delete_ticket(db, ticket_id):
         logger.warning("Ticket %s not found for delete", ticket_id)
         raise HTTPException(status_code=404, detail="Ticket not found")
-
     return {"deleted": True}
 
 
-
 @router.get("/asset/{asset_id}")
-
-def api_get_asset(asset_id: int, db: Session = Depends(get_db)) -> Any:
-
-    asset = get_asset(db, asset_id)
+async def api_get_asset(asset_id: int, db: AsyncSession = Depends(get_db)) -> Any:
+    asset = await get_asset(db, asset_id)
     if not asset:
         logger.warning("Asset %s not found", asset_id)
         raise HTTPException(status_code=404, detail="Asset not found")
-
     return asset
 
 
-
 @router.get("/assets")
-
-def api_list_assets(
-    skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
+async def api_list_assets(
+    skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
 ) -> list[Any]:
-
-    return list_assets(db, skip, limit)
+    return await list_assets(db, skip, limit)
 
 
 @router.get("/vendor/{vendor_id}")
-
-def api_get_vendor(vendor_id: int, db: Session = Depends(get_db)) -> Any:
-
-    vendor = get_vendor(db, vendor_id)
+async def api_get_vendor(vendor_id: int, db: AsyncSession = Depends(get_db)) -> Any:
+    vendor = await get_vendor(db, vendor_id)
     if not vendor:
         logger.warning("Vendor %s not found", vendor_id)
         raise HTTPException(status_code=404, detail="Vendor not found")
-
     return vendor
 
 
-
 @router.get("/vendors")
-
-def api_list_vendors(
-    skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
+async def api_list_vendors(
+    skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
 ) -> list[Any]:
-
-    return list_vendors(db, skip, limit)
+    return await list_vendors(db, skip, limit)
 
 
 @router.get("/site/{site_id}")
-
-def api_get_site(site_id: int, db: Session = Depends(get_db)) -> Any:
-
-    site = get_site(db, site_id)
+async def api_get_site(site_id: int, db: AsyncSession = Depends(get_db)) -> Any:
+    site = await get_site(db, site_id)
     if not site:
         logger.warning("Site %s not found", site_id)
         raise HTTPException(status_code=404, detail="Site not found")
-
     return site
 
 
-
 @router.get("/sites")
-
-def api_list_sites(
-    skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
+async def api_list_sites(
+    skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
 ) -> list[Any]:
-
-    return list_sites(db, skip, limit)
+    return await list_sites(db, skip, limit)
 
 
 @router.get("/categories")
-
-def api_list_categories(db: Session = Depends(get_db)) -> list[Any]:
-
-    return list_categories(db)
+async def api_list_categories(db: AsyncSession = Depends(get_db)) -> list[Any]:
+    return await list_categories(db)
 
 
 @router.get("/statuses")
-
-def api_list_statuses(db: Session = Depends(get_db)) -> list[Any]:
-
-    return list_statuses(db)
-
+async def api_list_statuses(db: AsyncSession = Depends(get_db)) -> list[Any]:
+    return await list_statuses(db)
 
 
 @router.get("/ticket/{ticket_id}/attachments")
-
-def api_get_ticket_attachments(
-    ticket_id: int, db: Session = Depends(get_db)
+async def api_get_ticket_attachments(
+    ticket_id: int, db: AsyncSession = Depends(get_db)
 ) -> list[Any]:
-
-    return get_ticket_attachments(db, ticket_id)
-
+    return await get_ticket_attachments(db, ticket_id)
 
 
 @router.get("/ticket/{ticket_id}/messages")
-
-def api_get_ticket_messages(
-    ticket_id: int, db: Session = Depends(get_db)
+async def api_get_ticket_messages(
+    ticket_id: int, db: AsyncSession = Depends(get_db)
 ) -> list[Any]:
-
-    return get_ticket_messages(db, ticket_id)
-
+    return await get_ticket_messages(db, ticket_id)
 
 
 @router.post("/ticket/{ticket_id}/messages")
 async def api_post_ticket_message(
-
     ticket_id: int,
     msg: MessageIn,
-
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ) -> Any:
-
-    return post_ticket_message(
-
+    return await post_ticket_message(
         db, ticket_id, msg.message, msg.sender_code, msg.sender_name
     )
 
 
-
-
 @router.post("/ai/suggest_response")
-
-def api_ai_suggest_response(ticket: TicketOut, context: str = "") -> dict:
-
+async def api_ai_suggest_response(ticket: TicketOut, context: str = "") -> dict:
     return {"response": ai_suggest_response(ticket.dict(), context)}
 
 
 # Analysis endpoints
 
 
-
 @router.get("/analytics/status")
-
-def api_tickets_by_status(db: Session = Depends(get_db)) -> list[tuple[int | None, int]]:
-
-    return tickets_by_status(db)
+async def api_tickets_by_status(
+    db: AsyncSession = Depends(get_db),
+) -> list[tuple[int | None, int]]:
+    return await tickets_by_status(db)
 
 
 @router.get("/analytics/open_by_site")
-
-def api_open_tickets_by_site(db: Session = Depends(get_db)) -> list[tuple[int | None, int]]:
-
-    return open_tickets_by_site(db)
+async def api_open_tickets_by_site(
+    db: AsyncSession = Depends(get_db),
+) -> list[tuple[int | None, int]]:
+    return await open_tickets_by_site(db)
 
 
 @router.get("/analytics/sla_breaches")
-
-def api_sla_breaches(sla_days: int = 2, db: Session = Depends(get_db)) -> dict:
-
-    return {"breaches": sla_breaches(db, sla_days)}
+async def api_sla_breaches(
+    sla_days: int = 2, db: AsyncSession = Depends(get_db)
+) -> dict:
+    return {"breaches": await sla_breaches(db, sla_days)}
 
 
 @router.get("/analytics/open_by_user")
-
-def api_open_tickets_by_user(db: Session = Depends(get_db)) -> list[tuple[str | None, int]]:
-
-    return open_tickets_by_user(db)
+async def api_open_tickets_by_user(
+    db: AsyncSession = Depends(get_db),
+) -> list[tuple[str | None, int]]:
+    return await open_tickets_by_user(db)
 
 
 @router.get("/analytics/waiting_on_user")
-
-def api_tickets_waiting_on_user(db: Session = Depends(get_db)) -> list[tuple[str | None, int]]:
-
-    return tickets_waiting_on_user(db)
-
-
+async def api_tickets_waiting_on_user(
+    db: AsyncSession = Depends(get_db),
+) -> list[tuple[str | None, int]]:
+    return await tickets_waiting_on_user(db)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -1,56 +1,56 @@
-from sqlalchemy.orm import Session
-from sqlalchemy import func
+import logging
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import func, select
 from db.models import Ticket
+
+logger = logging.getLogger(__name__)
 
 
 class AnalyticsService:
     """Service providing reporting queries on ticket data."""
 
-    def __init__(self, db: Session):
+    def __init__(self, db: AsyncSession):
         self.db = db
 
-    def tickets_by_status(self):
-        results = (
-            self.db.query(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID))
-            .group_by(Ticket.Ticket_Status_ID)
-            .all()
+    async def tickets_by_status(self) -> list[tuple[int | None, int]]:
+        result = await self.db.execute(
+            select(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID)).group_by(
+                Ticket.Ticket_Status_ID
+            )
         )
-        return [(row[0], row[1]) for row in results]
+        return [(row[0], row[1]) for row in result.all()]
 
-    def open_tickets_by_site(self):
-        results = (
-            self.db.query(Ticket.Site_ID, func.count(Ticket.Ticket_ID))
-            .filter(Ticket.Ticket_Status_ID != 3)
+    async def open_tickets_by_site(self) -> list[tuple[int | None, int]]:
+        result = await self.db.execute(
+            select(Ticket.Site_ID, func.count(Ticket.Ticket_ID))
+            .where(Ticket.Ticket_Status_ID != 3)
             .group_by(Ticket.Site_ID)
-            .all()
         )
-        return [(row[0], row[1]) for row in results]
+        return [(row[0], row[1]) for row in result.all()]
 
-    def sla_breaches(self, sla_days: int = 2):
+    async def sla_breaches(self, sla_days: int = 2) -> int:
         from datetime import datetime, timedelta
 
         cutoff = datetime.utcnow() - timedelta(days=sla_days)
-        return (
-            self.db.query(func.count(Ticket.Ticket_ID))
-            .filter(Ticket.Created_Date < cutoff)
-            .filter(Ticket.Ticket_Status_ID != 3)
-            .scalar()
+        result = await self.db.execute(
+            select(func.count(Ticket.Ticket_ID))
+            .where(Ticket.Created_Date < cutoff)
+            .where(Ticket.Ticket_Status_ID != 3)
         )
+        return result.scalar_one()
 
-    def open_tickets_by_user(self):
-        results = (
-            self.db.query(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID))
-            .filter(Ticket.Ticket_Status_ID != 3)
+    async def open_tickets_by_user(self) -> list[tuple[str | None, int]]:
+        result = await self.db.execute(
+            select(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID))
+            .where(Ticket.Ticket_Status_ID != 3)
             .group_by(Ticket.Assigned_Email)
-            .all()
         )
-        return [(row[0], row[1]) for row in results]
+        return [(row[0], row[1]) for row in result.all()]
 
-    def tickets_waiting_on_user(self):
-        results = (
-            self.db.query(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID))
-            .filter(Ticket.Ticket_Status_ID == 4)
+    async def tickets_waiting_on_user(self) -> list[tuple[str | None, int]]:
+        result = await self.db.execute(
+            select(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID))
+            .where(Ticket.Ticket_Status_ID == 4)
             .group_by(Ticket.Ticket_Contact_Email)
-            .all()
         )
-        return [(row[0], row[1]) for row in results]
+        return [(row[0], row[1]) for row in result.all()]

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -1,63 +1,71 @@
-from sqlalchemy.orm import Session
+import logging
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from fastapi import HTTPException
 from db.models import Ticket
+
+logger = logging.getLogger(__name__)
 
 
 class TicketService:
     """Service class providing ticket-related database operations."""
 
-    def __init__(self, db: Session):
+    def __init__(self, db: AsyncSession):
         self.db = db
 
-    def get_ticket(self, ticket_id: int):
-        return self.db.query(Ticket).filter(Ticket.Ticket_ID == ticket_id).first()
+    async def get_ticket(self, ticket_id: int) -> Ticket | None:
+        return await self.db.get(Ticket, ticket_id)
 
-    def list_tickets(self, skip: int = 0, limit: int = 10):
-        return self.db.query(Ticket).offset(skip).limit(limit).all()
+    async def list_tickets(self, skip: int = 0, limit: int = 10) -> list[Ticket]:
+        result = await self.db.execute(select(Ticket).offset(skip).limit(limit))
+        return result.scalars().all()
 
-    def create_ticket(self, ticket_obj: Ticket):
+    async def create_ticket(self, ticket_obj: Ticket) -> Ticket:
         self.db.add(ticket_obj)
         try:
-            self.db.commit()
-            self.db.refresh(ticket_obj)
+            await self.db.commit()
+            await self.db.refresh(ticket_obj)
         except SQLAlchemyError as e:
-            self.db.rollback()
+            await self.db.rollback()
+            logger.exception("Failed to create ticket")
             raise HTTPException(status_code=500, detail=f"Failed to create ticket: {e}")
         return ticket_obj
 
-    def update_ticket(self, ticket_id: int, updates: dict):
-        ticket = self.get_ticket(ticket_id)
+    async def update_ticket(self, ticket_id: int, updates: dict) -> Ticket | None:
+        ticket = await self.get_ticket(ticket_id)
         if not ticket:
             return None
         for key, value in updates.items():
             if hasattr(ticket, key):
                 setattr(ticket, key, value)
         try:
-            self.db.commit()
-            self.db.refresh(ticket)
+            await self.db.commit()
+            await self.db.refresh(ticket)
             return ticket
         except Exception:
-            self.db.rollback()
+            await self.db.rollback()
+            logger.exception("Failed to update ticket %s", ticket_id)
             raise
 
-    def delete_ticket(self, ticket_id: int) -> bool:
-        ticket = self.get_ticket(ticket_id)
+    async def delete_ticket(self, ticket_id: int) -> bool:
+        ticket = await self.get_ticket(ticket_id)
         if not ticket:
             return False
         try:
-            self.db.delete(ticket)
-            self.db.commit()
+            await self.db.delete(ticket)
+            await self.db.commit()
             return True
         except Exception:
-            self.db.rollback()
+            await self.db.rollback()
+            logger.exception("Failed to delete ticket %s", ticket_id)
             raise
 
-    def search_tickets(self, query: str, limit: int = 10):
+    async def search_tickets(self, query: str, limit: int = 10) -> list[Ticket]:
         like = f"%{query}%"
-        return (
-            self.db.query(Ticket)
-            .filter((Ticket.Subject.ilike(like)) | (Ticket.Ticket_Body.ilike(like)))
-            .limit(limit)
-            .all()
+        result = await self.db.execute(
+            select(Ticket).where(
+                (Ticket.Subject.ilike(like)) | (Ticket.Ticket_Body.ilike(like))
+            ).limit(limit)
         )
+        return result.scalars().all()

--- a/tools/ai_tools.py
+++ b/tools/ai_tools.py
@@ -1,6 +1,7 @@
 
 from typing import Any, Dict
 
+import logging
 from ai.openai_agent import suggest_ticket_response
 
 logger = logging.getLogger(__name__)

--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -1,89 +1,54 @@
-
-from sqlalchemy.orm import Session
-from sqlalchemy import func
 import logging
+from datetime import datetime, timedelta
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import Ticket
-from services.analytics_service import AnalyticsService
 
 logger = logging.getLogger(__name__)
 
 
-
-def tickets_by_status(db: Session) -> list[tuple[int | None, int]]:
-
-    """
-    Returns a list of tuples (status_id, count) for all tickets.
-    """
-
-
-    logger.info("Calculating tickets by status")
-    results = db.query(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID)) \
-                .group_by(Ticket.Ticket_Status_ID).all()
-    return [(row[0], row[1]) for row in results]
+async def tickets_by_status(db: AsyncSession) -> list[tuple[int | None, int]]:
+    result = await db.execute(
+        select(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID)).group_by(
+            Ticket.Ticket_Status_ID
+        )
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
-
-def open_tickets_by_site(db: Session) -> list[tuple[int | None, int]]:
-
-    """
-    Returns list of tuples (site_id, open_count) for tickets not closed (status != 3).
-    """
-
-
-    logger.info("Calculating open tickets by site")
-    results = db.query(Ticket.Site_ID, func.count(Ticket.Ticket_ID)) \
-                .filter(Ticket.Ticket_Status_ID != 3) \
-                .group_by(Ticket.Site_ID).all()
-    return [(row[0], row[1]) for row in results]
+async def open_tickets_by_site(db: AsyncSession) -> list[tuple[int | None, int]]:
+    result = await db.execute(
+        select(Ticket.Site_ID, func.count(Ticket.Ticket_ID))
+        .where(Ticket.Ticket_Status_ID != 3)
+        .group_by(Ticket.Site_ID)
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
-
-def sla_breaches(db: Session, sla_days: int = 2) -> int:
-
-    """
-    Count tickets older than sla_days and not closed.
-    """
-    from datetime import datetime, timedelta
-
-    logger.info("Counting SLA breaches older than %s days", sla_days)
+async def sla_breaches(db: AsyncSession, sla_days: int = 2) -> int:
     cutoff = datetime.utcnow() - timedelta(days=sla_days)
     result = await db.execute(
         select(func.count(Ticket.Ticket_ID))
-        .filter(Ticket.Created_Date < cutoff)
-        .filter(Ticket.Ticket_Status_ID != 3)
+        .where(Ticket.Created_Date < cutoff)
+        .where(Ticket.Ticket_Status_ID != 3)
     )
-    return result.scalar()
+    return result.scalar_one()
 
 
-
-def open_tickets_by_user(db: Session) -> list[tuple[str | None, int]]:
-
-    """
-    Returns list of tuples (assigned_email, open_count) for tickets not closed.
-    """
-
-
-    logger.info("Calculating open tickets by user")
-    results = db.query(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID)) \
-                .filter(Ticket.Ticket_Status_ID != 3) \
-                .group_by(Ticket.Assigned_Email).all()
-    return [(row[0], row[1]) for row in results]
+async def open_tickets_by_user(db: AsyncSession) -> list[tuple[str | None, int]]:
+    result = await db.execute(
+        select(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID))
+        .where(Ticket.Ticket_Status_ID != 3)
+        .group_by(Ticket.Assigned_Email)
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
-def tickets_waiting_on_user(db: Session) -> list[tuple[str | None, int]]:
-
-    """
-    Returns list of tuples (contact_email, waiting_count) for tickets awaiting contact reply (status == 4).
-    """
-
-    logger.info("Calculating tickets waiting on user")
-    results = db.query(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID)) \
-                .filter(Ticket.Ticket_Status_ID == 4) \
-                .group_by(Ticket.Ticket_Contact_Email).all()
-    return [(row[0], row[1]) for row in results]
-
-
-
-
-
+async def tickets_waiting_on_user(db: AsyncSession) -> list[tuple[str | None, int]]:
+    result = await db.execute(
+        select(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID))
+        .where(Ticket.Ticket_Status_ID == 4)
+        .group_by(Ticket.Ticket_Contact_Email)
+    )
+    return [(row[0], row[1]) for row in result.all()]

--- a/tools/asset_tools.py
+++ b/tools/asset_tools.py
@@ -1,18 +1,15 @@
-
-from sqlalchemy.orm import Session
 import logging
-
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import Asset
 
 logger = logging.getLogger(__name__)
 
 
-def get_asset(db: Session, asset_id: int) -> Asset | None:
-    return db.query(Asset).filter(Asset.ID == asset_id).first()
+async def get_asset(db: AsyncSession, asset_id: int) -> Asset | None:
+    return await db.get(Asset, asset_id)
 
 
-def list_assets(db: Session, skip: int = 0, limit: int = 10) -> list[Asset]:
-
-    return db.query(Asset).offset(skip).limit(limit).all()
-
-
+async def list_assets(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Asset]:
+    result = await db.execute(select(Asset).offset(skip).limit(limit))
+    return result.scalars().all()

--- a/tools/attachment_tools.py
+++ b/tools/attachment_tools.py
@@ -1,13 +1,13 @@
-
-from sqlalchemy.orm import Session
 import logging
-
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import TicketAttachment
 
 logger = logging.getLogger(__name__)
 
 
-def get_ticket_attachments(db: Session, ticket_id: int) -> list[TicketAttachment]:
-
-    return db.query(TicketAttachment).filter(TicketAttachment.Ticket_ID == ticket_id).all()
-
+async def get_ticket_attachments(db: AsyncSession, ticket_id: int) -> list[TicketAttachment]:
+    result = await db.execute(
+        select(TicketAttachment).where(TicketAttachment.Ticket_ID == ticket_id)
+    )
+    return result.scalars().all()

--- a/tools/category_tools.py
+++ b/tools/category_tools.py
@@ -1,13 +1,11 @@
-
-from sqlalchemy.orm import Session
 import logging
-
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import TicketCategory
 
 logger = logging.getLogger(__name__)
 
 
-def list_categories(db: Session) -> list[TicketCategory]:
-
-    return db.query(TicketCategory).all()
-
+async def list_categories(db: AsyncSession) -> list[TicketCategory]:
+    result = await db.execute(select(TicketCategory))
+    return result.scalars().all()

--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -1,30 +1,31 @@
-from sqlalchemy.ext.asyncio import AsyncSession
+import logging
+from datetime import datetime
+from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from errors import DatabaseError
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from db.models import TicketMessage
-from datetime import datetime
-import logging
 
 logger = logging.getLogger(__name__)
 
 
-
-def get_ticket_messages(db: Session, ticket_id: int) -> list[TicketMessage]:
-
-    return (
-        db.query(TicketMessage)
-
-        .filter(TicketMessage.Ticket_ID == ticket_id)
+async def get_ticket_messages(db: AsyncSession, ticket_id: int) -> list[TicketMessage]:
+    result = await db.execute(
+        select(TicketMessage)
+        .where(TicketMessage.Ticket_ID == ticket_id)
         .order_by(TicketMessage.DateTimeStamp)
     )
     return result.scalars().all()
 
 
-def post_ticket_message(
-    db: Session, ticket_id: int, message: str, sender_code: str, sender_name: str
+async def post_ticket_message(
+    db: AsyncSession,
+    ticket_id: int,
+    message: str,
+    sender_code: str,
+    sender_name: str,
 ) -> TicketMessage:
-
     msg = TicketMessage(
         Ticket_ID=ticket_id,
         Message=message,
@@ -35,17 +36,11 @@ def post_ticket_message(
 
     db.add(msg)
     try:
-
-        db.commit()
-        db.refresh(msg)
+        await db.commit()
+        await db.refresh(msg)
         logger.info("Posted message to ticket %s", ticket_id)
-
     except SQLAlchemyError as e:
-
-        db.rollback()
-
+        await db.rollback()
         logger.exception("Failed to save ticket message for %s", ticket_id)
         raise HTTPException(status_code=500, detail=f"Failed to save message: {e}")
-
     return msg
-

--- a/tools/site_tools.py
+++ b/tools/site_tools.py
@@ -1,19 +1,15 @@
-
-from sqlalchemy.orm import Session
 import logging
-
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import Site
 
 logger = logging.getLogger(__name__)
 
 
-
-def get_site(db: Session, site_id: int) -> Site | None:
-    return db.query(Site).filter(Site.ID == site_id).first()
-
-
-def list_sites(db: Session, skip: int = 0, limit: int = 10) -> list[Site]:
-
-    return db.query(Site).offset(skip).limit(limit).all()
+async def get_site(db: AsyncSession, site_id: int) -> Site | None:
+    return await db.get(Site, site_id)
 
 
+async def list_sites(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Site]:
+    result = await db.execute(select(Site).offset(skip).limit(limit))
+    return result.scalars().all()

--- a/tools/status_tools.py
+++ b/tools/status_tools.py
@@ -1,15 +1,11 @@
-
-from sqlalchemy.orm import Session
 import logging
-
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import TicketStatus
 
 logger = logging.getLogger(__name__)
 
 
-def list_statuses(db: Session) -> list[TicketStatus]:
-
-
-    return db.query(TicketStatus).all()
-
-
+async def list_statuses(db: AsyncSession) -> list[TicketStatus]:
+    result = await db.execute(select(TicketStatus))
+    return result.scalars().all()

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -1,70 +1,56 @@
+import logging
+from typing import Iterable
 
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-
+from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import HTTPException
-
 from pydantic import BaseModel
 
 from db.models import Ticket
-from services.ticket_service import TicketService
-
-
-
-async def get_ticket(db: AsyncSession, ticket_id: int):
-    return await db.get(Ticket, ticket_id)
 
 logger = logging.getLogger(__name__)
 
 
-def get_ticket(db: Session, ticket_id: int) -> Ticket | None:
-    return db.query(Ticket).filter(Ticket.Ticket_ID == ticket_id).first()
+async def get_ticket(db: AsyncSession, ticket_id: int) -> Ticket | None:
+    """Fetch a ticket by id."""
+    return await db.get(Ticket, ticket_id)
 
 
-def list_tickets(db: Session, skip: int = 0, limit: int = 10) -> list[Ticket]:
-    return db.query(Ticket).offset(skip).limit(limit).all()
+async def list_tickets(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Ticket]:
+    result = await db.execute(select(Ticket).offset(skip).limit(limit))
+    return result.scalars().all()
 
 
-def create_ticket(db: Session, ticket_obj: Ticket) -> Ticket:
-
-
+async def create_ticket(db: AsyncSession, ticket_obj: Ticket) -> Ticket:
     db.add(ticket_obj)
     try:
         await db.commit()
         await db.refresh(ticket_obj)
     except SQLAlchemyError as e:
-
-        db.rollback()
-
+        await db.rollback()
         logger.exception("Failed to create ticket")
         raise HTTPException(status_code=500, detail=f"Failed to create ticket: {e}")
-
     return ticket_obj
 
 
-
-def update_ticket(db: Session, ticket_id: int, updates) -> Ticket | None:
-    """Update a ticket with a mapping or Pydantic model."""
+async def update_ticket(db: AsyncSession, ticket_id: int, updates: BaseModel | dict) -> Ticket | None:
     if isinstance(updates, BaseModel):
         updates = updates.dict(exclude_unset=True)
-    ticket = get_ticket(db, ticket_id)
-
+    ticket = await get_ticket(db, ticket_id)
     if not ticket:
         return None
     for key, value in updates.items():
         if hasattr(ticket, key):
             setattr(ticket, key, value)
     try:
-
-        db.commit()
-        db.refresh(ticket)
+        await db.commit()
+        await db.refresh(ticket)
         logger.info("Updated ticket %s", ticket_id)
         return ticket
     except Exception:
-        db.rollback()
+        await db.rollback()
         logger.exception("Failed to update ticket %s", ticket_id)
-
         raise
 
 
@@ -73,28 +59,25 @@ async def delete_ticket(db: AsyncSession, ticket_id: int) -> bool:
     if not ticket:
         return False
     try:
-
-        db.delete(ticket)
-        db.commit()
+        await db.delete(ticket)
+        await db.commit()
         logger.info("Deleted ticket %s", ticket_id)
         return True
     except Exception:
-        db.rollback()
+        await db.rollback()
         logger.exception("Failed to delete ticket %s", ticket_id)
-
         raise
 
 
-def search_tickets(db: Session, query: str, limit: int = 10) -> list[Ticket]:
+def _escape_wildcards(term: str) -> str:
+    return term.replace("%", "\\%").replace("_", "\\_")
 
-    like = f"%{query}%"
 
-    logger.info("Searching tickets for '%s'", query)
-    return (
-        db.query(Ticket)
-
-        .filter((Ticket.Subject.ilike(like)) | (Ticket.Ticket_Body.ilike(like)))
-        .limit(limit)
+async def search_tickets(db: AsyncSession, query: str, limit: int = 10) -> list[Ticket]:
+    like = f"%{_escape_wildcards(query)}%"
+    result = await db.execute(
+        select(Ticket).where(
+            Ticket.Subject.ilike(like) | Ticket.Ticket_Body.ilike(like)
+        ).limit(limit)
     )
-
-
+    return result.scalars().all()

--- a/tools/vendor_tools.py
+++ b/tools/vendor_tools.py
@@ -1,18 +1,15 @@
-
-from sqlalchemy.orm import Session
 import logging
-
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import Vendor
 
 logger = logging.getLogger(__name__)
 
 
+async def get_vendor(db: AsyncSession, vendor_id: int) -> Vendor | None:
+    return await db.get(Vendor, vendor_id)
 
-def get_vendor(db: Session, vendor_id: int) -> Vendor | None:
-    return db.query(Vendor).filter(Vendor.ID == vendor_id).first()
 
-
-def list_vendors(db: Session, skip: int = 0, limit: int = 10) -> list[Vendor]:
-
-    return db.query(Vendor).offset(skip).limit(limit).all()
-
+async def list_vendors(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Vendor]:
+    result = await db.execute(select(Vendor).offset(skip).limit(limit))
+    return result.scalars().all()


### PR DESCRIPTION
## Summary
- convert database service methods to use AsyncSession
- rewrite ticket utility functions as async helpers
- convert vendor/site/category/status/asset and other helpers
- asyncify API router with awaits
- fix missing imports in `main` and AI utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, NameError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_686407cb9f70832b86a763638996d9ff