### PR TITLE
Fix schema import for expanded tickets

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -43,7 +43,12 @@ from limiter import limiter
 from pydantic import BaseModel
 from sqlalchemy import select, func
 
-from schemas.ticket import TicketCreate, TicketOut, TicketUpdate
+from schemas.ticket import (
+    TicketCreate,
+    TicketOut,
+    TicketUpdate,
+    TicketExpandedOut,
+)
 from schemas.oncall import OnCallShiftOut
 
 from schemas.paginated import PaginatedResponse


### PR DESCRIPTION
## Summary
- import `TicketExpandedOut` in `api/routes.py`

## Testing
- `pytest tests/test_app.py::test_app_import -q` *(fails: cannot import name 'list_tickets_expanded')*

------
https://chatgpt.com/codex/tasks/task_e_6865edf00000832b80a30fe5f598df68