### PR TITLE
Use expanded ticket view

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -42,7 +42,7 @@ from limiter import limiter
 from pydantic import BaseModel
 from sqlalchemy import select, func
 
-from schemas.ticket import TicketCreate, TicketOut, TicketUpdate
+from schemas.ticket import TicketCreate, TicketOut, TicketUpdate, TicketExpandedOut
 from schemas.paginated import PaginatedResponse
 from db.models import (
     Asset,
@@ -98,8 +98,8 @@ class MessageIn(BaseModel):
         }
 
 
-@router.get("/ticket/{ticket_id}", response_model=TicketOut)
-async def api_get_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> Ticket:
+@router.get("/ticket/{ticket_id}", response_model=TicketExpandedOut)
+async def api_get_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> TicketExpandedOut:
     ticket = await get_ticket(db, ticket_id)
     if not ticket:
         logger.warning("Ticket %s not found", ticket_id)
@@ -109,28 +109,28 @@ async def api_get_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> 
 
 
 
-@router.get("/tickets", response_model=PaginatedResponse[TicketOut])
+@router.get("/tickets", response_model=PaginatedResponse[TicketExpandedOut])
 async def api_list_tickets(
     skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
-) -> PaginatedResponse[TicketOut]:
+) -> PaginatedResponse[TicketExpandedOut]:
     items = await list_tickets(db, skip, limit)
     total = await db.scalar(select(func.count(Ticket.Ticket_ID))) or 0
-    ticket_out = [TicketOut.from_orm(t) for t in items]
-    return PaginatedResponse[TicketOut](items=ticket_out, total=total, skip=skip, limit=limit)
+    ticket_out = [TicketExpandedOut.from_orm(t) for t in items]
+    return PaginatedResponse[TicketExpandedOut](items=ticket_out, total=total, skip=skip, limit=limit)
 
 
 
 
 
-@router.get("/tickets/search", response_model=List[TicketOut])
+@router.get("/tickets/search", response_model=List[TicketExpandedOut])
 
 async def api_search_tickets(
     q: str, limit: int = 10, db: AsyncSession = Depends(get_db)
 
-) -> list[Ticket]:
+) -> list[TicketExpandedOut]:
     logger.info("API search tickets query=%s limit=%s", q, limit)
     results = await search_tickets(db, q, limit)
-    return list(results)
+    return [TicketExpandedOut.from_orm(r) for r in results]
 
 
 

--- a/db/models.py
+++ b/db/models.py
@@ -81,3 +81,35 @@ class TicketStatus(Base):
     __tablename__ = "Ticket_Status"
     ID = Column(Integer, primary_key=True, index=True)
     Label = Column(String)
+
+
+class ViewBase(DeclarativeBase):
+    """Declarative base for database views."""
+    pass
+
+
+class VTicketMasterExpanded(ViewBase):
+    """Mapped class for the V_Ticket_Master_Expanded view."""
+
+    __tablename__ = "V_Ticket_Master_Expanded"
+
+    Ticket_ID = Column(Integer, primary_key=True, index=True)
+    Subject = Column(String)
+    Ticket_Body = Column(Text)
+    Ticket_Status_ID = Column(Integer)
+    Ticket_Status_Label = Column(String)
+    Ticket_Contact_Name = Column(String)
+    Ticket_Contact_Email = Column(String)
+    Asset_ID = Column(Integer)
+    Asset_Label = Column(String)
+    Site_ID = Column(Integer)
+    Site_Label = Column(String)
+    Ticket_Category_ID = Column(Integer)
+    Ticket_Category_Label = Column(String)
+    Created_Date = Column(DateTime)
+    Assigned_Name = Column(String)
+    Assigned_Email = Column(String)
+    Severity_ID = Column(Integer)
+    Assigned_Vendor_ID = Column(Integer)
+    Assigned_Vendor_Name = Column(String)
+    Resolution = Column(Text)

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -107,3 +107,16 @@ class TicketOut(TicketIn):
                 "Created_Date": "2024-01-01T12:00:00Z",
             }
         }
