### PR TITLE
Implement expanded ticket retrieval

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -11,6 +11,7 @@ from db.mssql import SessionLocal
 
 from tools.ticket_tools import (
     get_ticket,
+    get_ticket_expanded,
     list_tickets,
     list_tickets_expanded,
     create_ticket,
@@ -107,7 +108,7 @@ class MessageIn(BaseModel):
 
 @router.get("/ticket/{ticket_id}", response_model=TicketExpandedOut)
 async def api_get_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> TicketExpandedOut:
-    ticket = await get_ticket(db, ticket_id)
+    ticket = await get_ticket_expanded(db, ticket_id)
     if not ticket:
         logger.warning("Ticket %s not found", ticket_id)
         raise HTTPException(status_code=404, detail="Ticket not found")

--- a/db/mssql.py
+++ b/db/mssql.py
@@ -1,36 +1,21 @@
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from config import DB_CONN_STRING
 import logging
-import pyodbc
-print(pyodbc.drivers())
-engine_args = {}
-if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):import os
 from pathlib import Path
 
-# Check if .env exists
-if Path(".env").exists():
-    print("✓ .env file exists -"+ DB_CONN_STRING)
-    
-    # Check content
-    with open(".env", "r") as f:
-        content = f.read()
-        if "DB_CONN_STRING" in content:
-            print("✓ DB_CONN_STRING found in .env")
-        else:
-            print("❌ DB_CONN_STRING not found in .env")
-else:
-    print("❌ .env file not found!")
-    print("Create one by copying .env.example:")
-    print("  cp .env.example .env")
-    if DB_CONN_STRING.startswith("mssql+pyodbc"):
-        logging.error("Synchronous driver detected in DB_CONN_STRING: %s", DB_CONN_STRING)
-        raise RuntimeError("Use an async SQLAlchemy driver such as 'mssql+aioodbc'.")
-    engine_args["fast_executemany"] = True
+engine_args: dict[str, object] = {}
 
+# Disallow synchronous PyODBC driver
+if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql+pyodbc"):
+    logging.error("Synchronous driver detected in DB_CONN_STRING: %s", DB_CONN_STRING)
+    raise RuntimeError("Use an async SQLAlchemy driver such as 'mssql+aioodbc'.")
+
+# Enable fast_executemany for MSSQL when no .env file is present
+if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql") and not Path(".env").exists():
+    engine_args["fast_executemany"] = True
 
 engine = create_async_engine(
     DB_CONN_STRING or "mssql+aioodbc://${DB_USERNAME}:${DB_PASSWORD}@${DB_SERVER}/${DB_DATABASE}?driver=ODBC+Driver+18+for+SQL+Server",
     **engine_args,
 )
 SessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
-

--- a/tests/test_user_tools.py
+++ b/tests/test_user_tools.py
@@ -83,7 +83,7 @@ async def test_user_tools_graph_calls(monkeypatch):
                 json=lambda: data,
             )
 
-    monkeypatch.setattr(ut.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(ut.httpx, "AsyncClient", DummyClient)
 
 
     user = await ut.get_user_by_email("u@e.com")

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -20,6 +20,20 @@ async def get_ticket(db: AsyncSession, ticket_id: int) -> Ticket | None:
     return await db.get(Ticket, ticket_id)
 
 
+async def get_ticket_expanded(
+    db: AsyncSession, ticket_id: int
+) -> Mapping[str, Any] | None:
+    """Return a single ticket from the expanded view."""
+    result = await db.execute(
+        text(
+            "SELECT * FROM V_Ticket_Master_Expanded WHERE Ticket_ID = :tid LIMIT 1"
+        ),
+        {"tid": ticket_id},
+    )
+    row = result.fetchone()
+    return dict(row._mapping) if row else None
+
+
 async def list_tickets(
     db: AsyncSession, skip: int = 0, limit: int = 10
 ) -> Sequence[Ticket]:


### PR DESCRIPTION
## Summary
- add `get_ticket_expanded` helper for fetching from expanded view
- use new helper in `api_get_ticket` endpoint
- handle missing `.env` gracefully and simplify db init
- fix `test_user_tools_graph_calls` to use `DummyClient`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f7748b74832bb30b5824ba14e725