### PR TITLE
Remove unused import

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
 from sqlalchemy import text
-from db.mssql import SessionLocal
 
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware


### PR DESCRIPTION
## Summary
- clean up `main.py` by removing `SessionLocal` import

## Testing
- `flake8 main.py`
- `mypy .` *(fails: Library stubs not installed for "requests")*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6865da69eeb0832b871eb96146bf9734