### PR TITLE
Fix flake8 warnings

### DIFF
--- a/ai/openai_agent.py
+++ b/ai/openai_agent.py
@@ -58,4 +58,3 @@ async def suggest_ticket_response(ticket: Dict[str, Any], context: str = "") -> 
     except OpenAIError as exc:
         logger.exception("OpenAI API error")
         return f"OpenAI API error: {exc}"
-

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,6 +1,5 @@
 from logging.config import fileConfig
 
-import os
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
@@ -60,7 +59,9 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    config.set_main_option("sqlalchemy.url", DB_CONN_STRING or config.get_main_option("sqlalchemy.url"))
+    config.set_main_option(
+        "sqlalchemy.url", DB_CONN_STRING or config.get_main_option("sqlalchemy.url"),
+    )
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",

--- a/alembic/versions/2e80bc0ee0ea_create_expanded_ticket_view.py
+++ b/alembic/versions/2e80bc0ee0ea_create_expanded_ticket_view.py
@@ -8,7 +8,6 @@ Create Date: 2025-07-03 04:12:26.131518
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/alembic/versions/6d3242144893_create_ticket_expanded_view.py
+++ b/alembic/versions/6d3242144893_create_ticket_expanded_view.py
@@ -8,7 +8,6 @@ Create Date: 2025-07-01 15:10:48
 from typing import Sequence, Union
 
 from alembic import op  # type: ignore[attr-defined]
-import sqlalchemy as sa
 
 revision: str = '6d3242144893'
 down_revision: Union[str, None] = '7bee13849318'

--- a/alembic/versions/7bee13849318_initial.py
+++ b/alembic/versions/7bee13849318_initial.py
@@ -1,7 +1,7 @@
 """initial
 
 Revision ID: 7bee13849318
-Revises: 
+Revises:
 Create Date: 2025-07-01 15:10:47.847027
 
 """

--- a/config.py
+++ b/config.py
@@ -29,5 +29,3 @@ else:
     for name, value in vars(env_module).items():
         if name.isupper():
             globals()[name] = value
-
-

--- a/db/models.py
+++ b/db/models.py
@@ -134,4 +134,3 @@ class VTicketMasterExpanded(ViewBase):
     Assigned_Vendor_Name = Column(String)
     Resolution = Column(Text)
     Priority_Level = Column(String)
-

--- a/main.py
+++ b/main.py
@@ -79,5 +79,3 @@ async def health(db: AsyncSession = Depends(get_db)) -> dict:
 
     uptime = (datetime.now(UTC) - START_TIME).total_seconds()
     return {"db": db_status, "uptime": uptime, "version": APP_VERSION}
-
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.pool import StaticPool
 from db.models import Base
 from sqlalchemy import text
-import pytest
 import pytest_asyncio
 
 # Use a StaticPool so the in-memory DB is shared across threads

--- a/tests/test_db_conn.py
+++ b/tests/test_db_conn.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 import pytest
 
 import db.mssql as mssql

--- a/tests/test_oncall.py
+++ b/tests/test_oncall.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, UTC
 from main import app
 from db.models import OnCallShift
 from db.mssql import SessionLocal
-from tools.oncall_tools import get_current_oncall, list_oncall_schedule
+from tools.oncall_tools import list_oncall_schedule
 
 
 async def _add_shift(email: str, start: datetime, end: datetime) -> OnCallShift:
@@ -40,4 +40,3 @@ async def test_get_current_oncall_route():
         assert resp.status_code == 200
         data = resp.json()
         assert data["user_email"] == "active@example.com"
-

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -46,4 +46,3 @@ def test_ai_suggest_response_rate_limit(monkeypatch):
     # 11th request is blocked
     r = client.post("/ai/suggest_response", json=ticket)
     assert r.status_code == 429
-

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -79,4 +79,3 @@ async def test_update_ticket_invalid_field(client: AsyncClient):
 
     resp = await client.put(f"/ticket/{tid}", json={"BadField": "x"})
     assert resp.status_code == 422
