### PR TITLE
Add health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ alembic upgrade head
 
 ### API Highlights
 
-- `GET /health` - health check returning uptime and version
+- `GET /health` - health check returning database status, uptime, and version
 - `POST /ticket` - create a ticket
 - `GET /tickets` - list tickets
 - `GET /tickets/search?q=term` - search tickets by subject or body

--- a/api/routes.py
+++ b/api/routes.py
@@ -62,10 +62,7 @@ logger = logging.getLogger(__name__)
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     async with SessionLocal() as db:
-
         yield db
-    finally:
-        db.close()
 
 def get_ticket_service(db: AsyncSession = Depends(get_db)) -> TicketService:
     return TicketService(db)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Depends
 
 from fastapi.encoders import jsonable_encoder
 
@@ -8,10 +8,18 @@ from fastapi.encoders import jsonable_encoder
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
-from api.routes import router
+from api.routes import router, get_db
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 from limiter import limiter
 
 from datetime import datetime
+
+# Application version
+APP_VERSION = "0.1.0"
+
+# Record startup time to report uptime
+START_TIME = datetime.utcnow()
 from errors import ErrorResponse, NotFoundError, ValidationError, DatabaseError
 
 
@@ -57,4 +65,17 @@ async def handle_database(request: Request, exc: DatabaseError):
         timestamp=datetime.utcnow(),
     )
     return JSONResponse(status_code=500, content=jsonable_encoder(resp))
+
+
+@app.get("/health")
+async def health(db: AsyncSession = Depends(get_db)) -> dict:
+    """Return basic service health information."""
+    try:
+        await db.execute(text("SELECT 1"))
+        db_status = "ok"
+    except Exception:
+        db_status = "error"
+
+    uptime = (datetime.utcnow() - START_TIME).total_seconds()
+    return {"db": db_status, "uptime": uptime, "version": APP_VERSION}
 


### PR DESCRIPTION
## Summary
- add `/health` to expose database status, uptime and version
- update README docs for `/health`
- clean up db lifecycle helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: NameError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68659e81abdc832b8804e514d9eb3186