### PR TITLE
Fix duplicate list_tickets_expanded

### DIFF
--- a/db/mssql.py
+++ b/db/mssql.py
@@ -2,29 +2,23 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, Asyn
 from config import DB_CONN_STRING
 import logging
 import pyodbc
-print(pyodbc.drivers())
-engine_args = {}
-if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):import os
-from pathlib import Path
 
-# Check if .env exists
-if Path(".env").exists():
-    print("✓ .env file exists -"+ DB_CONN_STRING)
-    
-    # Check content
-    with open(".env", "r") as f:
-        content = f.read()
-        if "DB_CONN_STRING" in content:
-            print("✓ DB_CONN_STRING found in .env")
-        else:
-            print("❌ DB_CONN_STRING not found in .env")
-else:
-    print("❌ .env file not found!")
-    print("Create one by copying .env.example:")
-    print("  cp .env.example .env")
+print(pyodbc.drivers())
+
+engine_args: dict[str, object] = {}
+
+if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):
+    from pathlib import Path
+
+    if not Path(".env").exists():
+        print("❌ .env file not found!")
+        print("Create one by copying .env.example:")
+        print("  cp .env.example .env")
+
     if DB_CONN_STRING.startswith("mssql+pyodbc"):
         logging.error("Synchronous driver detected in DB_CONN_STRING: %s", DB_CONN_STRING)
         raise RuntimeError("Use an async SQLAlchemy driver such as 'mssql+aioodbc'.")
+
     engine_args["fast_executemany"] = True
 
 

--- a/tests/test_user_tools.py
+++ b/tests/test_user_tools.py
@@ -83,7 +83,7 @@ async def test_user_tools_graph_calls(monkeypatch):
                 json=lambda: data,
             )
 
-    monkeypatch.setattr(ut.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(ut.httpx, "AsyncClient", DummyClient)
 
 
     user = await ut.get_user_by_email("u@e.com")

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.models import Ticket, VTicketMasterExpanded
+from db.models import Ticket
 
 
 logger = logging.getLogger(__name__)
@@ -26,22 +26,11 @@ async def list_tickets(
     result = await db.execute(select(Ticket).offset(skip).limit(limit))
     return result.scalars().all()
 
-
-async def list_tickets_expanded(
-    db: AsyncSession, skip: int = 0, limit: int = 10
-) -> Sequence[VTicketMasterExpanded]:
-    """Return tickets from the expanded view."""
-    result = await db.execute(
-        select(VTicketMasterExpanded).offset(skip).limit(limit)
-    )
-    return result.scalars().all()
-
-
 async def list_tickets_expanded(
     db: AsyncSession, skip: int = 0, limit: int = 10
 
 
-) -> Sequence[VTicketMasterExpanded]:
+) -> Sequence[Mapping[str, Any]]:
     """Return tickets with related labels from the expanded view."""
 
     result = await db.execute(


### PR DESCRIPTION
## Summary
- remove duplicate `list_tickets_expanded` implementation and keep the raw SQL version
- fix minor test issues so suite runs cleanly
- guard MSSQL engine options based on connection string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f774110c832b87a377c927375388