### PR TITLE
Clean up health check imports and variables

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
 from api.routes import router, get_db
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from limiter import limiter
 
@@ -23,9 +22,6 @@ APP_VERSION = "0.1.0"
 # Record startup time to report uptime
 START_TIME = datetime.utcnow()
 from errors import ErrorResponse, NotFoundError, ValidationError, DatabaseError
-
-VERSION = "0.1.0"
-start_time = datetime.utcnow()
 
 
 app = FastAPI(title="Truck Stop MCP Helpdesk API")


### PR DESCRIPTION
## Summary
- remove a duplicate `text` import
- drop unused `VERSION` and `start_time`
- rely only on `APP_VERSION` and `START_TIME` in the health check

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'chat')*

------
https://chatgpt.com/codex/tasks/task_e_6865a2f9dc4c832b999b8aa8ceaa5915