### PR TITLE
Fix main app imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware


### PR DESCRIPTION
## Summary
- import `Request` and `jsonable_encoder` in `main.py`

## Testing
- `pytest tests/test_app.py -q` *(fails: SyntaxError in api/routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_6865985f1c9c832bae2e769727937362