### PR TITLE
Use config settings for OpenAI client

### DIFF
--- a/ai/openai_agent.py
+++ b/ai/openai_agent.py
@@ -4,9 +4,7 @@ import logging
 import openai
 
 from openai import APITimeoutError, OpenAIError
-from config import OPENAI_API_KEY
-
-OPENAI_TIMEOUT = 15  # seconds
+from config import OPENAI_API_KEY, OPENAI_MODEL_NAME, OPENAI_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +45,7 @@ def suggest_ticket_response(ticket: Dict[str, Any], context: str = "") -> str:
 
     try:
         response = client.chat.completions.create(
-            model="gpt-4o",
+            model=OPENAI_MODEL_NAME,
             messages=[{"role": "system", "content": prompt}],
         )
         return response.choices[0].message.content

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -110,6 +110,15 @@ async def test_ai_suggest_response(client: AsyncClient, monkeypatch):
                         message = Msg()
 
 
+    def fake_create(*_, **__):
+        class Msg:
+            content = "ok"
+
+        class Choice:
+            message = Msg()
+
+        return type("Resp", (), {"choices": [Choice()]})()
+
     from ai import openai_agent
     openai_agent._get_client()
     monkeypatch.setattr(openai_agent.openai_client.chat.completions, "create", fake_create)


### PR DESCRIPTION
## Summary
- reuse OPENAI_MODEL_NAME and OPENAI_TIMEOUT from `config.py`
- update OpenAI client initialization and chat completion usage
- fix analytics test helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b72eaf2c832b9989ac327d0eb0d6