### PR TITLE
Improve config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
    - `OPENAI_API_KEY` – API key used by the OpenAI integration.
    - `CONFIG_ENV` – which config to load: `dev`, `staging`, or `prod` (default `dev`).
 
-   They can be provided in the shell environment or in a `.env` file in the project root.  
-   OpenAI model parameters such as model name and timeouts are defined in the selected config file.
+   They can be provided in the shell environment or in a `.env` file in the project root.
+   `config.py` automatically loads `.env` and then imports `config_{CONFIG_ENV}.py`
+   so the appropriate settings are applied at startup. OpenAI model parameters
+   such as model name and timeouts are defined in the selected config file.
 
 ## Running the API
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -62,10 +62,7 @@ logger = logging.getLogger(__name__)
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     async with SessionLocal() as db:
-
         yield db
-    finally:
-        db.close()
 
 def get_ticket_service(db: AsyncSession = Depends(get_db)) -> TicketService:
     return TicketService(db)

--- a/config.py
+++ b/config.py
@@ -1,12 +1,31 @@
+"""Application configuration loader.
+
+This module loads environment variables from a ``.env`` file and then imports
+``config_{env}.py`` based on the ``CONFIG_ENV`` environment variable.  Values
+defined in the imported module are exposed at the top level of this module.
+"""
+
 import importlib
+import logging
 import os
 
-import logging
 from dotenv import load_dotenv
 
 
+load_dotenv()
+
+CONFIG_ENV = os.getenv("CONFIG_ENV", "dev")
 
 DB_CONN_STRING: str | None = os.getenv("DB_CONN_STRING")
 OPENAI_API_KEY: str | None = os.getenv("OPENAI_API_KEY")
+
+try:
+    env_module = importlib.import_module(f"config_{CONFIG_ENV}")
+except ModuleNotFoundError:
+    logging.warning("config_%s.py not found; using environment variables only", CONFIG_ENV)
+else:
+    for name, value in vars(env_module).items():
+        if name.isupper():
+            globals()[name] = value
 
 


### PR DESCRIPTION
## Summary
- allow selecting config via `CONFIG_ENV`
- autoload `.env` from config.py
- fix API route db dependency
- document config autoloading

## Testing
- `pip install -r requirements.txt`
- `pip install aiosqlite`
- `pip install slowapi`
- `pytest -q` *(fails: NameError: create_ticket is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68659e827e40832b919c81e80638a393