### PR TITLE
Implement Graph API helpers

### DIFF
--- a/tools/user_tools.py
+++ b/tools/user_tools.py
@@ -27,15 +27,52 @@ network access.
 from typing import Dict, List
 
 import logging
+import os
+import requests
 
 logger = logging.getLogger(__name__)
 
 
 GROUP_ID = "2ea9cf9b-4d28-456e-9eda-bd2c15825ee2"
 
+CLIENT_ID = os.getenv("GRAPH_CLIENT_ID")
+CLIENT_SECRET = os.getenv("GRAPH_CLIENT_SECRET")
+TENANT_ID = os.getenv("GRAPH_TENANT_ID")
+
+
+def _get_token() -> str | None:
+    if not (CLIENT_ID and CLIENT_SECRET and TENANT_ID):
+        return None
+
+    url = (
+        f"https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token"
+    )
+    data = {
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "scope": "https://graph.microsoft.com/.default",
+        "grant_type": "client_credentials",
+    }
+    resp = requests.post(url, data=data, timeout=10)
+    resp.raise_for_status()
+    return resp.json().get("access_token")
+
 
 def get_user_by_email(email: str) -> Dict[str, str | None]:
+    """Return details for a single user identified by email."""
 
+    token = _get_token()
+    if not token:
+        return {"email": email, "displayName": None, "id": None}
+
+    url = f"https://graph.microsoft.com/v1.0/users/{email}"
+    resp = requests.get(
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    data = resp.json()
     return {
         "email": data.get("mail"),
         "displayName": data.get("displayName"),
@@ -45,12 +82,35 @@ def get_user_by_email(email: str) -> Dict[str, str | None]:
 
 
 def get_all_users_in_group() -> List[Dict[str, str | None]]:
+    """Return all members of the helpdesk group."""
 
-    return []
+    token = _get_token()
+    if not token:
+        return []
+
+    url = f"https://graph.microsoft.com/v1.0/groups/{GROUP_ID}/members"
+    resp = requests.get(
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    users = []
+    for data in payload.get("value", []):
+        users.append(
+            {
+                "email": data.get("mail"),
+                "displayName": data.get("displayName"),
+                "id": data.get("id"),
+            }
+        )
+    return users
 
 
 def resolve_user_display_name(identifier: str) -> str:
     logger.info("Resolving display name for %s", identifier)
 
-    return identifier
+    user = get_user_by_email(identifier)
+    return user.get("displayName") or identifier
 


### PR DESCRIPTION
## Summary
- add OAuth token retrieval using Microsoft Graph credentials
- query Graph API for user info and group members
- fall back to dummy data when no credentials are set

## Testing
- `pip install -r requirements.txt`
- `pip install aiosqlite`
- `pytest -q` *(fails: ModuleNotFoundError: slowapi)*

------
https://chatgpt.com/codex/tasks/task_e_686407cd0d8c832b9754a499c16a3291