### PR TITLE
Fix async SLA breach counting

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -29,6 +29,13 @@ from tools.site_tools import get_site, list_sites
 from tools.category_tools import list_categories
 from tools.status_tools import list_statuses
 from tools.message_tools import get_ticket_messages, post_ticket_message
+from tools.analysis_tools import (
+    tickets_by_status,
+    open_tickets_by_site,
+    sla_breaches,
+    open_tickets_by_user,
+    tickets_waiting_on_user,
+)
 from tools.ai_tools import ai_suggest_response
 from services.ticket_service import TicketService
 from services.analytics_service import AnalyticsService
@@ -62,10 +69,10 @@ logger = logging.getLogger(__name__)
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     async with SessionLocal() as db:
-
-        yield db
-    finally:
-        db.close()
+        try:
+            yield db
+        finally:
+            await db.close()
 
 def get_ticket_service(db: AsyncSession = Depends(get_db)) -> TicketService:
     return TicketService(db)
@@ -284,37 +291,38 @@ def api_ai_suggest_response(ticket: TicketOut, context: str = "") -> dict:
 
 
 @router.get("/analytics/status")
-
-def api_tickets_by_status(db: Session = Depends(get_db)) -> list[tuple[int | None, int]]:
-
-    return tickets_by_status(db)
+async def api_tickets_by_status(
+    db: AsyncSession = Depends(get_db)
+) -> list[tuple[int | None, int]]:
+    return await tickets_by_status(db)
 
 
 @router.get("/analytics/open_by_site")
-
-def api_open_tickets_by_site(db: Session = Depends(get_db)) -> list[tuple[int | None, int]]:
-
-    return open_tickets_by_site(db)
+async def api_open_tickets_by_site(
+    db: AsyncSession = Depends(get_db)
+) -> list[tuple[int | None, int]]:
+    return await open_tickets_by_site(db)
 
 
 @router.get("/analytics/sla_breaches")
-
-def api_sla_breaches(sla_days: int = 2, db: Session = Depends(get_db)) -> dict:
-
-    return {"breaches": sla_breaches(db, sla_days)}
+async def api_sla_breaches(
+    sla_days: int = 2, db: AsyncSession = Depends(get_db)
+) -> dict:
+    breaches = await sla_breaches(db, sla_days)
+    return {"breaches": breaches}
 
 
 @router.get("/analytics/open_by_user")
-
-def api_open_tickets_by_user(db: Session = Depends(get_db)) -> list[tuple[str | None, int]]:
-
-    return open_tickets_by_user(db)
+async def api_open_tickets_by_user(
+    db: AsyncSession = Depends(get_db)
+) -> list[tuple[str | None, int]]:
+    return await open_tickets_by_user(db)
 
 
 @router.get("/analytics/waiting_on_user")
-
-def api_tickets_waiting_on_user(db: Session = Depends(get_db)) -> list[tuple[str | None, int]]:
-
-    return tickets_waiting_on_user(db)
+async def api_tickets_waiting_on_user(
+    db: AsyncSession = Depends(get_db)
+) -> list[tuple[str | None, int]]:
+    return await tickets_waiting_on_user(db)
 
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -7,6 +7,7 @@ from main import app
 from db.models import Ticket
 from db.mssql import SessionLocal
 from services.ticket_service import TicketService
+from tools.ticket_tools import create_ticket
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,6 +5,7 @@ from db.models import Base, Ticket
 from db.mssql import engine, SessionLocal
 from services.ticket_service import TicketService
 from datetime import datetime
+from tools.ticket_tools import create_ticket, search_tickets
 
 os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")
 

--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -1,16 +1,15 @@
 
-from sqlalchemy.orm import Session
-from sqlalchemy import func
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 import logging
 
 from db.models import Ticket
-from services.analytics_service import AnalyticsService
 
 logger = logging.getLogger(__name__)
 
 
 
