### PR TITLE
Add /health endpoint and update test

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -62,10 +62,7 @@ logger = logging.getLogger(__name__)
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     async with SessionLocal() as db:
-
         yield db
-    finally:
-        db.close()
 
 def get_ticket_service(db: AsyncSession = Depends(get_db)) -> TicketService:
     return TicketService(db)

--- a/main.py
+++ b/main.py
@@ -2,9 +2,9 @@
 from fastapi import FastAPI, Request
 
 from fastapi.encoders import jsonable_encoder
-
 from fastapi.responses import JSONResponse
-from fastapi.encoders import jsonable_encoder
+from sqlalchemy import text
+from db.mssql import SessionLocal
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
@@ -13,6 +13,9 @@ from limiter import limiter
 
 from datetime import datetime
 from errors import ErrorResponse, NotFoundError, ValidationError, DatabaseError
+
+VERSION = "0.1.0"
+start_time = datetime.utcnow()
 
 
 app = FastAPI(title="Truck Stop MCP Helpdesk API")
@@ -57,4 +60,17 @@ async def handle_database(request: Request, exc: DatabaseError):
         timestamp=datetime.utcnow(),
     )
     return JSONResponse(status_code=500, content=jsonable_encoder(resp))
+
+
+@app.get("/health")
+async def health() -> dict:
+    """Simple health check endpoint."""
+    db_status = "ok"
+    try:
+        async with SessionLocal() as session:
+            await session.execute(text("SELECT 1"))
+    except Exception:
+        db_status = "error"
+    uptime = (datetime.utcnow() - start_time).total_seconds()
+    return {"db": db_status, "uptime": uptime, "version": VERSION}
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -8,6 +8,5 @@ def test_health_ok():
     resp = client.get("/health")
     assert resp.status_code == 200
     data = resp.json()
+    assert set(data.keys()) == {"db", "uptime", "version"}
     assert data["db"] == "ok"
-    assert "uptime" in data
-    assert "version" in data


### PR DESCRIPTION
## Summary
- fix DB session helper
- implement `/health` route
- update health test to check expected keys

## Testing
- `pytest tests/test_health.py -q`
- `pytest -q` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68659e86523c832ba3cc9913f45e3ede