### PR TITLE
Expose OpenAI client setter for tests

### DIFF
--- a/ai/openai_agent.py
+++ b/ai/openai_agent.py
@@ -14,6 +14,12 @@ logger = logging.getLogger(__name__)
 openai_client: openai.Client | None = None
 
 
+def set_client(client: openai.Client | None) -> None:
+    """Override the cached OpenAI client used by this module."""
+    global openai_client
+    openai_client = client
+
+
 def _get_client() -> openai.Client:
     """Return a reusable OpenAI client instance."""
     global openai_client

--- a/tests/test_openai_agent.py
+++ b/tests/test_openai_agent.py
@@ -3,7 +3,8 @@ from ai import openai_agent
 
 
 def test_suggest_ticket_response_requires_key(monkeypatch):
-    monkeypatch.setattr(openai_agent, "openai_client", None)
+    monkeypatch.setattr(openai_agent, "OPENAI_API_KEY", None)
+    openai_agent.set_client(None)
     with pytest.raises(RuntimeError):
         openai_agent.suggest_ticket_response({"Subject": "Test", "Ticket_Body": "body"})
 


### PR DESCRIPTION
## Summary
- allow overriding the cached OpenAI client via `set_client`
- adjust tests to use the helper instead of patching globals

## Testing
- `pytest tests/test_openai_agent.py::test_suggest_ticket_response_requires_key -q`
- `pytest tests/test_analytics.py::test_ai_suggest_response -q`
- `pytest tests/test_rate_limit.py::test_ai_suggest_response_rate_limit -q` *(fails: assert 200 == 429)*
- `pytest -q` *(fails: 6 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6865a2fe7c94832bba5d5ae7d3d0acd7