### PR TITLE
Add Docker config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.log
+*.sqlite
+.env
+.git
+.gitignore
+.venv
+*.egg-info
+*.pytest_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.12-slim
+
+# Install MS ODBC drivers and build tools
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl gnupg2 apt-transport-https \
+    && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update \
+    && ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY . .
+
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -136,3 +136,17 @@ LEFT JOIN Priorities p ON p.ID = t.Priority_ID;
 - `GET /tickets/search?q=term` - search tickets by subject or body
 - `PUT /ticket/{id}` - update an existing ticket
 - `DELETE /ticket/{id}` - remove a ticket
+
+## Docker
+
+Build the image and start the stack with Docker Compose:
+
+```bash
+docker compose build
+docker compose up
+```
+
+The API listens on `http://localhost:8000`. The compose file reads environment
+values from `.env`. `DB_CONN_STRING` is set automatically to connect to the
+`postgres` container using the provided `POSTGRES_USER`, `POSTGRES_PASSWORD`, and
+`POSTGRES_DB` values.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:16
+    env_file: .env
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - demo
+
+  helpdesk-api:
+    build: .
+    env_file: .env
+    depends_on:
+      - postgres
+    networks: ['demo']
+    ports:
+      - "8000:8000"
+    environment:
+      DB_CONN_STRING: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${POSTGRES_DB}
+
+volumes:
+  postgres-data:
+
+networks:
+  demo:


### PR DESCRIPTION
## Summary
- add Dockerfile to run the API
- ignore development files in `.dockerignore`
- add docker-compose with postgres and helpdesk-api services
- document Docker usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866f18637b4832b92d6c012f99d4ba9