### PR TITLE
Switch to async OpenAI client

### DIFF
--- a/ai/openai_agent.py
+++ b/ai/openai_agent.py
@@ -9,16 +9,16 @@ from config import OPENAI_API_KEY, OPENAI_MODEL_NAME, OPENAI_TIMEOUT
 logger = logging.getLogger(__name__)
 
 # Lazily created OpenAI client instance
-openai_client: openai.Client | None = None
+openai_client: openai.AsyncClient | None = None
 
 
-def set_client(client: openai.Client | None) -> None:
+def set_client(client: openai.AsyncClient | None) -> None:
     """Override the cached OpenAI client used by this module."""
     global openai_client
     openai_client = client
 
 
-def _get_client() -> openai.Client:
+def _get_client() -> openai.AsyncClient:
     """Return a reusable OpenAI client instance."""
     global openai_client
 
@@ -26,12 +26,12 @@ def _get_client() -> openai.Client:
         if not OPENAI_API_KEY:
             raise RuntimeError("OPENAI_API_KEY environment variable not set")
 
-        openai_client = openai.Client(api_key=OPENAI_API_KEY, timeout=OPENAI_TIMEOUT)
+        openai_client = openai.AsyncClient(api_key=OPENAI_API_KEY, timeout=OPENAI_TIMEOUT)
 
     return openai_client
 
 
-def suggest_ticket_response(ticket: Dict[str, Any], context: str = "") -> str:
+async def suggest_ticket_response(ticket: Dict[str, Any], context: str = "") -> str:
     """Generate a suggested response to a ticket using OpenAI."""
 
     client = _get_client()
@@ -44,7 +44,7 @@ def suggest_ticket_response(ticket: Dict[str, Any], context: str = "") -> str:
     )
 
     try:
