### PR TITLE
Upgrade Pydantic for fastmcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
   Optional Microsoft Graph credentials enable real user lookups:
 
    - `GRAPH_CLIENT_ID` – application (client) ID issued by Azure AD.
-   - `GRAPH_CLIENT_SECRET` – client secret associated with the app registration.
-   - `GRAPH_TENANT_ID` – tenant ID used when acquiring OAuth tokens.
+  - `GRAPH_CLIENT_SECRET` – client secret associated with the app registration.
+  - `GRAPH_TENANT_ID` – tenant ID used when acquiring OAuth tokens.
+  - `MCP_URL` – optional FastMCP server URL used by AI helper functions
+    (default `http://localhost:8080`).
 
   When these variables are not provided, the Graph helper functions fall back
   to stub implementations so tests can run without network access.

--- a/ai/mcp_agent.py
+++ b/ai/mcp_agent.py
@@ -1,0 +1,38 @@
+import logging
+import os
+from typing import Any, Dict
+
+from fastmcp import Client
+
+MCP_URL = os.getenv("MCP_URL", "http://localhost:8080")
+
+logger = logging.getLogger(__name__)
+
+_client: Client | None = None
+
+
+def _get_client() -> Client:
+    global _client
+    if _client is None:
+        _client = Client(MCP_URL)
+    return _client
+
+
+async def suggest_ticket_response(ticket: Dict[str, Any], context: str = "") -> str:
+    client = _get_client()
+    async with client:
+        try:
+            result = await client.call_tool(
+                "suggest_ticket_response",
+                {"ticket": ticket, "context": context},
+            )
+            if result.data is not None:
+                return str(result.data)
+            if result.content:
+                from fastmcp.utilities.types import TextContent
+                for block in result.content:
+                    if isinstance(block, TextContent):
+                        return block.text
+        except Exception:
+            logger.exception("FastMCP request failed")
+    return ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 fastapi==0.110.0
 uvicorn==0.35.0
 sqlalchemy==2.0.41
-pydantic==1.10.15
+pydantic==2.11.7
+fastmcp==2.10.1
 python-dotenv==1.1.1
 pytest==8.4.1
 pytest-asyncio==0.23.6

--- a/schemas/basic.py
+++ b/schemas/basic.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from datetime import datetime
 
 
@@ -6,40 +6,35 @@ class AssetOut(BaseModel):
     ID: int
     Label: str
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class VendorOut(BaseModel):
     ID: int
     Name: str
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class SiteOut(BaseModel):
     ID: int
     Label: str
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class TicketCategoryOut(BaseModel):
     ID: int
     Label: str
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class TicketStatusOut(BaseModel):
     ID: int
     Label: str
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class TicketAttachmentOut(BaseModel):
@@ -49,8 +44,7 @@ class TicketAttachmentOut(BaseModel):
     WebURl: str
     UploadDateTime: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class TicketMessageOut(BaseModel):
@@ -61,5 +55,4 @@ class TicketMessageOut(BaseModel):
     SenderUserName: str
     DateTimeStamp: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/schemas/oncall.py
+++ b/schemas/oncall.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, ConfigDict
 from datetime import datetime
 
 
@@ -11,5 +11,4 @@ class OnCallShiftBase(BaseModel):
 class OnCallShiftOut(OnCallShiftBase):
     id: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr, Field, validator
+from pydantic import BaseModel, EmailStr, Field, field_validator, ConfigDict
 from typing import Annotated
 from email_validator import validate_email, EmailNotValidError
 from typing import Optional
@@ -20,7 +20,7 @@ class TicketBase(BaseModel):
     Assigned_Vendor_ID: Optional[int] = None
     Resolution: Optional[Annotated[str, Field(max_length=2000)]] = None
 
-    @validator("Ticket_Contact_Email", "Assigned_Email", pre=True)
+    @field_validator("Ticket_Contact_Email", "Assigned_Email", mode="before")
     def validate_emails(cls, v):
         if v is None:
             return None
@@ -35,8 +35,8 @@ class TicketBase(BaseModel):
 class TicketCreate(TicketBase):
     """Schema used when creating a new ticket."""
 
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "Subject": "Printer not working",
                 "Ticket_Body": "The office printer is jammed",
@@ -44,6 +44,7 @@ class TicketCreate(TicketBase):
                 "Ticket_Contact_Email": "jane@example.com",
             }
         }
