### PR TITLE
Add env template file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DB_CONN_STRING=mssql+aioodbc://USER:PASS@HOST/DB?driver=ODBC+Driver+18+for+SQL+Server
+OPENAI_API_KEY=your-key
+CONFIG_ENV=dev

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
    - `OPENAI_API_KEY` – API key used by the OpenAI integration.
    - `CONFIG_ENV` – which config to load: `dev`, `staging`, or `prod` (default `dev`).
 
-   They can be provided in the shell environment or in a `.env` file in the project root.
-   `config.py` automatically loads `.env` and then imports `config_{CONFIG_ENV}.py`
-   so the appropriate settings are applied at startup. OpenAI model parameters
-   such as model name and timeouts are defined in the selected config file.
+  They can be provided in the shell environment or in a `.env` file in the project root.
+  A template called `.env.example` lists the required variables; copy it to `.env` and
+  update the values for your environment. `config.py` automatically loads `.env` and
+  then imports `config_{CONFIG_ENV}.py` so the appropriate settings are applied at
+  startup. OpenAI model parameters such as model name and timeouts are defined in the
+  selected config file.
 
 ## Running the API
 


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for required environment variables
- document new env template usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d4a40cdc832b9bc98ba40166d51b