### PR TITLE
Fix email validator

### DIFF
--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -20,10 +20,12 @@ class TicketBase(BaseModel):
     Assigned_Vendor_ID: Optional[int] = None
     Resolution: Optional[Annotated[str, Field(max_length=2000)]] = None
 
-    @validator("Ticket_Contact_Email", "Assigned_Email")
+    @validator("Ticket_Contact_Email", "Assigned_Email", pre=True)
     def validate_emails(cls, v):
         if v is None:
-            return v
+            return None
+        if isinstance(v, str) and (v == "" or v.lower() == "null"):
+            return None
         try:
             return validate_email(v, check_deliverability=False).email
         except EmailNotValidError as e:
@@ -81,10 +83,12 @@ class TicketIn(BaseModel):
     Assigned_Vendor_ID: Optional[int] = None
     Resolution: Optional[Annotated[str, Field(max_length=2000)]] = None
 
-    @validator("Ticket_Contact_Email", "Assigned_Email")
+    @validator("Ticket_Contact_Email", "Assigned_Email", pre=True)
     def validate_emails(cls, v):
         if v is None:
-            return v
+            return None
+        if isinstance(v, str) and (v == "" or v.lower() == "null"):
+            return None
         try:
             return validate_email(v, check_deliverability=False).email
         except EmailNotValidError as e:

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -3,6 +3,7 @@ from httpx import AsyncClient
 import pytest_asyncio
 from main import app
 from db.mssql import engine
+from db.models import VTicketMasterExpanded
 
 CREATE_VIEW_SQL = """
 CREATE VIEW IF NOT EXISTS V_Ticket_Master_Expanded AS
@@ -145,3 +146,16 @@ async def test_ticket_sorting(client: AsyncClient):
     assert resp.status_code == 200
     data = resp.json()
     assert data["items"][0]["Ticket_ID"] == second.json()["Ticket_ID"]
+
+
+def test_ticket_expanded_from_orm_blank_assigned_email():
+    ticket = VTicketMasterExpanded(
+        Ticket_ID=1,
+        Subject="s",
+        Ticket_Body="b",
+        Ticket_Contact_Name="n",
+        Ticket_Contact_Email="c@example.com",
+        Assigned_Email="",
+    )
+    obj = TicketExpandedOut.from_orm(ticket)
+    assert obj.Assigned_Email is None


### PR DESCRIPTION
## Summary
- allow blank or 'null' strings for optional emails
- ensure email validators run in pre mode
- test that blank Assigned_Email passes `from_orm`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e7690938832b8a9a7df74137b280