+
+
+class TicketExpandedOut(TicketOut):
+    """Ticket output schema that includes related labels."""
+
+    Ticket_Status_Label: Optional[str] = None
+    Site_Label: Optional[str] = None
+    Asset_Label: Optional[str] = None
+    Ticket_Category_Label: Optional[str] = None
+    Assigned_Vendor_Name: Optional[str] = None
+
+    class Config:
+        orm_mode = True

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -2,7 +2,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from fastapi import HTTPException
-from db.models import Ticket
+from db.models import Ticket, VTicketMasterExpanded
 
 
 class TicketService:
@@ -11,11 +11,11 @@ class TicketService:
     def __init__(self, db: AsyncSession):
         self.db = db
 
-    async def get_ticket(self, ticket_id: int) -> Ticket | None:
-        return await self.db.get(Ticket, ticket_id)
+    async def get_ticket(self, ticket_id: int) -> VTicketMasterExpanded | None:
+        return await self.db.get(VTicketMasterExpanded, ticket_id)
 
-    async def list_tickets(self, skip: int = 0, limit: int = 10) -> list[Ticket]:
-        result = await self.db.execute(select(Ticket).offset(skip).limit(limit))
+    async def list_tickets(self, skip: int = 0, limit: int = 10) -> list[VTicketMasterExpanded]:
+        result = await self.db.execute(select(VTicketMasterExpanded).offset(skip).limit(limit))
         return list(result.scalars().all())
 
     async def create_ticket(self, ticket_obj: Ticket) -> Ticket:
@@ -55,11 +55,14 @@ class TicketService:
             await self.db.rollback()
             raise
 
-    async def search_tickets(self, query: str, limit: int = 10) -> list[Ticket]:
+    async def search_tickets(self, query: str, limit: int = 10) -> list[VTicketMasterExpanded]:
         like = f"%{query}%"
         result = await self.db.execute(
-            select(Ticket)
-            .filter((Ticket.Subject.ilike(like)) | (Ticket.Ticket_Body.ilike(like)))
+            select(VTicketMasterExpanded)
+            .filter(
+                (VTicketMasterExpanded.Subject.ilike(like))
+                | (VTicketMasterExpanded.Ticket_Body.ilike(like))
+            )
             .limit(limit)
         )
         return list(result.scalars().all())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import db.mssql as mssql
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.pool import StaticPool
 from db.models import Base
+from sqlalchemy import text
 import pytest
 import pytest_asyncio
 
