### PR TITLE
Fix missing view import for expanded ticket query

### DIFF
--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.models import Ticket
+from db.models import Ticket, VTicketMasterExpanded
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- fix missing import for `VTicketMasterExpanded` in `ticket_tools`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865fd4e5208832b8a950eaca8be26d2