-        response = client.chat.completions.create(
+        response = await client.chat.completions.create(
             model=OPENAI_MODEL_NAME,
             messages=[{"role": "system", "content": prompt}],
         )

--- a/api/routes.py
+++ b/api/routes.py
@@ -43,7 +43,7 @@ from limiter import limiter
 from pydantic import BaseModel
 from sqlalchemy import select, func
 
-from schemas.ticket import TicketCreate, TicketOut, TicketUpdate
+from schemas.ticket import TicketCreate, TicketOut, TicketUpdate, TicketExpandedOut
 from schemas.oncall import OnCallShiftOut
 
 from schemas.paginated import PaginatedResponse
@@ -126,7 +126,7 @@ async def api_list_tickets_expanded(
 ) -> PaginatedResponse[TicketExpandedOut]:
     items = await list_tickets_expanded(db, skip, limit)
     total = await db.scalar(select(func.count(VTicketMasterExpanded.Ticket_ID))) or 0
-    ticket_out = [TicketExpandedOut.from_orm(t) for t in items]
+    ticket_out = [TicketExpandedOut(**t._mapping) for t in items]
     return PaginatedResponse[TicketExpandedOut](
         items=ticket_out, total=total, skip=skip, limit=limit
     )
@@ -268,11 +268,11 @@ async def api_post_ticket_message(
 
 @router.post("/ai/suggest_response")
 @limiter.limit("10/minute")
-def api_ai_suggest_response(
+async def api_ai_suggest_response(
     request: Request, ticket: TicketOut, context: str = ""
 ) -> dict:
 
-    return {"response": ai_suggest_response(ticket.dict(), context)}
+    return {"response": await ai_suggest_response(ticket.dict(), context)}
 
 
 # Analysis endpoints

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -109,15 +109,24 @@ class TicketOut(TicketIn):
         }
 
 
+
 class TicketExpandedOut(TicketOut):
 
     """Ticket output schema that includes related labels."""
 
-    Ticket_Status_Label: Optional[str] = None
+    Ticket_Status_Label: Optional[str] = Field(None, alias="Status_Label")
     Site_Label: Optional[str] = None
     Asset_Label: Optional[str] = None
-    Ticket_Category_Label: Optional[str] = None
+    Ticket_Category_Label: Optional[str] = Field(None, alias="Category_Label")
     Assigned_Vendor_Name: Optional[str] = None
+
+    @property
+    def Status_Label(self) -> Optional[str]:
+        return self.Ticket_Status_Label
+
+    @property
+    def Category_Label(self) -> Optional[str]:
+        return self.Ticket_Category_Label
 
 
     class Config:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,38 +25,6 @@ mssql.SessionLocal = async_sessionmaker(bind=mssql.engine, expire_on_commit=Fals
 async def _init_models():
     async with mssql.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-        await conn.execute(text("DROP VIEW IF EXISTS V_Ticket_Master_Expanded"))
-        await conn.execute(text(
-            """
-            CREATE VIEW V_Ticket_Master_Expanded AS
-            SELECT t.Ticket_ID,
-                   t.Subject,
-                   t.Ticket_Body,
-                   t.Ticket_Status_ID,
-                   ts.Label AS Ticket_Status_Label,
-                   t.Ticket_Contact_Name,
-                   t.Ticket_Contact_Email,
-                   t.Asset_ID,
-                   a.Label AS Asset_Label,
-                   t.Site_ID,
-                   s.Label AS Site_Label,
-                   t.Ticket_Category_ID,
-                   c.Label AS Ticket_Category_Label,
-                   t.Created_Date,
-                   t.Assigned_Name,
-                   t.Assigned_Email,
-                   t.Severity_ID,
-                   t.Assigned_Vendor_ID,
-                   v.Name AS Assigned_Vendor_Name,
-                   t.Resolution
-            FROM Tickets_Master t
-            LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
-            LEFT JOIN Assets a ON a.ID = t.Asset_ID
-            LEFT JOIN Sites s ON s.ID = t.Site_ID
-            LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
-            LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID
-            """
-        ))
 
 import asyncio
 asyncio.get_event_loop().run_until_complete(_init_models())

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -16,7 +16,7 @@ os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")
 import pytest_asyncio
 
 
-def fake_create(*args, **kwargs):
+async def fake_create(*args, **kwargs):
     """Return a dummy OpenAI chat completion response."""
     class Msg:
         content = "ok"
@@ -107,21 +107,6 @@ async def test_analytics_waiting_on_user(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_ai_suggest_response(client: AsyncClient, monkeypatch):
-    from ai import openai_agent
-
-    class DummyClient:
-        class Chat:
-            class Completions:
-                @staticmethod
-                def create(*_, **__):
-                    class Msg:
-                        content = "ok"
-
-                    class Choice:
-                        message = Msg()
-
-                    return type("Resp", (), {"choices": [Choice()]})()
-
     from ai import openai_agent
     openai_agent._get_client()
     assert openai_agent.openai_client is not None

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -10,7 +10,7 @@ def _patch_openai(monkeypatch):
         class Chat:
             class Completions:
                 @staticmethod
-                def create(*args, **kwargs):
+                async def create(*args, **kwargs):
                     class Msg:
                         content = "ok"
 

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -19,8 +19,9 @@ DROP_VIEW_SQL = "DROP VIEW IF EXISTS V_Ticket_Master_Expanded"
 @pytest_asyncio.fixture(autouse=True)
 async def expanded_view(db_setup):
     async with engine.begin() as conn:
-        await conn.exec_driver_sql("DROP TABLE IF EXISTS V_Ticket_Master_Expanded")
+        # SQLite requires DROP VIEW for existing views
         await conn.exec_driver_sql(DROP_VIEW_SQL)
+        await conn.exec_driver_sql("DROP TABLE IF EXISTS V_Ticket_Master_Expanded")
         await conn.exec_driver_sql(CREATE_VIEW_SQL)
     yield
     async with engine.begin() as conn:

--- a/tools/ai_tools.py
+++ b/tools/ai_tools.py
@@ -7,7 +7,7 @@ from ai.openai_agent import suggest_ticket_response
 logger = logging.getLogger(__name__)
 
 
-def ai_suggest_response(ticket: Dict[str, Any], context: str = "") -> str:
+async def ai_suggest_response(ticket: Dict[str, Any], context: str = "") -> str:
 
-    return suggest_ticket_response(ticket, context)
+    return await suggest_ticket_response(ticket, context)
 


### PR DESCRIPTION
## Summary
- support async OpenAI usage via `openai.AsyncClient`
- update AI route to await async suggestion call
- adjust tests for async OpenAI client
- fix ticket update/delete helpers and expanded ticket schema
- tweak tests for SQLite view handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ec0637b4832b8bfba8944241e0df