-

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -62,4 +62,3 @@ async def test_search_tickets():
         await create_ticket(db, t)
         results = await search_tickets_expanded(db, "Network")
         assert results and results[0].Subject == "Network issue"
-

--- a/tests/test_ticket_lifecycle.py
+++ b/tests/test_ticket_lifecycle.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
 from main import app

--- a/tests/test_user_tools.py
+++ b/tests/test_user_tools.py
@@ -2,7 +2,6 @@ import importlib
 from types import SimpleNamespace
 
 import pytest
-import pytest_asyncio
 
 
 def reload_module(monkeypatch, **env):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,4 +21,3 @@ def test_subject_too_long():
             Ticket_Contact_Name="Name",
             Ticket_Contact_Email="test@example.com",
         )
-

--- a/tools/ai_tools.py
+++ b/tools/ai_tools.py
@@ -10,4 +10,3 @@ logger = logging.getLogger(__name__)
 async def ai_suggest_response(ticket: Dict[str, Any], context: str = "") -> str:
 
     return await suggest_ticket_response(ticket, context)
-

--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -92,8 +92,3 @@ async def tickets_waiting_on_user(db: AsyncSession) -> list[tuple[str | None, in
         .group_by(Ticket.Ticket_Contact_Email)
     )
     return [(row[0], row[1]) for row in result.all()]
-
-
-
-
-

--- a/tools/asset_tools.py
+++ b/tools/asset_tools.py
@@ -15,5 +15,3 @@ async def get_asset(db: AsyncSession, asset_id: int) -> Asset | None:
 async def list_assets(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Asset]:
     result = await db.execute(select(Asset).offset(skip).limit(limit))
     return list(result.scalars().all())
-
-

--- a/tools/attachment_tools.py
+++ b/tools/attachment_tools.py
@@ -13,4 +13,3 @@ async def get_ticket_attachments(db: AsyncSession, ticket_id: int) -> list[Ticke
         select(TicketAttachment).filter(TicketAttachment.Ticket_ID == ticket_id)
     )
     return list(result.scalars().all())
-

--- a/tools/category_tools.py
+++ b/tools/category_tools.py
@@ -11,4 +11,3 @@ logger = logging.getLogger(__name__)
 async def list_categories(db: AsyncSession) -> list[TicketCategory]:
     result = await db.execute(select(TicketCategory))
     return list(result.scalars().all())
-

--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -47,4 +47,3 @@ async def post_ticket_message(
         raise HTTPException(status_code=500, detail=f"Failed to save message: {e}")
 
     return msg
-

--- a/tools/site_tools.py
+++ b/tools/site_tools.py
@@ -16,5 +16,3 @@ async def get_site(db: AsyncSession, site_id: int) -> Site | None:
 async def list_sites(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Site]:
     result = await db.execute(select(Site).offset(skip).limit(limit))
     return list(result.scalars().all())
-
-

--- a/tools/status_tools.py
+++ b/tools/status_tools.py
@@ -11,5 +11,3 @@ logger = logging.getLogger(__name__)
 async def list_statuses(db: AsyncSession) -> list[TicketStatus]:
     result = await db.execute(select(TicketStatus))
     return list(result.scalars().all())
-
-

--- a/tools/user_tools.py
+++ b/tools/user_tools.py
@@ -105,5 +105,3 @@ async def resolve_user_display_name(identifier: str) -> str:
     logger.info("Resolving display name for %s", identifier)
     user = await get_user_by_email(identifier)
     return user.get("displayName") or identifier
-
-

--- a/tools/vendor_tools.py
+++ b/tools/vendor_tools.py
@@ -16,4 +16,3 @@ async def get_vendor(db: AsyncSession, vendor_id: int) -> Vendor | None:
 async def list_vendors(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Vendor]:
     result = await db.execute(select(Vendor).offset(skip).limit(limit))
     return list(result.scalars().all())
-


### PR DESCRIPTION
## Summary
- remove unused imports and trailing blank lines
- trim excessive whitespace in migrations and configs
- clean up imports in API routes
- ensure tests don't have unused imports

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6866c49b9b90832b8917a7d73f39e972