@@ -24,6 +25,38 @@ mssql.SessionLocal = async_sessionmaker(bind=mssql.engine, expire_on_commit=Fals
 async def _init_models():
     async with mssql.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(text("DROP VIEW IF EXISTS V_Ticket_Master_Expanded"))
+        await conn.execute(text(
+            """
+            CREATE VIEW V_Ticket_Master_Expanded AS
+            SELECT t.Ticket_ID,
+                   t.Subject,
+                   t.Ticket_Body,
+                   t.Ticket_Status_ID,
+                   ts.Label AS Ticket_Status_Label,
+                   t.Ticket_Contact_Name,
+                   t.Ticket_Contact_Email,
+                   t.Asset_ID,
+                   a.Label AS Asset_Label,
+                   t.Site_ID,
+                   s.Label AS Site_Label,
+                   t.Ticket_Category_ID,
+                   c.Label AS Ticket_Category_Label,
+                   t.Created_Date,
+                   t.Assigned_Name,
+                   t.Assigned_Email,
+                   t.Severity_ID,
+                   t.Assigned_Vendor_ID,
+                   v.Name AS Assigned_Vendor_Name,
+                   t.Resolution
+            FROM Tickets_Master t
+            LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
+            LEFT JOIN Assets a ON a.ID = t.Asset_ID
+            LEFT JOIN Sites s ON s.ID = t.Site_ID
+            LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
+            LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID
+            """
+        ))
 
 import asyncio
 asyncio.get_event_loop().run_until_complete(_init_models())
@@ -32,8 +65,41 @@ asyncio.get_event_loop().run_until_complete(_init_models())
 @pytest_asyncio.fixture(autouse=True)
 async def db_setup():
     async with mssql.engine.begin() as conn:
+        await conn.execute(text("DROP VIEW IF EXISTS V_Ticket_Master_Expanded"))
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(text(
+            """
+            CREATE VIEW V_Ticket_Master_Expanded AS
+            SELECT t.Ticket_ID,
+                   t.Subject,
+                   t.Ticket_Body,
+                   t.Ticket_Status_ID,
+                   ts.Label AS Ticket_Status_Label,
+                   t.Ticket_Contact_Name,
+                   t.Ticket_Contact_Email,
+                   t.Asset_ID,
+                   a.Label AS Asset_Label,
+                   t.Site_ID,
+                   s.Label AS Site_Label,
+                   t.Ticket_Category_ID,
+                   c.Label AS Ticket_Category_Label,
+                   t.Created_Date,
+                   t.Assigned_Name,
+                   t.Assigned_Email,
+                   t.Severity_ID,
+                   t.Assigned_Vendor_ID,
+                   v.Name AS Assigned_Vendor_Name,
+                   t.Resolution
+            FROM Tickets_Master t
+            LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
+            LEFT JOIN Assets a ON a.ID = t.Asset_ID
+            LEFT JOIN Sites s ON s.ID = t.Site_ID
+            LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
+            LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID
+            """
+        ))
     yield
     async with mssql.engine.begin() as conn:
+        await conn.execute(text("DROP VIEW IF EXISTS V_Ticket_Master_Expanded"))
         await conn.run_sync(Base.metadata.drop_all)

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -11,19 +11,19 @@ from pydantic import BaseModel
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.models import Ticket
+from db.models import Ticket, VTicketMasterExpanded
 
 
 logger = logging.getLogger(__name__)
 
 
-async def get_ticket(db: AsyncSession, ticket_id: int) -> Ticket | None:
-    return await db.get(Ticket, ticket_id)
+async def get_ticket(db: AsyncSession, ticket_id: int) -> VTicketMasterExpanded | None:
+    return await db.get(VTicketMasterExpanded, ticket_id)
 
 
-async def list_tickets(db: AsyncSession, skip: int = 0, limit: int = 10) -> Sequence[Ticket]:
+async def list_tickets(db: AsyncSession, skip: int = 0, limit: int = 10) -> Sequence[VTicketMasterExpanded]:
     result = await db.execute(
-        select(Ticket).offset(skip).limit(limit)
+        select(VTicketMasterExpanded).offset(skip).limit(limit)
     )
     return result.scalars().all()
 
@@ -79,12 +79,12 @@ async def delete_ticket(db: AsyncSession, ticket_id: int) -> bool:
         raise
 
 
-async def search_tickets(db: AsyncSession, query: str, limit: int = 10) -> Sequence[Ticket]:
+async def search_tickets(db: AsyncSession, query: str, limit: int = 10) -> Sequence[VTicketMasterExpanded]:
     like = f"%{query}%"
     logger.info("Searching tickets for '%s'", query)
     result = await db.execute(
-        select(Ticket).filter(
-            (Ticket.Subject.ilike(like)) | (Ticket.Ticket_Body.ilike(like))
+        select(VTicketMasterExpanded).filter(
+            (VTicketMasterExpanded.Subject.ilike(like)) | (VTicketMasterExpanded.Ticket_Body.ilike(like))
         ).limit(limit)
     )
     return result.scalars().all()


### PR DESCRIPTION
## Summary
- add view model `VTicketMasterExpanded`
- expose a new schema `TicketExpandedOut`
- query the expanded ticket view in tools and service layers
- update API responses to use the expanded schema
- create the SQL view for tests

## Testing
- `pip install -q -r requirements.txt` *(fails: No matching distribution found for aioodbc>=0.6)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6865e121b2a0832b98557941ee25f359