+    )
 
 
 class TicketUpdate(BaseModel):
@@ -63,8 +64,7 @@ class TicketUpdate(BaseModel):
     Assigned_Vendor_ID: Optional[int] = None
     Resolution: Optional[str] = None
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class TicketIn(BaseModel):
@@ -83,7 +83,7 @@ class TicketIn(BaseModel):
     Assigned_Vendor_ID: Optional[int] = None
     Resolution: Optional[Annotated[str, Field(max_length=2000)]] = None
 
-    @validator("Ticket_Contact_Email", "Assigned_Email", pre=True)
+    @field_validator("Ticket_Contact_Email", "Assigned_Email", mode="before")
     def validate_emails(cls, v):
         if v is None:
             return None
@@ -98,9 +98,9 @@ class TicketIn(BaseModel):
 class TicketOut(TicketIn):
     Ticket_ID: int
 
-    class Config:
-        orm_mode = True
-        schema_extra = {
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
             "example": {
                 "Ticket_ID": 1,
                 "Subject": "Printer not working",
@@ -110,7 +110,8 @@ class TicketOut(TicketIn):
                 "Ticket_Contact_Email": "jane@example.com",
                 "Created_Date": "2024-01-01T12:00:00Z",
             }
-        }
+        },
+    )
 
 
 
@@ -127,6 +128,4 @@ class TicketExpandedOut(TicketOut):
     Assigned_Vendor_Name: Optional[str] = None
     Priority_Level: Optional[str] = None
 
-    class Config:
-        orm_mode = True
-        allow_population_by_field_name = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime, timedelta, UTC
 
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from main import app
 from db.models import Ticket
 from db.mssql import SessionLocal
@@ -28,7 +28,8 @@ async def fake_create(*args, **kwargs):
 
 @pytest_asyncio.fixture
 async def client():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
 
 async def _add_ticket(**kwargs):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -4,6 +4,7 @@ from db.mssql import SessionLocal
 from tools.ticket_tools import create_ticket
 import asyncio
 import httpx
+from httpx import ASGITransport
 from main import app
 
 
@@ -21,13 +22,15 @@ async def _add_sample_ticket():
 
 
 async def _search_worker():
-    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/tickets/search", params={"q": "Net"})
         return resp.json()[0]["Subject"]
 
 
 async def _analytics_worker():
-    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/analytics/status")
         return resp.json()[0]["count"]
 

--- a/tests/test_oncall.py
+++ b/tests/test_oncall.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from datetime import datetime, timedelta, UTC
 
 from main import app
@@ -35,7 +35,8 @@ async def test_get_current_oncall_route():
     now = datetime.now(UTC)
     await _add_shift("active@example.com", now - timedelta(minutes=30), now + timedelta(minutes=30))
 
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/oncall")
         assert resp.status_code == 200
         data = resp.json()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from main import app
 from db.models import Asset, Vendor, Site
 from db.mssql import SessionLocal
@@ -10,7 +10,8 @@ import pytest_asyncio
 
 @pytest_asyncio.fixture
 async def client():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
 
 

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 import pytest_asyncio
 from main import app
 from db.mssql import engine
@@ -54,7 +54,8 @@ async def expanded_view(db_setup):
 
 @pytest_asyncio.fixture
 async def client():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
 
 

--- a/tools/ai_tools.py
+++ b/tools/ai_tools.py
@@ -1,12 +1,14 @@
-
 from typing import Any, Dict
-
+import os
 import logging
-from ai.openai_agent import suggest_ticket_response
+
+from ai.mcp_agent import suggest_ticket_response as mcp_suggest_response
 
 logger = logging.getLogger(__name__)
 
 
 async def ai_suggest_response(ticket: Dict[str, Any], context: str = "") -> str:
-
-    return await suggest_ticket_response(ticket, context)
+    if os.getenv("OPENAI_API_KEY"):
+        from ai.openai_agent import suggest_ticket_response as openai_suggest_response
+        return await openai_suggest_response(ticket, context)
+    return await mcp_suggest_response(ticket, context)


### PR DESCRIPTION
## Summary
- add `fastmcp` to requirements and bump to `pydantic` 2
- adjust models to use Pydantic v2 configuration and validators
- add `mcp_agent` for FastMCP support
- lazily import OpenAI helper in `ai_tools`
- update tests to use `ASGITransport`
- document optional `MCP_URL` env var

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686758052034832b921fec15f89376f1