### PR TITLE
Add aioodbc pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ mypy==1.16.1
 slowapi==0.1.9
 aiosqlite==0.21.0
 requests==2.32.3
-aioodbc==0.5.0
+aioodbc>=0.6


### PR DESCRIPTION
## Summary
- pin aioodbc dependency with a minimum version

## Testing
- `python3 -m venv /tmp/testenv`
- `/tmp/testenv/bin/pip install -r requirements.txt` *(fails: no matching distribution for aioodbc>=0.6)*

------
https://chatgpt.com/codex/tasks/task_e_6865d13e5c08832bbe228ca60e9b3bef