### PR TITLE
Clean up unused imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 
 from fastapi.responses import JSONResponse
-from fastapi.encoders import jsonable_encoder
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 

--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -4,7 +4,6 @@ from sqlalchemy import func
 import logging
 
 from db.models import Ticket
-from services.analytics_service import AnalyticsService
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove duplicate `jsonable_encoder` import
- clean up unused imports in analysis tools

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68659e851290832ba17b7acfb32af209