### PR TITLE
Use expanded view for tickets

### DIFF
--- a/db/mssql.py
+++ b/db/mssql.py
@@ -1,36 +1,19 @@
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from config import DB_CONN_STRING
 import logging
-import pyodbc
-print(pyodbc.drivers())
-engine_args = {}
-if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):import os
-from pathlib import Path
 
-# Check if .env exists
-if Path(".env").exists():
-    print("✓ .env file exists -"+ DB_CONN_STRING)
-    
-    # Check content
-    with open(".env", "r") as f:
-        content = f.read()
-        if "DB_CONN_STRING" in content:
-            print("✓ DB_CONN_STRING found in .env")
-        else:
-            print("❌ DB_CONN_STRING not found in .env")
-else:
-    print("❌ .env file not found!")
-    print("Create one by copying .env.example:")
-    print("  cp .env.example .env")
+engine_args: dict[str, object] = {}
+
+if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):
     if DB_CONN_STRING.startswith("mssql+pyodbc"):
         logging.error("Synchronous driver detected in DB_CONN_STRING: %s", DB_CONN_STRING)
         raise RuntimeError("Use an async SQLAlchemy driver such as 'mssql+aioodbc'.")
     engine_args["fast_executemany"] = True
 
-
 engine = create_async_engine(
-    DB_CONN_STRING or "mssql+aioodbc://${DB_USERNAME}:${DB_PASSWORD}@${DB_SERVER}/${DB_DATABASE}?driver=ODBC+Driver+18+for+SQL+Server",
+    DB_CONN_STRING or "sqlite+aiosqlite:///:memory:",
     **engine_args,
 )
+
 SessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -33,13 +33,17 @@ async def test_create_and_get_ticket(client: AsyncClient):
     assert list_resp.status_code == 200
     data = list_resp.json()
     assert data["total"] == 1
-    assert data["items"][0]["Ticket_ID"] == tid
+    item = data["items"][0]
+    assert item["Ticket_ID"] == tid
+    assert "Ticket_Status_Label" in item
     assert data["skip"] == 0
     assert data["limit"] == 10
 
     get_resp = await client.get(f"/ticket/{tid}")
     assert get_resp.status_code == 200
-    assert get_resp.json()["Subject"] == "API test"
+    ticket_json = get_resp.json()
+    assert ticket_json["Subject"] == "API test"
+    assert "Ticket_Status_Label" in ticket_json
 
 
 @pytest.mark.asyncio

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,7 +4,7 @@ import pytest
 from db.models import Base, Ticket
 from db.mssql import engine, SessionLocal
 from datetime import datetime, UTC
-from tools.ticket_tools import create_ticket, search_tickets
+from tools.ticket_tools import create_ticket, search_tickets_expanded
 
 os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")
 
@@ -12,6 +12,38 @@ os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")
 async def _setup_models():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await conn.exec_driver_sql("DROP VIEW IF EXISTS V_Ticket_Master_Expanded")
+        await conn.exec_driver_sql(
+            """
+            CREATE VIEW V_Ticket_Master_Expanded AS
+            SELECT t.Ticket_ID,
+                   t.Subject,
+                   t.Ticket_Body,
+                   t.Ticket_Status_ID,
+                   ts.Label AS Ticket_Status_Label,
+                   t.Ticket_Contact_Name,
+                   t.Ticket_Contact_Email,
+                   t.Asset_ID,
+                   a.Label AS Asset_Label,
+                   t.Site_ID,
+                   s.Label AS Site_Label,
+                   t.Ticket_Category_ID,
+                   c.Label AS Ticket_Category_Label,
+                   t.Created_Date,
+                   t.Assigned_Name,
+                   t.Assigned_Email,
+                   t.Severity_ID,
+                   t.Assigned_Vendor_ID,
+                   v.Name AS Assigned_Vendor_Name,
+                   t.Resolution
+            FROM Tickets_Master t
+            LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
+            LEFT JOIN Assets a ON a.ID = t.Asset_ID
+            LEFT JOIN Sites s ON s.ID = t.Site_ID
+            LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
+            LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID
+            """
+        )
 
 asyncio.get_event_loop().run_until_complete(_setup_models())
 
@@ -26,6 +58,6 @@ async def test_search_tickets():
         )
 
         await create_ticket(db, t)
-        results = await search_tickets(db, "Network")
+        results = await search_tickets_expanded(db, "Network")
         assert results and results[0].Subject == "Network issue"
 

--- a/tests/test_user_tools.py
+++ b/tests/test_user_tools.py
@@ -69,7 +69,6 @@ async def test_user_tools_graph_calls(monkeypatch):
                 json=lambda: {"access_token": "tok"},
             )
 
