### PR TITLE
Refactor OpenAI client usage

### DIFF
--- a/ai/openai_agent.py
+++ b/ai/openai_agent.py
@@ -1,15 +1,28 @@
 from typing import Any, Dict
 
+import logging
 import openai
 
-from openai import APITimeoutError, OpenAIError
+from openai import APITimeoutError, OpenAIError, OpenAI
 from config import OPENAI_API_KEY
+
+logger = logging.getLogger(__name__)
+
+openai_client: OpenAI | None = None
+
+
+def _get_client() -> OpenAI:
+    """Return a singleton OpenAI client, instantiating it if necessary."""
+    global openai_client
+    if openai_client is None:
+        if not OPENAI_API_KEY:
+            raise RuntimeError("OPENAI_API_KEY environment variable not set")
+        openai_client = OpenAI(api_key=OPENAI_API_KEY)
+    return openai_client
 
 
 def suggest_ticket_response(ticket: Dict[str, Any], context: str = "") -> str:
-    if not OPENAI_API_KEY:
-
-        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+    client = _get_client()
 
     prompt = (
         "You are a Tier 1 help desk agent for a truck stop. Here is the ticket:\n"
@@ -19,7 +32,7 @@ def suggest_ticket_response(ticket: Dict[str, Any], context: str = "") -> str:
     )
     try:
 
-        response = openai.ChatCompletion.create(  # type: ignore[attr-defined]
+        response = client.chat.completions.create(
 
             model="gpt-4o",
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -105,7 +105,19 @@ async def test_ai_suggest_response(client: AsyncClient, monkeypatch):
         return type("Resp", (), {"choices": [Choice()]})()
 
     from ai import openai_agent
-    monkeypatch.setattr(openai_agent.openai_client.chat.completions, "create", fake_create)
+
+    class DummyClient:
+        class Chat:
+            class Completions:
+                @staticmethod
+                def create(*args, **kwargs):
+                    return type("Resp", (), {"choices": [{"message": {"content": "ok"}}]})()
+
+            completions = Completions()
+
+        chat = Chat()
+
+    monkeypatch.setattr(openai_agent, "_get_client", lambda: DummyClient())
 
     payload = {
         "Subject": "AI", "Ticket_Body": "body",

--- a/tests/test_openai_agent.py
+++ b/tests/test_openai_agent.py
@@ -4,6 +4,7 @@ from ai import openai_agent
 
 def test_suggest_ticket_response_requires_key(monkeypatch):
     monkeypatch.setattr(openai_agent, "openai_client", None)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with pytest.raises(RuntimeError):
         openai_agent.suggest_ticket_response({"Subject": "Test", "Ticket_Body": "body"})
 
@@ -38,7 +39,7 @@ def test_client_initialized_once(monkeypatch):
     import importlib
     import openai
 
-    monkeypatch.setattr(openai, "Client", DummyClient)
+    monkeypatch.setattr(openai, "OpenAI", DummyClient)
     oa = importlib.reload(openai_agent)
 
     # Call multiple times; initialization should only happen once

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,13 +1,22 @@
-import openai
 from fastapi.testclient import TestClient
 from main import app
 
 client = TestClient(app)
 
 def _patch_openai(monkeypatch):
-    def fake_create(*args, **kwargs):
-        return {"choices": [{"message": {"content": "ok"}}]}
-    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+    class DummyClient:
+        class Chat:
+            class Completions:
+                @staticmethod
+                def create(*args, **kwargs):
+                    return {"choices": [{"message": {"content": "ok"}}]}
+
+            completions = Completions()
+
+        chat = Chat()
+
+    from ai import openai_agent
+    monkeypatch.setattr(openai_agent, "openai_client", DummyClient())
 
 def _create_ticket():
     payload = {


### PR DESCRIPTION
## Summary
- create a singleton OpenAI client with the configured API key
- log OpenAI errors using a module level logger
- adjust tests for new OpenAI client pattern

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q aiosqlite`
- `pip install -q slowapi==0.1.8`
- `pytest -q` *(fails: SyntaxError in existing project files)*

------
https://chatgpt.com/codex/tasks/task_e_686407cf5660832b87cefcfa5b0b49f9