### PR TITLE
Fix indentation error in MSSQL module

### DIFF
--- a/db/mssql.py
+++ b/db/mssql.py
@@ -1,16 +1,14 @@
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from config import DB_CONN_STRING
 import logging
 
+engine_args: dict[str, object] = {}
+
+if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):
     if DB_CONN_STRING.startswith("mssql+pyodbc"):
         logging.error("Synchronous driver detected in DB_CONN_STRING: %s", DB_CONN_STRING)
         raise RuntimeError("Use an async SQLAlchemy driver such as 'mssql+aioodbc'.")
-    if DB_CONN_STRING.startswith("mssql"):
-        engine_args["fast_executemany"] = True
+    engine_args["fast_executemany"] = True
 
 engine = create_async_engine(
     DB_CONN_STRING or "sqlite+aiosqlite:///:memory:",
@@ -18,4 +16,3 @@ engine = create_async_engine(
 )
 
 SessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
-


### PR DESCRIPTION
## Summary
- fix indentation in `db/mssql.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6865fc7258dc832bbdd330df4db31963