### PR TITLE
Ensure consistent ordering on paginated lists

### DIFF
--- a/tools/asset_tools.py
+++ b/tools/asset_tools.py
@@ -13,7 +13,9 @@ async def get_asset(db: AsyncSession, asset_id: int) -> Asset | None:
 
 
 async def list_assets(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Asset]:
-    result = await db.execute(select(Asset).offset(skip).limit(limit))
+    result = await db.execute(
+        select(Asset).order_by(Asset.ID).offset(skip).limit(limit)
+    )
     return list(result.scalars().all())
 
 

--- a/tools/site_tools.py
+++ b/tools/site_tools.py
@@ -14,7 +14,9 @@ async def get_site(db: AsyncSession, site_id: int) -> Site | None:
 
 
 async def list_sites(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Site]:
-    result = await db.execute(select(Site).offset(skip).limit(limit))
+    result = await db.execute(
+        select(Site).order_by(Site.ID).offset(skip).limit(limit)
+    )
     return list(result.scalars().all())
 
 

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -27,7 +27,10 @@ async def list_tickets_expanded(
 ) -> Sequence[VTicketMasterExpanded]:
     """Return tickets with related labels from the expanded view."""
     result = await db.execute(
-        select(VTicketMasterExpanded).offset(skip).limit(limit)
+        select(VTicketMasterExpanded)
+        .order_by(VTicketMasterExpanded.Ticket_ID)
+        .offset(skip)
+        .limit(limit)
     )
     return result.scalars().all()
 

--- a/tools/vendor_tools.py
+++ b/tools/vendor_tools.py
@@ -14,6 +14,8 @@ async def get_vendor(db: AsyncSession, vendor_id: int) -> Vendor | None:
 
 
 async def list_vendors(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Vendor]:
-    result = await db.execute(select(Vendor).offset(skip).limit(limit))
+    result = await db.execute(
+        select(Vendor).order_by(Vendor.ID).offset(skip).limit(limit)
+    )
     return list(result.scalars().all())
 


### PR DESCRIPTION
## Summary
- add default ordering by ID for `list_tickets_expanded`
- order asset, vendor, and site listings by their primary key before pagination

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c49a9a84832ba0afa7eb6b58695a