### PR TITLE
Add expanded ticket view endpoint

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -81,3 +81,29 @@ class TicketStatus(Base):
     __tablename__ = "Ticket_Status"
     ID = Column(Integer, primary_key=True, index=True)
     Label = Column(String)
+
+
+class VTicketMasterExpanded(Base):
+    """Mapped view providing ticket details with related labels."""
+
+    __tablename__ = "V_Ticket_Master_Expanded"
+    __table_args__ = {"extend_existing": True}
+
+    Ticket_ID = Column(Integer, primary_key=True, index=True)
+    Subject = Column(String)
+    Ticket_Body = Column(Text)
+    Ticket_Status_ID = Column(Integer)
+    Ticket_Contact_Name = Column(String)
+    Ticket_Contact_Email = Column(String)
+    Asset_ID = Column(Integer)
+    Site_ID = Column(Integer)
+    Ticket_Category_ID = Column(Integer)
+    Created_Date = Column(DateTime)
+    Assigned_Name = Column(String)
+    Assigned_Email = Column(String)
+    Severity_ID = Column(Integer)
+    Assigned_Vendor_ID = Column(Integer)
+    Resolution = Column(Text)
+    Status_Label = Column(String)
+    Category_Label = Column(String)
+    Site_Label = Column(String)

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -107,3 +107,14 @@ class TicketOut(TicketIn):
                 "Created_Date": "2024-01-01T12:00:00Z",
             }
         }
+
+
+class TicketExpandedOut(TicketOut):
+    """Schema for the VTicketMasterExpanded view."""
+
+    Status_Label: Optional[str] = None
+    Category_Label: Optional[str] = None
+    Site_Label: Optional[str] = None
+
+    class Config:
+        orm_mode = True

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -1,0 +1,66 @@
+import pytest
+from httpx import AsyncClient
+import pytest_asyncio
+from main import app
+from db.mssql import engine
+
+CREATE_VIEW_SQL = """
+CREATE VIEW IF NOT EXISTS V_Ticket_Master_Expanded AS
+SELECT tm.*, ts.Label AS Status_Label, tc.Label AS Category_Label, s.Label AS Site_Label
+FROM Tickets_Master tm
+LEFT JOIN Ticket_Status ts ON tm.Ticket_Status_ID = ts.ID
+LEFT JOIN Ticket_Categories tc ON tm.Ticket_Category_ID = tc.ID
+LEFT JOIN Sites s ON tm.Site_ID = s.ID
+"""
+
+DROP_VIEW_SQL = "DROP VIEW IF EXISTS V_Ticket_Master_Expanded"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def expanded_view(db_setup):
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql("DROP TABLE IF EXISTS V_Ticket_Master_Expanded")
+        await conn.exec_driver_sql(DROP_VIEW_SQL)
+        await conn.exec_driver_sql(CREATE_VIEW_SQL)
+    yield
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(DROP_VIEW_SQL)
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_tickets_expanded_endpoint(client: AsyncClient):
+    payload = {
+        "Subject": "Exp",
+        "Ticket_Body": "Body",
+        "Ticket_Contact_Name": "T",
+        "Ticket_Contact_Email": "t@example.com",
+    }
+    created = await client.post("/ticket", json=payload)
+    assert created.status_code == 200
+    tid = created.json()["Ticket_ID"]
+
+    resp = await client.get("/tickets/expanded")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    item = data["items"][0]
+    assert item["Ticket_ID"] == tid
+    assert "Status_Label" in item
+    assert "Category_Label" in item
+    assert "Site_Label" in item
+
+
+from schemas.ticket import TicketExpandedOut
+
+
+def test_ticket_expanded_schema():
+    data = {"Ticket_ID": 1, "Subject": "s", "Status_Label": "Open"}
+    obj = TicketExpandedOut(**data)
+    assert obj.Ticket_ID == 1
+    assert obj.Status_Label == "Open"


### PR DESCRIPTION
## Summary
- add `VTicketMasterExpanded` SQLAlchemy model for view
- extend ticket schemas with `TicketExpandedOut`
- implement `list_tickets_expanded` query
- expose `/tickets/expanded` API route
- test schema and new endpoint

## Testing
- `pytest -q` *(fails: 13 failed, 18 passed, 44 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6865da672df0832bbfa0aa10155c38dc