### PR TITLE
Refactor ticket tools for async

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -7,9 +7,8 @@ import httpx
 from main import app
 
 
-def _add_sample_ticket():
-    session = SessionLocal()
-    try:
+async def _add_sample_ticket():
+    async with SessionLocal() as session:
         t = Ticket(
             Subject="Net",
             Ticket_Body="Conn",
@@ -18,9 +17,7 @@ def _add_sample_ticket():
             Created_Date=datetime.utcnow(),
             Ticket_Status_ID=1,
         )
-        create_ticket(session, t)
-    finally:
-        session.close()
+        await create_ticket(session, t)
 
 
 async def _search_worker():
@@ -40,7 +37,7 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_concurrent_search():
-    _add_sample_ticket()
+    await _add_sample_ticket()
     tasks = [asyncio.create_task(_search_worker()) for _ in range(5)]
     results = await asyncio.gather(*tasks)
     assert all(r == "Net" for r in results)
@@ -48,7 +45,7 @@ async def test_concurrent_search():
 
 @pytest.mark.asyncio
 async def test_concurrent_analytics():
-    _add_sample_ticket()
+    await _add_sample_ticket()
     tasks = [asyncio.create_task(_analytics_worker()) for _ in range(5)]
     counts = await asyncio.gather(*tasks)
     assert all(c >= 1 for c in counts)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -49,19 +49,19 @@ async def test_get_ticket_not_found(client: AsyncClient):
 
 
 
-def test_update_ticket():
-    ticket = _create_ticket()
+@pytest.mark.asyncio
+async def test_update_ticket(client: AsyncClient):
+    ticket = await _create_ticket(client)
     tid = ticket["Ticket_ID"]
-
-    resp = client.put(f"/ticket/{tid}", json={"Subject": "Updated"})
+    resp = await client.put(f"/ticket/{tid}", json={"Subject": "Updated"})
     assert resp.status_code == 200
     assert resp.json()["Subject"] == "Updated"
 
 
-def test_update_ticket_invalid_field():
-    ticket = _create_ticket()
+@pytest.mark.asyncio
+async def test_update_ticket_invalid_field(client: AsyncClient):
+    ticket = await _create_ticket(client)
     tid = ticket["Ticket_ID"]
-
-    resp = client.put(f"/ticket/{tid}", json={"BadField": "x"})
+    resp = await client.put(f"/ticket/{tid}", json={"BadField": "x"})
     assert resp.status_code == 422
 

--- a/tools/ai_tools.py
+++ b/tools/ai_tools.py
@@ -1,6 +1,7 @@
 
 from typing import Any, Dict
 
+import logging
 from ai.openai_agent import suggest_ticket_response
 
 logger = logging.getLogger(__name__)

--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -1,6 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 from errors import DatabaseError
 from db.models import TicketMessage
 from datetime import datetime

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -1,70 +1,71 @@
 
-from sqlalchemy.ext.asyncio import AsyncSession
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
 from sqlalchemy import select
-from sqlalchemy.exc import SQLAlchemyError
 
 from fastapi import HTTPException
-
 from pydantic import BaseModel
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import Ticket
-from services.ticket_service import TicketService
 
-
-
-async def get_ticket(db: AsyncSession, ticket_id: int):
-    return await db.get(Ticket, ticket_id)
 
 logger = logging.getLogger(__name__)
 
 
-def get_ticket(db: Session, ticket_id: int) -> Ticket | None:
-    return db.query(Ticket).filter(Ticket.Ticket_ID == ticket_id).first()
+def _escape_wildcards(text: str) -> str:
+    """Escape SQL wildcard characters for LIKE queries."""
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
-def list_tickets(db: Session, skip: int = 0, limit: int = 10) -> list[Ticket]:
-    return db.query(Ticket).offset(skip).limit(limit).all()
+async def get_ticket(db: AsyncSession, ticket_id: int) -> Ticket | None:
+    return await db.get(Ticket, ticket_id)
 
 
-def create_ticket(db: Session, ticket_obj: Ticket) -> Ticket:
+async def list_tickets(db: AsyncSession, skip: int = 0, limit: int = 10) -> Sequence[Ticket]:
+    result = await db.execute(
+        select(Ticket).offset(skip).limit(limit)
+    )
+    return result.scalars().all()
 
 
+async def create_ticket(db: AsyncSession, ticket_obj: Ticket) -> Ticket:
     db.add(ticket_obj)
     try:
         await db.commit()
         await db.refresh(ticket_obj)
     except SQLAlchemyError as e:
-
-        db.rollback()
-
+        await db.rollback()
         logger.exception("Failed to create ticket")
         raise HTTPException(status_code=500, detail=f"Failed to create ticket: {e}")
-
     return ticket_obj
 
 
-
-def update_ticket(db: Session, ticket_id: int, updates) -> Ticket | None:
+async def update_ticket(db: AsyncSession, ticket_id: int, updates) -> Ticket | None:
     """Update a ticket with a mapping or Pydantic model."""
     if isinstance(updates, BaseModel):
         updates = updates.dict(exclude_unset=True)
-    ticket = get_ticket(db, ticket_id)
 
+    ticket = await get_ticket(db, ticket_id)
     if not ticket:
         return None
+
     for key, value in updates.items():
         if hasattr(ticket, key):
             setattr(ticket, key, value)
-    try:
 
-        db.commit()
-        db.refresh(ticket)
+    try:
+        await db.commit()
+        await db.refresh(ticket)
         logger.info("Updated ticket %s", ticket_id)
         return ticket
     except Exception:
-        db.rollback()
+        await db.rollback()
         logger.exception("Failed to update ticket %s", ticket_id)
-
         raise
 
 
@@ -73,28 +74,24 @@ async def delete_ticket(db: AsyncSession, ticket_id: int) -> bool:
     if not ticket:
         return False
     try:
-
-        db.delete(ticket)
-        db.commit()
+        await db.delete(ticket)
+        await db.commit()
         logger.info("Deleted ticket %s", ticket_id)
         return True
     except Exception:
-        db.rollback()
+        await db.rollback()
         logger.exception("Failed to delete ticket %s", ticket_id)
-
         raise
 
 
-def search_tickets(db: Session, query: str, limit: int = 10) -> list[Ticket]:
-
+async def search_tickets(db: AsyncSession, query: str, limit: int = 10) -> Sequence[Ticket]:
     like = f"%{query}%"
-
     logger.info("Searching tickets for '%s'", query)
-    return (
-        db.query(Ticket)
-
-        .filter((Ticket.Subject.ilike(like)) | (Ticket.Ticket_Body.ilike(like)))
-        .limit(limit)
+    result = await db.execute(
+        select(Ticket).filter(
+            (Ticket.Subject.ilike(like)) | (Ticket.Ticket_Body.ilike(like))
+        ).limit(limit)
     )
+    return result.scalars().all()
 
 


### PR DESCRIPTION
## Summary
- convert ticket utilities to async/await
- update API routes for async ticket handling
- adapt tests for new async ticket helpers
- add missing imports

## Testing
- `pytest -q` *(fails: NameError/AttributeError and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_686407d3d7ac832b85f1650dda3b4d3c