### PR TITLE
Improve analytics queries with status/site labels

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -49,6 +49,7 @@ from schemas.ticket import (
 from schemas.oncall import OnCallShiftOut
 
 from schemas.paginated import PaginatedResponse
+from schemas.analytics import StatusCount, SiteOpenCount
 from db.models import (
     Ticket,
     VTicketMasterExpanded,
@@ -259,19 +260,25 @@ async def api_ai_suggest_response(
 
 # Analysis endpoints
 
-@router.get("/analytics/status")
+@router.get("/analytics/status", response_model=list[StatusCount])
 async def api_tickets_by_status(
     db: AsyncSession = Depends(get_db),
-) -> list[tuple[int | None, int]]:
+) -> list[StatusCount]:
 
-    return await tickets_by_status(db)
+    return [
+        StatusCount(status_id=sid, status_label=label, count=count)
+        for sid, label, count in await tickets_by_status(db)
+    ]
 
-@router.get("/analytics/open_by_site")
+@router.get("/analytics/open_by_site", response_model=list[SiteOpenCount])
 async def api_open_tickets_by_site(
     db: AsyncSession = Depends(get_db),
-) -> list[tuple[int | None, int]]:
+) -> list[SiteOpenCount]:
 
-    return await open_tickets_by_site(db)
+    return [
+        SiteOpenCount(site_id=sid, site_label=label, count=count)
+        for sid, label, count in await open_tickets_by_site(db)
+    ]
 
 @router.get("/analytics/sla_breaches")
 async def api_sla_breaches(

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,0 +1,4 @@
+from .ticket import TicketCreate, TicketUpdate, TicketIn, TicketOut, TicketExpandedOut
+from .oncall import OnCallShiftOut
+from .paginated import PaginatedResponse
+from .analytics import StatusCount, SiteOpenCount

--- a/schemas/analytics.py
+++ b/schemas/analytics.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class StatusCount(BaseModel):
+    status_id: Optional[int]
+    status_label: Optional[str]
+    count: int
+
+class SiteOpenCount(BaseModel):
+    site_id: Optional[int]
+    site_label: Optional[str]
+    count: int

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -56,8 +56,9 @@ async def test_analytics_status(client: AsyncClient):
 
     resp = await client.get("/analytics/status")
     assert resp.status_code == 200
-    data = {item[0]: item[1] for item in resp.json()}
+    data = {item["status_id"]: item["count"] for item in resp.json()}
     assert data == {1: 2, 2: 1}
+    assert all("status_label" in item for item in resp.json())
 
 @pytest.mark.asyncio
 async def test_analytics_open_by_site(client: AsyncClient):
@@ -68,8 +69,9 @@ async def test_analytics_open_by_site(client: AsyncClient):
 
     resp = await client.get("/analytics/open_by_site")
     assert resp.status_code == 200
-    data = {item[0]: item[1] for item in resp.json()}
+    data = {item["site_id"]: item["count"] for item in resp.json()}
     assert data == {1: 2, 2: 1}
+    assert all("site_label" in item for item in resp.json())
 
 @pytest.mark.asyncio
 async def test_analytics_sla_breaches(client: AsyncClient):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -29,7 +29,7 @@ async def _search_worker():
 async def _analytics_worker():
     async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
         resp = await ac.get("/analytics/status")
-        return resp.json()[0][1]
+        return resp.json()[0]["count"]
 
 
 import pytest


### PR DESCRIPTION
## Summary
- join TicketStatus and Site tables when counting tickets
- expose new `StatusCount` and `SiteOpenCount` schemas
- update analytics API endpoints to return labeled counts
- update tests expecting new response format

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e1f26de4832b9a8597b5724a429b