### PR TITLE
Enforce async MSSQL driver

### DIFF
--- a/db/mssql.py
+++ b/db/mssql.py
@@ -1,8 +1,12 @@
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from config import DB_CONN_STRING
+import logging
 
 engine_args = {}
 if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):
+    if DB_CONN_STRING.startswith("mssql+pyodbc"):
+        logging.error("Synchronous driver detected in DB_CONN_STRING: %s", DB_CONN_STRING)
+        raise RuntimeError("Use an async SQLAlchemy driver such as 'mssql+aioodbc'.")
     engine_args["fast_executemany"] = True
 
 

--- a/tests/test_db_conn.py
+++ b/tests/test_db_conn.py
@@ -1,0 +1,13 @@
+import importlib
+import os
+import pytest
+
+import db.mssql as mssql
+
+
+def test_pyodbc_conn_string_not_allowed(monkeypatch):
+    conn = "mssql+pyodbc://user:pass@localhost/db"
+    monkeypatch.setenv("DB_CONN_STRING", conn)
+    monkeypatch.setattr("config.DB_CONN_STRING", conn, raising=False)
+    with pytest.raises(RuntimeError):
+        importlib.reload(mssql)


### PR DESCRIPTION
## Summary
- fail fast if `mssql+pyodbc` driver is configured
- add regression test for the invalid connection string

## Testing
- `pytest -q tests/test_db_conn.py`

------
https://chatgpt.com/codex/tasks/task_e_6865bdc07e30832b9556e6c940d8c120