### PR TITLE
Wrap AI stream response as SSE

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -331,7 +331,7 @@ async def api_ai_suggest_response_stream(
 
     async def _generate() -> AsyncGenerator[str, None]:
         async for chunk in ai_stream_response(ticket.dict(), context):
-            yield chunk
+            yield f"data: {chunk}\n\n"
 
     return StreamingResponse(_generate(), media_type="text/event-stream")
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -35,4 +35,10 @@ async def test_ai_suggest_response_stream(client, monkeypatch):
         assert resp.status_code == 200
         chunks = [chunk async for chunk in resp.aiter_text()]
 
-    assert "part1part2" == "".join(chunks)
+    # verify SSE framing and plain text reconstruction
+    all_text = "".join(chunks)
+    lines = [line for line in all_text.splitlines() if line.startswith("data:")]
+    assert lines
+    assert all(line.startswith("data:") for line in lines)
+    text = "".join(line.removeprefix("data:").strip() for line in lines)
+    assert text == "part1part2"


### PR DESCRIPTION
## Summary
- stream AI suggestions as Server-Sent Events
- check SSE framing in stream tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ddb77660832b989183b03d029d94