### PR TITLE
Use AsyncSession consistently

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -1,56 +1,53 @@
-from sqlalchemy.orm import Session
-from sqlalchemy import func
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import Ticket
 
 
 class AnalyticsService:
     """Service providing reporting queries on ticket data."""
 
-    def __init__(self, db: Session):
+    def __init__(self, db: AsyncSession):
         self.db = db
 
-    def tickets_by_status(self):
-        results = (
-            self.db.query(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID))
-            .group_by(Ticket.Ticket_Status_ID)
-            .all()
+    async def tickets_by_status(self):
+        result = await self.db.execute(
+            select(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID)).group_by(
+                Ticket.Ticket_Status_ID
+            )
         )
-        return [(row[0], row[1]) for row in results]
+        return [(row[0], row[1]) for row in result.all()]
 
-    def open_tickets_by_site(self):
-        results = (
-            self.db.query(Ticket.Site_ID, func.count(Ticket.Ticket_ID))
+    async def open_tickets_by_site(self):
+        result = await self.db.execute(
+            select(Ticket.Site_ID, func.count(Ticket.Ticket_ID))
             .filter(Ticket.Ticket_Status_ID != 3)
             .group_by(Ticket.Site_ID)
-            .all()
         )
-        return [(row[0], row[1]) for row in results]
+        return [(row[0], row[1]) for row in result.all()]
 
-    def sla_breaches(self, sla_days: int = 2):
+    async def sla_breaches(self, sla_days: int = 2):
         from datetime import datetime, timedelta
 
         cutoff = datetime.utcnow() - timedelta(days=sla_days)
-        return (
-            self.db.query(func.count(Ticket.Ticket_ID))
+        result = await self.db.execute(
+            select(func.count(Ticket.Ticket_ID))
             .filter(Ticket.Created_Date < cutoff)
             .filter(Ticket.Ticket_Status_ID != 3)
-            .scalar()
         )
+        return result.scalar()
 
-    def open_tickets_by_user(self):
-        results = (
-            self.db.query(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID))
+    async def open_tickets_by_user(self):
+        result = await self.db.execute(
+            select(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID))
             .filter(Ticket.Ticket_Status_ID != 3)
             .group_by(Ticket.Assigned_Email)
-            .all()
         )
-        return [(row[0], row[1]) for row in results]
+        return [(row[0], row[1]) for row in result.all()]
 
-    def tickets_waiting_on_user(self):
-        results = (
-            self.db.query(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID))
+    async def tickets_waiting_on_user(self):
+        result = await self.db.execute(
+            select(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID))
             .filter(Ticket.Ticket_Status_ID == 4)
             .group_by(Ticket.Ticket_Contact_Email)
-            .all()
         )
-        return [(row[0], row[1]) for row in results]
+        return [(row[0], row[1]) for row in result.all()]

--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -1,6 +1,6 @@
 
-from sqlalchemy.orm import Session
-from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import func, select
 import logging
 
 from db.models import Ticket
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 
-def tickets_by_status(db: Session) -> list[tuple[int | None, int]]:
+async def tickets_by_status(db: AsyncSession) -> list[tuple[int | None, int]]:
 
     """
     Returns a list of tuples (status_id, count) for all tickets.
@@ -18,13 +18,16 @@ def tickets_by_status(db: Session) -> list[tuple[int | None, int]]:
 
 
     logger.info("Calculating tickets by status")
-    results = db.query(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID)) \
-                .group_by(Ticket.Ticket_Status_ID).all()
-    return [(row[0], row[1]) for row in results]
+    result = await db.execute(
+        select(Ticket.Ticket_Status_ID, func.count(Ticket.Ticket_ID)).group_by(
+            Ticket.Ticket_Status_ID
+        )
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
 
-def open_tickets_by_site(db: Session) -> list[tuple[int | None, int]]:
+async def open_tickets_by_site(db: AsyncSession) -> list[tuple[int | None, int]]:
 
     """
     Returns list of tuples (site_id, open_count) for tickets not closed (status != 3).
@@ -32,14 +35,16 @@ def open_tickets_by_site(db: Session) -> list[tuple[int | None, int]]:
 
 
     logger.info("Calculating open tickets by site")
