### PR TITLE
Fix analytics test to use shared fake create

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -122,21 +122,8 @@ async def test_ai_suggest_response(client: AsyncClient, monkeypatch):
 
                     return type("Resp", (), {"choices": [Choice()]})()
 
-<
-
-    def fake_create(*_, **__):
-        class Msg:
-            content = "ok"
-
-        class Choice:
-            message = Msg()
-
-        return type("Resp", (), {"choices": [Choice()]})()
-
-
     from ai import openai_agent
     openai_agent._get_client()
-    fake_create = DummyClient.Chat.Completions.create
     monkeypatch.setattr(openai_agent.openai_client.chat.completions, "create", fake_create)
 
 


### PR DESCRIPTION
## Summary
- fix `tests/test_analytics.py` by removing stray line
- remove redundant inner `fake_create`
- patch OpenAI calls with module level helper

## Testing
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bdc2d3f0832b811f7ae40c82b879