### PR TITLE
Add optional Graph credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 DB_CONN_STRING=mssql+aioodbc://USER:PASS@HOST/DB?driver=ODBC+Driver+18+for+SQL+Server
 OPENAI_API_KEY=your-key
 CONFIG_ENV=dev
+# Optional Microsoft Graph credentials
+GRAPH_CLIENT_ID=your-client-id
+GRAPH_CLIENT_SECRET=your-client-secret
+GRAPH_TENANT_ID=your-tenant-id

--- a/README.md
+++ b/README.md
@@ -21,16 +21,20 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
     ```bash
     DB_CONN_STRING="mssql+aioodbc://user:pass@host/db?driver=ODBC+Driver+18+for+SQL+Server"
     ```
-    The `driver` name must match an ODBC driver installed on the host machine.
+   The `driver` name must match an ODBC driver installed on the host machine.
    - `OPENAI_API_KEY` – API key used by the OpenAI integration.
    - `CONFIG_ENV` – which config to load: `dev`, `staging`, or `prod` (default `dev`).
+   - `GRAPH_CLIENT_ID`, `GRAPH_CLIENT_SECRET`, `GRAPH_TENANT_ID` – optional credentials used for Microsoft Graph
+     lookups in `tools.user_tools`. When omitted, stub responses are returned.
 
   They can be provided in the shell environment or in a `.env` file in the project root.
-  A template called `.env.example` lists the required variables; copy it to `.env` and
+  A template called `.env.example` lists the required and optional variables; copy it to `.env` and
   update the values for your environment. `config.py` automatically loads `.env` and
   then imports `config_{CONFIG_ENV}.py` so the appropriate settings are applied at
   startup. OpenAI model parameters such as model name and timeouts are defined in the
-  selected config file.
+  selected config file. The Graph credentials are optional; without them, the Graph
+  helper functions return stub data so tests and development work without network
+  access.
 
 ## Running the API
 


### PR DESCRIPTION
## Summary
- expand .env example with Microsoft Graph variables
- document optional Graph credentials in the README

## Testing
- `pip install fastapi==0.110.0 uvicorn==0.35.0 sqlalchemy==2.0.41 pydantic==1.10.15 python-dotenv==1.1.1 openai==1.93.0 pytest==8.4.1 pytest-asyncio==0.23.6 email-validator==2.2.0 mypy==1.16.1 slowapi==0.1.9 aiosqlite==0.21.0 requests==2.32.3 -q`
- `pip install httpx==0.27.0 -q`
- `pytest -q` *(fails: ImportError: cannot import name 'list_tickets_expanded')*

------
https://chatgpt.com/codex/tasks/task_e_6865edf125d8832bafbec1bb00caafd6