### PR TITLE
Use timezone aware datetime

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -65,7 +65,7 @@ from db.models import (
 )
 
 
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 
@@ -147,7 +147,7 @@ async def api_search_tickets(
 
 @router.post("/ticket", response_model=TicketOut)
 async def api_create_ticket(ticket: TicketCreate, db: AsyncSession = Depends(get_db)) -> Ticket:
-    obj = Ticket(**ticket.dict(), Created_Date=datetime.utcnow())
+    obj = Ticket(**ticket.dict(), Created_Date=datetime.now(UTC))
     logger.info("API create ticket")
     created = await create_ticket(db, obj)
     return created

--- a/main.py
+++ b/main.py
@@ -14,13 +14,13 @@ from api.routes import router, get_db
 from sqlalchemy.ext.asyncio import AsyncSession
 from limiter import limiter
 
-from datetime import datetime
+from datetime import datetime, UTC
 
 # Application version
 APP_VERSION = "0.1.0"
 
 # Record startup time to report uptime
-START_TIME = datetime.utcnow()
+START_TIME = datetime.now(UTC)
 from errors import ErrorResponse, NotFoundError, ValidationError, DatabaseError
 
 
@@ -41,7 +41,7 @@ async def handle_not_found(request: Request, exc: NotFoundError):
         error_code=exc.error_code,
         message=exc.message,
         details=exc.details,
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(UTC),
     )
     return JSONResponse(status_code=404, content=jsonable_encoder(resp))
 
@@ -52,7 +52,7 @@ async def handle_validation(request: Request, exc: ValidationError):
         error_code=exc.error_code,
         message=exc.message,
         details=exc.details,
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(UTC),
     )
     return JSONResponse(status_code=400, content=jsonable_encoder(resp))
 
@@ -63,7 +63,7 @@ async def handle_database(request: Request, exc: DatabaseError):
         error_code=exc.error_code,
         message=exc.message,
         details=exc.details,
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(UTC),
     )
     return JSONResponse(status_code=500, content=jsonable_encoder(resp))
 
@@ -78,7 +78,7 @@ async def health(db: AsyncSession = Depends(get_db)) -> dict:
     except Exception:
         db_status = "error"
 
-    uptime = (datetime.utcnow() - START_TIME).total_seconds()
+    uptime = (datetime.now(UTC) - START_TIME).total_seconds()
     return {"db": db_status, "uptime": uptime, "version": APP_VERSION}
 
 

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -26,9 +26,9 @@ class AnalyticsService:
         return [(row[0], row[1]) for row in result.all()]
 
     async def sla_breaches(self, sla_days: int = 2):
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, UTC
 
-        cutoff = datetime.utcnow() - timedelta(days=sla_days)
+        cutoff = datetime.now(UTC) - timedelta(days=sla_days)
         result = await self.db.execute(
             select(func.count(Ticket.Ticket_ID))
             .filter(Ticket.Created_Date < cutoff)

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 import pytest
 from httpx import AsyncClient
@@ -31,7 +31,7 @@ async def _add_ticket(**kwargs):
             Ticket_Status_ID=kwargs.get("Ticket_Status_ID", 1),
             Site_ID=kwargs.get("Site_ID"),
             Assigned_Email=kwargs.get("Assigned_Email"),
-            Created_Date=kwargs.get("Created_Date", datetime.utcnow()),
+            Created_Date=kwargs.get("Created_Date", datetime.now(UTC)),
         )
 
         await create_ticket(db, ticket)
@@ -63,7 +63,7 @@ async def test_analytics_open_by_site(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_analytics_sla_breaches(client: AsyncClient):
-    old = datetime.utcnow() - timedelta(days=3)
+    old = datetime.now(UTC) - timedelta(days=3)
     await _add_ticket(Created_Date=old)
     await _add_ticket()
     resp = await client.get("/analytics/sla_breaches", params={"sla_days": 2})

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 from db.models import Ticket
 from db.mssql import SessionLocal
 from tools.ticket_tools import create_ticket
@@ -14,7 +14,7 @@ async def _add_sample_ticket():
             Ticket_Body="Conn",
             Ticket_Contact_Name="T",
             Ticket_Contact_Email="t@example.com",
-            Created_Date=datetime.utcnow(),
+            Created_Date=datetime.now(UTC),
             Ticket_Status_ID=1,
         )
         await create_ticket(session, t)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,7 +4,7 @@ import pytest
 from db.models import Base, Ticket
 from db.mssql import engine, SessionLocal
 from services.ticket_service import TicketService
-from datetime import datetime
+from datetime import datetime, UTC
 from tools.ticket_tools import create_ticket, search_tickets
 
 os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")
@@ -23,7 +23,7 @@ async def test_search_tickets():
         t = Ticket(
             Subject="Network issue",
             Ticket_Body="Cannot connect",
-            Created_Date=datetime.utcnow(),
+            Created_Date=datetime.now(UTC),
         )
 
         await create_ticket(db, t)

--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -50,10 +50,10 @@ async def sla_breaches(db: AsyncSession, sla_days: int = 2) -> int:
     """
     Count tickets older than sla_days and not closed.
     """
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, UTC
 
     logger.info("Counting SLA breaches older than %s days", sla_days)
-    cutoff = datetime.utcnow() - timedelta(days=sla_days)
+    cutoff = datetime.now(UTC) - timedelta(days=sla_days)
     result = await db.execute(
         select(func.count(Ticket.Ticket_ID))
         .filter(Ticket.Created_Date < cutoff)

--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from fastapi import HTTPException
 
 from db.models import TicketMessage
-from datetime import datetime
+from datetime import datetime, UTC
 import logging
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ async def post_ticket_message(
         Message=message,
         SenderUserCode=sender_code,
         SenderUserName=sender_name,
-        DateTimeStamp=datetime.utcnow(),
+        DateTimeStamp=datetime.now(UTC),
     )
 
     db.add(msg)


### PR DESCRIPTION
## Summary
- ensure timezone awareness by switching to `datetime.now(UTC)`
- update API and tools for UTC time
- adjust unit tests for new imports

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: NameError in test_ai_suggest_response)*

------
https://chatgpt.com/codex/tasks/task_e_6865b72d903c832ba1456451670da87a