### PR TITLE
Fix async helper usage in route tests

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -12,21 +12,21 @@ async def client():
         yield ac
 
 
-async def _create_ticket(client: AsyncClient):
+def _create_ticket(client: AsyncClient):
     payload = {
         "Subject": "API test",
         "Ticket_Body": "Checking routes",
         "Ticket_Contact_Name": "Tester",
         "Ticket_Contact_Email": "tester@example.com",
     }
-    response = await client.post("/ticket", json=payload)
-    assert response.status_code == 200
-    return response.json()
+    return client.post("/ticket", json=payload)
 
 
 @pytest.mark.asyncio
 async def test_create_and_get_ticket(client: AsyncClient):
-    created = await _create_ticket(client)
+    resp = await _create_ticket(client)
+    assert resp.status_code == 200
+    created = resp.json()
     tid = created["Ticket_ID"]
 
     list_resp = await client.get("/tickets")
@@ -49,19 +49,26 @@ async def test_get_ticket_not_found(client: AsyncClient):
 
 
 
-def test_update_ticket():
-    ticket = _create_ticket()
+@pytest.mark.asyncio
+async def test_update_ticket(client: AsyncClient):
+    resp = await _create_ticket(client)
+    assert resp.status_code == 200
+    ticket = resp.json()
     tid = ticket["Ticket_ID"]
 
-    resp = client.put(f"/ticket/{tid}", json={"Subject": "Updated"})
+    resp = await client.put(f"/ticket/{tid}", json={"Subject": "Updated"})
     assert resp.status_code == 200
     assert resp.json()["Subject"] == "Updated"
 
 
-def test_update_ticket_invalid_field():
-    ticket = _create_ticket()
+
+@pytest.mark.asyncio
+async def test_update_ticket_invalid_field(client: AsyncClient):
+    resp = await _create_ticket(client)
+    assert resp.status_code == 200
+    ticket = resp.json()
     tid = ticket["Ticket_ID"]
 
-    resp = client.put(f"/ticket/{tid}", json={"BadField": "x"})
+    resp = await client.put(f"/ticket/{tid}", json={"BadField": "x"})
     assert resp.status_code == 422
 


### PR DESCRIPTION
## Summary
- refactor `_create_ticket` helper to return coroutine
- await `_create_ticket` calls in route tests
- convert route update tests to async

## Testing
- `pytest tests/test_routes.py::test_create_and_get_ticket -q` *(fails: SyntaxError in api/routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68659861c1f0832bab29ecd754808130