### PR TITLE
Update async client patch

### DIFF
--- a/tests/test_user_tools.py
+++ b/tests/test_user_tools.py
@@ -83,7 +83,7 @@ async def test_user_tools_graph_calls(monkeypatch):
                 json=lambda: data,
             )
 
-    monkeypatch.setattr(ut.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(ut.httpx, "AsyncClient", DummyClient)
 
 
     user = await ut.get_user_by_email("u@e.com")


### PR DESCRIPTION
## Summary
- use `DummyClient` when patching `httpx.AsyncClient`

## Testing
- `pytest tests/test_user_tools.py -q` *(fails: Invalid argument(s) 'fast_executemany' sent to create_engine)*


------
https://chatgpt.com/codex/tasks/task_e_6865f7730314832bad96cba27e60fe38