### PR TITLE
Add filtering and sorting to ticket listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ LEFT JOIN Priorities p ON p.ID = t.Priority_ID;
 
 - `GET /health` - health check returning database status, uptime, and version
 - `POST /ticket` - create a ticket
-- `GET /tickets` - list tickets
-- `GET /tickets/expanded` - list tickets with related labels
+- `GET /tickets` - list tickets. Supports dynamic query parameters to filter by
+  any column in `V_Ticket_Master_Expanded` and a `sort` parameter for ordering.
+- `GET /tickets/expanded` - list tickets with related labels. Accepts the same
+  filtering and sorting parameters as `/tickets`.
 - `GET /tickets/search?q=term` - search tickets by subject or body
 - `PUT /ticket/{id}` - update an existing ticket
 - `DELETE /ticket/{id}` - remove a ticket

--- a/api/routes.py
+++ b/api/routes.py
@@ -104,10 +104,30 @@ async def api_get_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> 
 )
 
 async def api_list_tickets(
-    skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
+    request: Request,
+    skip: int = 0,
+    limit: int = 10,
+    db: AsyncSession = Depends(get_db),
 ) -> PaginatedResponse[TicketExpandedOut]:
-    items = await list_tickets_expanded(db, skip, limit)
-    total = await db.scalar(select(func.count(VTicketMasterExpanded.Ticket_ID))) or 0
+    params = request.query_params
+    filters = {
+        k: v
+        for k, v in params.items()
+        if k not in {"skip", "limit", "sort"}
+    }
+    sort = params.getlist("sort") or None
+
+    items = await list_tickets_expanded(
+        db, skip, limit, filters=filters or None, sort=sort
+    )
+
+    count_query = select(func.count(VTicketMasterExpanded.Ticket_ID))
+    for key, value in filters.items():
+        if hasattr(VTicketMasterExpanded, key):
+            count_query = count_query.filter(
+                getattr(VTicketMasterExpanded, key) == value
+            )
+    total = await db.scalar(count_query) or 0
 
     ticket_out = [TicketExpandedOut.from_orm(t) for t in items]
     return PaginatedResponse[TicketExpandedOut](items=ticket_out, total=total, skip=skip, limit=limit)
@@ -117,10 +137,30 @@ async def api_list_tickets(
     response_model_by_alias=False,
 )
 async def api_list_tickets_expanded(
-    skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
+    request: Request,
+    skip: int = 0,
+    limit: int = 10,
+    db: AsyncSession = Depends(get_db),
 ) -> PaginatedResponse[TicketExpandedOut]:
-    items = await list_tickets_expanded(db, skip, limit)
-    total = await db.scalar(select(func.count(VTicketMasterExpanded.Ticket_ID))) or 0
+    params = request.query_params
+    filters = {
+        k: v
+        for k, v in params.items()
+        if k not in {"skip", "limit", "sort"}
+    }
+    sort = params.getlist("sort") or None
+
+    items = await list_tickets_expanded(
+        db, skip, limit, filters=filters or None, sort=sort
+    )
+
+    count_query = select(func.count(VTicketMasterExpanded.Ticket_ID))
+    for key, value in filters.items():
+        if hasattr(VTicketMasterExpanded, key):
+            count_query = count_query.filter(
+                getattr(VTicketMasterExpanded, key) == value
+            )
+    total = await db.scalar(count_query) or 0
 
     ticket_out = [TicketExpandedOut.from_orm(t) for t in items]
     return PaginatedResponse[TicketExpandedOut](


### PR DESCRIPTION
## Summary
- expand `/tickets` and `/tickets/expanded` to accept filtering and sorting
- allow `list_tickets_expanded` to build dynamic queries
- document new parameters in README
- add tests for filtering and sorting

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866da4b5228832bb1a54915a9ee7d10