### PR TITLE
Add aioodbc dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
    pip install -r requirements.txt
    ```
 
+   The requirements include `aioodbc` for async ODBC connections; `pyodbc` is no longer required.
 2. **Environment variables**
 
    The application requires the following variables:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ fastapi==0.110.0
 uvicorn==0.35.0
 sqlalchemy==2.0.41
 pydantic==1.10.15
-pyodbc==5.2.0
 python-dotenv==1.1.1
 openai==1.93.0
 pytest==8.4.1
@@ -12,5 +11,5 @@ httpx<0.28
 mypy==1.16.1
 slowapi==0.1.9
 aiosqlite==0.21.0
-
 requests==2.32.3
+aioodbc==0.5.0


### PR DESCRIPTION
## Summary
- add `aioodbc` to requirements and remove `pyodbc`
- mention async driver requirement in setup instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c177b4fc832b86cfc10da60d0b4e