### PR TITLE
Expose status and category labels via aliases

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -104,7 +104,11 @@ class MessageIn(BaseModel):
         }
 
 
-@router.get("/ticket/{ticket_id}", response_model=TicketExpandedOut)
+@router.get(
+    "/ticket/{ticket_id}",
+    response_model=TicketExpandedOut,
+    response_model_by_alias=False,
+)
 async def api_get_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> TicketExpandedOut:
     ticket = await get_ticket_expanded(db, ticket_id)
     if not ticket:
@@ -115,7 +119,11 @@ async def api_get_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> 
 
 
 
-@router.get("/tickets", response_model=PaginatedResponse[TicketExpandedOut])
+@router.get(
+    "/tickets",
+    response_model=PaginatedResponse[TicketExpandedOut],
+    response_model_by_alias=False,
+)
 
 async def api_list_tickets(
     skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
@@ -129,7 +137,11 @@ async def api_list_tickets(
 
 
 
-@router.get("/tickets/expanded", response_model=PaginatedResponse[TicketExpandedOut])
+@router.get(
+    "/tickets/expanded",
+    response_model=PaginatedResponse[TicketExpandedOut],
+    response_model_by_alias=False,
+)
 async def api_list_tickets_expanded(
     skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
 ) -> PaginatedResponse[TicketExpandedOut]:
@@ -143,7 +155,11 @@ async def api_list_tickets_expanded(
 
 
 
-@router.get("/tickets/search", response_model=List[TicketExpandedOut])
+@router.get(
+    "/tickets/search",
+    response_model=List[TicketExpandedOut],
+    response_model_by_alias=False,
+)
 
 async def api_search_tickets(
     q: str, limit: int = 10, db: AsyncSession = Depends(get_db)

--- a/db/models.py
+++ b/db/models.py
@@ -83,6 +83,12 @@ class TicketStatus(Base):
     Label = Column(String)
 
 
+class Priority(Base):
+    __tablename__ = "Priorities"
+    ID = Column(Integer, primary_key=True, index=True)
+    Level = Column(String)
+
+
 
 class OnCallShift(Base):
     __tablename__ = "OnCall_Shifts"

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -114,25 +114,14 @@ class TicketExpandedOut(TicketOut):
 
     """Ticket output schema that includes related labels."""
 
-
-    Ticket_Status_Label: Optional[str] = None
-    Status_Label: Optional[str] = None
+    status_label: Optional[str] = Field(None, alias="Ticket_Status_Label")
     Site_Label: Optional[str] = None
     Asset_Label: Optional[str] = None
-    Ticket_Category_Label: Optional[str] = None
-    Category_Label: Optional[str] = None
+    category_label: Optional[str] = Field(None, alias="Ticket_Category_Label")
 
     Assigned_Vendor_Name: Optional[str] = None
     Priority_Level: Optional[str] = None
 
-    @property
-    def Status_Label(self) -> Optional[str]:
-        return self.Ticket_Status_Label
-
-    @property
-    def Category_Label(self) -> Optional[str]:
-        return self.Ticket_Category_Label
-
-
     class Config:
         orm_mode = True
+        allow_population_by_field_name = True

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -35,7 +35,7 @@ async def test_create_and_get_ticket(client: AsyncClient):
     assert data["total"] == 1
     item = data["items"][0]
     assert item["Ticket_ID"] == tid
-    assert "Ticket_Status_Label" in item
+    assert "status_label" in item
     assert data["skip"] == 0
     assert data["limit"] == 10
 
@@ -43,7 +43,7 @@ async def test_create_and_get_ticket(client: AsyncClient):
     assert get_resp.status_code == 200
     ticket_json = get_resp.json()
     assert ticket_json["Subject"] == "API test"
-    assert "Ticket_Status_Label" in ticket_json
+    assert "status_label" in ticket_json
 
 
 @pytest.mark.asyncio

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -74,8 +74,8 @@ async def test_tickets_expanded_endpoint(client: AsyncClient):
     assert data["total"] == 1
     item = data["items"][0]
     assert item["Ticket_ID"] == tid
-    assert "Ticket_Status_Label" in item
-    assert "Ticket_Category_Label" in item
+    assert "status_label" in item
+    assert "category_label" in item
     assert "Site_Label" in item
 
 
@@ -86,4 +86,4 @@ def test_ticket_expanded_schema():
     data = {"Ticket_ID": 1, "Subject": "s", "Ticket_Status_Label": "Open"}
     obj = TicketExpandedOut(**data)
     assert obj.Ticket_ID == 1
-    assert obj.Ticket_Status_Label == "Open"
+    assert obj.status_label == "Open"


### PR DESCRIPTION
## Summary
- add missing `Priority` table model for test DB
- expose `status_label` and `category_label` via `Field` aliases
- disable alias output on ticket listing endpoints
- update tests for alias fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c05e34cc832b8adf0b41efd5bcae