-def tickets_by_status(db: Session) -> list[tuple[int | None, int]]:
+async def tickets_by_status(db: AsyncSession) -> list[tuple[int | None, int]]:
 
     """
     Returns a list of tuples (status_id, count) for all tickets.
@@ -18,13 +17,16 @@ def tickets_by_status(db: Session) -> list[tuple[int | None, int]]:
 
 
     logger.info("Calculating tickets by status")
-    results = db.query(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID)) \
-                .group_by(Ticket.Ticket_Status_ID).all()
-    return [(row[0], row[1]) for row in results]
+    result = await db.execute(
+        select(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID)).group_by(
+            Ticket.Ticket_Status_ID
+        )
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
 
-def open_tickets_by_site(db: Session) -> list[tuple[int | None, int]]:
+async def open_tickets_by_site(db: AsyncSession) -> list[tuple[int | None, int]]:
 
     """
     Returns list of tuples (site_id, open_count) for tickets not closed (status != 3).
@@ -32,14 +34,16 @@ def open_tickets_by_site(db: Session) -> list[tuple[int | None, int]]:
 
 
     logger.info("Calculating open tickets by site")
-    results = db.query(Ticket.Site_ID, func.count(Ticket.Ticket_ID)) \
-                .filter(Ticket.Ticket_Status_ID != 3) \
-                .group_by(Ticket.Site_ID).all()
-    return [(row[0], row[1]) for row in results]
+    result = await db.execute(
+        select(Ticket.Site_ID, func.count(Ticket.Ticket_ID))
+        .filter(Ticket.Ticket_Status_ID != 3)
+        .group_by(Ticket.Site_ID)
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
 
-def sla_breaches(db: Session, sla_days: int = 2) -> int:
+async def sla_breaches(db: AsyncSession, sla_days: int = 2) -> int:
 
     """
     Count tickets older than sla_days and not closed.
@@ -57,7 +61,7 @@ def sla_breaches(db: Session, sla_days: int = 2) -> int:
 
 
 
-def open_tickets_by_user(db: Session) -> list[tuple[str | None, int]]:
+async def open_tickets_by_user(db: AsyncSession) -> list[tuple[str | None, int]]:
 
     """
     Returns list of tuples (assigned_email, open_count) for tickets not closed.
@@ -65,23 +69,27 @@ def open_tickets_by_user(db: Session) -> list[tuple[str | None, int]]:
 
 
     logger.info("Calculating open tickets by user")
-    results = db.query(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID)) \
-                .filter(Ticket.Ticket_Status_ID != 3) \
-                .group_by(Ticket.Assigned_Email).all()
-    return [(row[0], row[1]) for row in results]
+    result = await db.execute(
+        select(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID))
+        .filter(Ticket.Ticket_Status_ID != 3)
+        .group_by(Ticket.Assigned_Email)
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
-def tickets_waiting_on_user(db: Session) -> list[tuple[str | None, int]]:
+async def tickets_waiting_on_user(db: AsyncSession) -> list[tuple[str | None, int]]:
 
     """
     Returns list of tuples (contact_email, waiting_count) for tickets awaiting contact reply (status == 4).
     """
 
     logger.info("Calculating tickets waiting on user")
-    results = db.query(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID)) \
-                .filter(Ticket.Ticket_Status_ID == 4) \
-                .group_by(Ticket.Ticket_Contact_Email).all()
-    return [(row[0], row[1]) for row in results]
+    result = await db.execute(
+        select(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID))
+        .filter(Ticket.Ticket_Status_ID == 4)
+        .group_by(Ticket.Ticket_Contact_Email)
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
 


### PR DESCRIPTION
## Summary
- convert analytics helpers to async
- update analytics API endpoints to await async helpers
- fix imports in tests
- correct DB dependency cleanup

## Testing
- `pytest tests/test_analytics.py::test_analytics_sla_breaches -q`
- `pytest -q` *(fails: Connection error from blocked OpenAI API, health check status mismatch, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68659e84aca8832bae7aaf35aeba932a