-    results = db.query(Ticket.Site_ID, func.count(Ticket.Ticket_ID)) \
-                .filter(Ticket.Ticket_Status_ID != 3) \
-                .group_by(Ticket.Site_ID).all()
-    return [(row[0], row[1]) for row in results]
+    result = await db.execute(
+        select(Ticket.Site_ID, func.count(Ticket.Ticket_ID))
+        .filter(Ticket.Ticket_Status_ID != 3)
+        .group_by(Ticket.Site_ID)
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
 
-def sla_breaches(db: Session, sla_days: int = 2) -> int:
+async def sla_breaches(db: AsyncSession, sla_days: int = 2) -> int:
 
     """
     Count tickets older than sla_days and not closed.
@@ -57,7 +62,7 @@ def sla_breaches(db: Session, sla_days: int = 2) -> int:
 
 
 
-def open_tickets_by_user(db: Session) -> list[tuple[str | None, int]]:
+async def open_tickets_by_user(db: AsyncSession) -> list[tuple[str | None, int]]:
 
     """
     Returns list of tuples (assigned_email, open_count) for tickets not closed.
@@ -65,23 +70,27 @@ def open_tickets_by_user(db: Session) -> list[tuple[str | None, int]]:
 
 
     logger.info("Calculating open tickets by user")
-    results = db.query(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID)) \
-                .filter(Ticket.Ticket_Status_ID != 3) \
-                .group_by(Ticket.Assigned_Email).all()
-    return [(row[0], row[1]) for row in results]
+    result = await db.execute(
+        select(Ticket.Assigned_Email, func.count(Ticket.Ticket_ID))
+        .filter(Ticket.Ticket_Status_ID != 3)
+        .group_by(Ticket.Assigned_Email)
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
-def tickets_waiting_on_user(db: Session) -> list[tuple[str | None, int]]:
+async def tickets_waiting_on_user(db: AsyncSession) -> list[tuple[str | None, int]]:
 
     """
     Returns list of tuples (contact_email, waiting_count) for tickets awaiting contact reply (status == 4).
     """
 
     logger.info("Calculating tickets waiting on user")
-    results = db.query(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID)) \
-                .filter(Ticket.Ticket_Status_ID == 4) \
-                .group_by(Ticket.Ticket_Contact_Email).all()
-    return [(row[0], row[1]) for row in results]
+    result = await db.execute(
+        select(Ticket.Ticket_Contact_Email, func.count(Ticket.Ticket_ID))
+        .filter(Ticket.Ticket_Status_ID == 4)
+        .group_by(Ticket.Ticket_Contact_Email)
+    )
+    return [(row[0], row[1]) for row in result.all()]
 
 
 

--- a/tools/asset_tools.py
+++ b/tools/asset_tools.py
@@ -1,5 +1,6 @@
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 import logging
 
 from db.models import Asset
@@ -7,12 +8,12 @@ from db.models import Asset
 logger = logging.getLogger(__name__)
 
 
-def get_asset(db: Session, asset_id: int) -> Asset | None:
-    return db.query(Asset).filter(Asset.ID == asset_id).first()
+async def get_asset(db: AsyncSession, asset_id: int) -> Asset | None:
+    return await db.get(Asset, asset_id)
 
 
-def list_assets(db: Session, skip: int = 0, limit: int = 10) -> list[Asset]:
-
-    return db.query(Asset).offset(skip).limit(limit).all()
+async def list_assets(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Asset]:
+    result = await db.execute(select(Asset).offset(skip).limit(limit))
+    return result.scalars().all()
 
 

--- a/tools/attachment_tools.py
+++ b/tools/attachment_tools.py
@@ -1,5 +1,6 @@
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 import logging
 
 from db.models import TicketAttachment
@@ -7,7 +8,9 @@ from db.models import TicketAttachment
 logger = logging.getLogger(__name__)
 
 
-def get_ticket_attachments(db: Session, ticket_id: int) -> list[TicketAttachment]:
-
-    return db.query(TicketAttachment).filter(TicketAttachment.Ticket_ID == ticket_id).all()
+async def get_ticket_attachments(db: AsyncSession, ticket_id: int) -> list[TicketAttachment]:
+    result = await db.execute(
+        select(TicketAttachment).filter(TicketAttachment.Ticket_ID == ticket_id)
+    )
+    return result.scalars().all()
 

--- a/tools/category_tools.py
+++ b/tools/category_tools.py
@@ -1,5 +1,6 @@
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 import logging
 
 from db.models import TicketCategory
@@ -7,7 +8,7 @@ from db.models import TicketCategory
 logger = logging.getLogger(__name__)
 
 
