### PR TITLE
Remove unused helpers and duplicate imports

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -17,7 +17,6 @@ from tools.ticket_tools import (
     update_ticket,
     delete_ticket,
     search_tickets,
-    _escape_wildcards,
 )
 
 
@@ -36,14 +35,6 @@ from tools.analysis_tools import (
     tickets_waiting_on_user,
 )
 from tools.ai_tools import ai_suggest_response
-from tools.analysis_tools import (
-    tickets_by_status,
-    open_tickets_by_site,
-    sla_breaches,
-    open_tickets_by_user,
-    tickets_waiting_on_user,
-)
-from services.ticket_service import TicketService
 from services.analytics_service import AnalyticsService
 from limiter import limiter
 
@@ -86,10 +77,6 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         finally:
             await db.close()
 
-
-
-def get_ticket_service(db: AsyncSession = Depends(get_db)) -> TicketService:
-    return TicketService(db)
 
 
 def get_analytics_service(db: AsyncSession = Depends(get_db)) -> AnalyticsService:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -109,9 +109,12 @@ async def test_ai_suggest_response(client: AsyncClient, monkeypatch):
                     class Choice:
                         message = Msg()
 
+                    return type("Resp", (), {"choices": [Choice()]})()
+
 
     from ai import openai_agent
     openai_agent._get_client()
+    fake_create = DummyClient.Chat.Completions.create
     monkeypatch.setattr(openai_agent.openai_client.chat.completions, "create", fake_create)
 
 

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -17,11 +17,6 @@ from db.models import Ticket
 logger = logging.getLogger(__name__)
 
 
-def _escape_wildcards(text: str) -> str:
-    """Escape SQL wildcard characters for LIKE queries."""
-    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
-
 async def get_ticket(db: AsyncSession, ticket_id: int) -> Ticket | None:
     return await db.get(Ticket, ticket_id)
 

--- a/tools/user_tools.py
+++ b/tools/user_tools.py
@@ -26,9 +26,6 @@ network access.
 
 from typing import Dict, List
 
-import os
-import requests
-
 import logging
 import os
 import requests


### PR DESCRIPTION
## Summary
- drop duplicate `os` and `requests` imports
- remove repeated `analysis_tools` import block
- delete unused `get_ticket_service` and `_escape_wildcards`
- patch analytics test stub to return a fake response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b72d4c4c832b9b20130d676e044e