### PR TITLE
Add on-call shift API

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -34,6 +34,7 @@ from tools.analysis_tools import (
     open_tickets_by_user,
     tickets_waiting_on_user,
 )
+from tools.oncall_tools import get_current_oncall, list_oncall_schedule
 from tools.ai_tools import ai_suggest_response
 from services.analytics_service import AnalyticsService
 from limiter import limiter
@@ -43,6 +44,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, func
 
 from schemas.ticket import TicketCreate, TicketOut, TicketUpdate
+from schemas.oncall import OnCallShiftOut
 from schemas.paginated import PaginatedResponse
 from db.models import (
     Asset,
@@ -306,5 +308,9 @@ async def api_open_tickets_by_user(db: AsyncSession = Depends(get_db)) -> list[t
 async def api_tickets_waiting_on_user(db: AsyncSession = Depends(get_db)) -> list[tuple[str | None, int]]:
 
     return await tickets_waiting_on_user(db)
+
+@router.get("/oncall", response_model=OnCallShiftOut | None)
+async def api_get_oncall(db: AsyncSession = Depends(get_db)) -> Any:
+    return await get_current_oncall(db)
 
 

--- a/db/models.py
+++ b/db/models.py
@@ -81,3 +81,12 @@ class TicketStatus(Base):
     __tablename__ = "Ticket_Status"
     ID = Column(Integer, primary_key=True, index=True)
     Label = Column(String)
+
+
+class OnCallShift(Base):
+    __tablename__ = "OnCall_Shifts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_email = Column(String, nullable=False, index=True)
+    start_time = Column(DateTime, nullable=False)
+    end_time = Column(DateTime, nullable=False)

--- a/schemas/oncall.py
+++ b/schemas/oncall.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, EmailStr
+from datetime import datetime
+
+
+class OnCallShiftBase(BaseModel):
+    user_email: EmailStr
+    start_time: datetime
+    end_time: datetime
+
+
+class OnCallShiftOut(OnCallShiftBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/tests/test_oncall.py
+++ b/tests/test_oncall.py
@@ -1,0 +1,43 @@
+import pytest
+from httpx import AsyncClient
+from datetime import datetime, timedelta, UTC
+
+from main import app
+from db.models import OnCallShift
+from db.mssql import SessionLocal
+from tools.oncall_tools import get_current_oncall, list_oncall_schedule
+
+
+async def _add_shift(email: str, start: datetime, end: datetime) -> OnCallShift:
+    async with SessionLocal() as db:
+        shift = OnCallShift(user_email=email, start_time=start, end_time=end)
+        db.add(shift)
+        await db.commit()
+        await db.refresh(shift)
+        return shift
+
+
+@pytest.mark.asyncio
+async def test_list_oncall_schedule():
+    now = datetime.now(UTC)
+    await _add_shift("a@example.com", now - timedelta(hours=2), now - timedelta(hours=1))
+    await _add_shift("b@example.com", now + timedelta(hours=1), now + timedelta(hours=2))
+
+    async with SessionLocal() as db:
+        schedule = await list_oncall_schedule(db)
+        emails = [s.user_email for s in schedule]
+
+    assert emails == ["a@example.com", "b@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_get_current_oncall_route():
+    now = datetime.now(UTC)
+    await _add_shift("active@example.com", now - timedelta(minutes=30), now + timedelta(minutes=30))
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get("/oncall")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_email"] == "active@example.com"
+

--- a/tools/oncall_tools.py
+++ b/tools/oncall_tools.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime, UTC
+import logging
+from typing import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import OnCallShift
+
+logger = logging.getLogger(__name__)
+
+
+async def get_current_oncall(db: AsyncSession) -> OnCallShift | None:
+    """Return the on-call shift active at the current time."""
+    now = datetime.now(UTC)
+    result = await db.execute(
+        select(OnCallShift)
+        .where(OnCallShift.start_time <= now)
+        .where(OnCallShift.end_time > now)
+        .order_by(OnCallShift.start_time.desc())
+        .limit(1)
+    )
+    shift = result.scalars().first()
+    logger.info("Current on-call shift: %s", shift)
+    return shift
+
+
+async def list_oncall_schedule(db: AsyncSession, skip: int = 0, limit: int = 10) -> Sequence[OnCallShift]:
+    """Return upcoming on-call shifts ordered by start_time."""
+    result = await db.execute(
+        select(OnCallShift).order_by(OnCallShift.start_time).offset(skip).limit(limit)
+    )
+    return result.scalars().all()


### PR DESCRIPTION
## Summary
- add `OnCallShift` SQLAlchemy model
- expose `/oncall` route to fetch current shift
- implement `tools/oncall_tools` utilities
- add pydantic schema for on-call shifts
- test on-call schedule retrieval and route

## Testing
- `pip install fastapi uvicorn sqlalchemy pydantic==1.10.15 python-dotenv openai==1.93.0 pytest pytest-asyncio email-validator httpx==0.27.2 slowapi==0.1.9 aiosqlite requests`
- `pip install aioodbc==0.5.0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e4fd76a8832bb86cb68d71f1dae2