-def list_categories(db: Session) -> list[TicketCategory]:
-
-    return db.query(TicketCategory).all()
+async def list_categories(db: AsyncSession) -> list[TicketCategory]:
+    result = await db.execute(select(TicketCategory))
+    return result.scalars().all()
 

--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -1,7 +1,6 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
 from errors import DatabaseError
 from db.models import TicketMessage
 from datetime import datetime
@@ -11,19 +10,17 @@ logger = logging.getLogger(__name__)
 
 
 
-def get_ticket_messages(db: Session, ticket_id: int) -> list[TicketMessage]:
-
-    return (
-        db.query(TicketMessage)
-
+async def get_ticket_messages(db: AsyncSession, ticket_id: int) -> list[TicketMessage]:
+    result = await db.execute(
+        select(TicketMessage)
         .filter(TicketMessage.Ticket_ID == ticket_id)
         .order_by(TicketMessage.DateTimeStamp)
     )
     return result.scalars().all()
 
 
-def post_ticket_message(
-    db: Session, ticket_id: int, message: str, sender_code: str, sender_name: str
+async def post_ticket_message(
+    db: AsyncSession, ticket_id: int, message: str, sender_code: str, sender_name: str
 ) -> TicketMessage:
 
     msg = TicketMessage(
@@ -36,14 +33,12 @@ def post_ticket_message(
 
     db.add(msg)
     try:
-
-        db.commit()
-        db.refresh(msg)
+        await db.commit()
+        await db.refresh(msg)
         logger.info("Posted message to ticket %s", ticket_id)
 
     except SQLAlchemyError as e:
-
-        db.rollback()
+        await db.rollback()
 
         logger.exception("Failed to save ticket message for %s", ticket_id)
         raise HTTPException(status_code=500, detail=f"Failed to save message: {e}")

--- a/tools/site_tools.py
+++ b/tools/site_tools.py
@@ -1,5 +1,6 @@
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 import logging
 
 from db.models import Site
@@ -8,12 +9,12 @@ logger = logging.getLogger(__name__)
 
 
 
-def get_site(db: Session, site_id: int) -> Site | None:
-    return db.query(Site).filter(Site.ID == site_id).first()
+async def get_site(db: AsyncSession, site_id: int) -> Site | None:
+    return await db.get(Site, site_id)
 
 
-def list_sites(db: Session, skip: int = 0, limit: int = 10) -> list[Site]:
-
-    return db.query(Site).offset(skip).limit(limit).all()
+async def list_sites(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Site]:
+    result = await db.execute(select(Site).offset(skip).limit(limit))
+    return result.scalars().all()
 
 

--- a/tools/status_tools.py
+++ b/tools/status_tools.py
@@ -1,5 +1,6 @@
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 import logging
 
 from db.models import TicketStatus
@@ -7,9 +8,8 @@ from db.models import TicketStatus
 logger = logging.getLogger(__name__)
 
 
-def list_statuses(db: Session) -> list[TicketStatus]:
-
-
-    return db.query(TicketStatus).all()
+async def list_statuses(db: AsyncSession) -> list[TicketStatus]:
+    result = await db.execute(select(TicketStatus))
+    return result.scalars().all()
 
 

--- a/tools/vendor_tools.py
+++ b/tools/vendor_tools.py
@@ -1,5 +1,6 @@
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 import logging
 
 from db.models import Vendor
@@ -8,11 +9,11 @@ logger = logging.getLogger(__name__)
 
 
 
-def get_vendor(db: Session, vendor_id: int) -> Vendor | None:
-    return db.query(Vendor).filter(Vendor.ID == vendor_id).first()
+async def get_vendor(db: AsyncSession, vendor_id: int) -> Vendor | None:
+    return await db.get(Vendor, vendor_id)
 
 
-def list_vendors(db: Session, skip: int = 0, limit: int = 10) -> list[Vendor]:
-
-    return db.query(Vendor).offset(skip).limit(limit).all()
+async def list_vendors(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Vendor]:
+    result = await db.execute(select(Vendor).offset(skip).limit(limit))
+    return result.scalars().all()
 


### PR DESCRIPTION
## Summary
- refactor services to async/await with `AsyncSession`
- update analysis tools and CRUD helpers to async
- adjust API routes to await updated tools

## Testing
- `flake8`
- `pytest -q` *(fails: NameError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68659e85d940832ba43c31a2244ee8a4