### PR TITLE
Add README section on expanded ticket view

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,45 @@ alembic revision --autogenerate -m "message"
 alembic upgrade head
 ```
 
+### V_Ticket_Master_Expanded
+
+The API uses the `V_Ticket_Master_Expanded` view to join tickets with
+related labels such as status, asset, site, and vendor. Endpoints like
+`/tickets/expanded` and `/tickets/search` rely on this view to return a
+fully populated ticket record.
+
+Create the view with SQL similar to the following:
+
+```sql
+CREATE VIEW V_Ticket_Master_Expanded AS
+SELECT t.Ticket_ID,
+       t.Subject,
+       t.Ticket_Body,
+       t.Ticket_Status_ID,
+       ts.Label AS Ticket_Status_Label,
+       t.Ticket_Contact_Name,
+       t.Ticket_Contact_Email,
+       t.Asset_ID,
+       a.Label AS Asset_Label,
+       t.Site_ID,
+       s.Label AS Site_Label,
+       t.Ticket_Category_ID,
+       c.Label AS Ticket_Category_Label,
+       t.Created_Date,
+       t.Assigned_Name,
+       t.Assigned_Email,
+       t.Severity_ID,
+       t.Assigned_Vendor_ID,
+       v.Name AS Assigned_Vendor_Name,
+       t.Resolution
+FROM Tickets_Master t
+LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
+LEFT JOIN Assets a ON a.ID = t.Asset_ID
+LEFT JOIN Sites s ON s.ID = t.Site_ID
+LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
+LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID;
+```
+
 ### API Highlights
 
 - `GET /health` - health check returning database status, uptime, and version


### PR DESCRIPTION
## Summary
- describe V_Ticket_Master_Expanded view used by API
- include SQL to create the view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686600326004832bb66eeee7075b9a38