-
         async def get(self, url, headers=None, timeout=None):
             assert headers["Authorization"] == "Bearer tok"
             if "groups" in url:
@@ -82,6 +81,8 @@ async def test_user_tools_graph_calls(monkeypatch):
                 raise_for_status=lambda: None,
                 json=lambda: data,
             )
+
+    FakeAsyncClient = DummyClient
 
     monkeypatch.setattr(ut.httpx, "AsyncClient", FakeAsyncClient)
 

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Sequence, Mapping, Any
+from typing import Sequence
 
-from sqlalchemy import select, text
-
+from sqlalchemy import select
 from fastapi import HTTPException
 from pydantic import BaseModel
 from sqlalchemy.exc import SQLAlchemyError
@@ -12,48 +11,40 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import Ticket, VTicketMasterExpanded
 
-
 logger = logging.getLogger(__name__)
 
 
-async def get_ticket(db: AsyncSession, ticket_id: int) -> Ticket | None:
-    return await db.get(Ticket, ticket_id)
-
-
-async def list_tickets(
-    db: AsyncSession, skip: int = 0, limit: int = 10
-) -> Sequence[Ticket]:
-    result = await db.execute(select(Ticket).offset(skip).limit(limit))
-    return result.scalars().all()
+async def get_ticket_expanded(
+    db: AsyncSession, ticket_id: int
+) -> VTicketMasterExpanded | None:
+    """Return a ticket from the expanded view."""
+    return await db.get(VTicketMasterExpanded, ticket_id)
 
 
 async def list_tickets_expanded(
     db: AsyncSession, skip: int = 0, limit: int = 10
 ) -> Sequence[VTicketMasterExpanded]:
-    """Return tickets from the expanded view."""
+    """Return tickets with related labels from the expanded view."""
     result = await db.execute(
         select(VTicketMasterExpanded).offset(skip).limit(limit)
     )
     return result.scalars().all()
 
 
-async def list_tickets_expanded(
-    db: AsyncSession, skip: int = 0, limit: int = 10
-
-
+async def search_tickets_expanded(
+    db: AsyncSession, query: str, limit: int = 10
 ) -> Sequence[VTicketMasterExpanded]:
-    """Return tickets with related labels from the expanded view."""
-
+    """Search tickets in the expanded view by subject or body."""
+    like = f"%{query}%"
     result = await db.execute(
-        text(
-            "SELECT * FROM V_Ticket_Master_Expanded LIMIT :limit OFFSET :skip"
-        ),
-        {"limit": limit, "skip": skip},
+        select(VTicketMasterExpanded)
+        .filter(
+            (VTicketMasterExpanded.Subject.ilike(like))
+            | (VTicketMasterExpanded.Ticket_Body.ilike(like))
+        )
+        .limit(limit)
     )
-
-    return [dict(row._mapping) for row in result]
-
-
+    return result.scalars().all()
 
 
 async def create_ticket(db: AsyncSession, ticket_obj: Ticket) -> Ticket:
@@ -72,7 +63,6 @@ async def update_ticket(db: AsyncSession, ticket_id: int, updates) -> Ticket | N
     """Update a ticket with a mapping or Pydantic model."""
     if isinstance(updates, BaseModel):
         updates = updates.dict(exclude_unset=True)
-
 
     ticket = await db.get(Ticket, ticket_id)
     if not ticket:
@@ -94,7 +84,6 @@ async def update_ticket(db: AsyncSession, ticket_id: int, updates) -> Ticket | N
 
 
 async def delete_ticket(db: AsyncSession, ticket_id: int) -> bool:
-
     ticket = await db.get(Ticket, ticket_id)
     if not ticket:
         return False
@@ -107,16 +96,3 @@ async def delete_ticket(db: AsyncSession, ticket_id: int) -> bool:
         await db.rollback()
         logger.exception("Failed to delete ticket %s", ticket_id)
         raise
-
-
-async def search_tickets(
-    db: AsyncSession, query: str, limit: int = 10
-) -> Sequence[Ticket]:
-    like = f"%{query}%"
-    logger.info("Searching tickets for '%s'", query)
-    result = await db.execute(
-        select(Ticket)
-        .filter((Ticket.Subject.ilike(like)) | (Ticket.Ticket_Body.ilike(like)))
-        .limit(limit)
-    )
-    return result.scalars().all()


### PR DESCRIPTION
## Summary
- query the VTicketMasterExpanded view in ticket tools
- update ticket routes to return expanded view data
- search tickets against the expanded view
- adapt tests for expanded view results
- fix SQLAlchemy engine setup for SQLite tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f81d7964832bab2ba1e552b32e97