### PR TITLE
Add CLI tool for streaming responses and ticket creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,25 @@ LEFT JOIN Priorities p ON p.ID = t.Priority_ID;
 - `POST /ai/suggest_response/stream` - stream an AI reply as it is generated
 
 
+## CLI
+
+`tools.cli` provides a small command-line interface to the API. Set `API_BASE_URL` to the server URL (default `http://localhost:8000`).
+
+Stream an AI-generated response:
+
+```bash
+echo '{"Ticket_ID":1,"Subject":"Subj","Ticket_Body":"Body","Ticket_Status_ID":1,"Ticket_Contact_Name":"Name","Ticket_Contact_Email":"a@example.com"}' | \
+python -m tools.cli stream-response
+```
+
+Create a ticket:
+
+```bash
+echo '{"Subject":"Subj","Ticket_Body":"Body","Ticket_Contact_Name":"Name","Ticket_Contact_Email":"a@example.com"}' | \
+python -m tools.cli create-ticket
+```
+
+
 ## Docker
 
 Build the image and start the stack with Docker Compose:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,67 @@
+import argparse
+import io
+import json
+import os
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from main import app
+
+import tools.cli as cli
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+def cli_setup(monkeypatch):
+    transport = ASGITransport(app=app)
+
+    def _client(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        kwargs.setdefault("base_url", "http://test")
+        return AsyncClient(**kwargs)
+
+    monkeypatch.setenv("API_BASE_URL", "http://test")
+    monkeypatch.setattr(cli.httpx, "AsyncClient", _client)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_cli(cli_setup, capsys, monkeypatch):
+    payload = {
+        "Subject": "CLI test",
+        "Ticket_Body": "Body",
+        "Ticket_Contact_Name": "Tester",
+        "Ticket_Contact_Email": "t@example.com",
+    }
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps(payload)))
+    await cli.create_ticket(argparse.Namespace())
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["Subject"] == "CLI test"
+    assert "Ticket_ID" in data
+
+
+@pytest.mark.asyncio
+async def test_stream_response_cli(cli_setup, capsys, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    async def dummy_stream(ticket, context=""):
+        yield "part1"
+        yield "part2"
+
+    monkeypatch.setattr("tools.ai_tools.ai_stream_response", dummy_stream)
+    monkeypatch.setattr("api.routes.ai_stream_response", dummy_stream)
+
+    ticket = {
+        "Ticket_ID": 1,
+        "Subject": "Subj",
+        "Ticket_Body": "Body",
+        "Ticket_Status_ID": 1,
+        "Ticket_Contact_Name": "Name",
+        "Ticket_Contact_Email": "a@example.com",
+    }
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps(ticket)))
+    await cli.stream_response(argparse.Namespace())
+    out = capsys.readouterr().out
+    assert out == "part1part2"

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -1,0 +1,56 @@
+import argparse
+import asyncio
+import json
+import os
+import sys
+
+import httpx
+
+
+API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000")
+
+
+async def stream_response(_args: argparse.Namespace) -> None:
+    """Read a ticket from STDIN and stream the AI response to STDOUT."""
+    ticket = json.load(sys.stdin)
+
+    async with httpx.AsyncClient(base_url=API_BASE_URL) as client:
+        async with client.stream("POST", "/ai/suggest_response/stream", json=ticket) as resp:
+            resp.raise_for_status()
+            async for chunk in resp.aiter_text():
+                sys.stdout.write(chunk)
+                sys.stdout.flush()
+
+
+async def create_ticket(_args: argparse.Namespace) -> None:
+    """Read JSON from STDIN and post to /ticket."""
+    payload = json.load(sys.stdin)
+
+    async with httpx.AsyncClient(base_url=API_BASE_URL) as client:
+        resp = await client.post("/ticket", json=payload)
+        resp.raise_for_status()
+        sys.stdout.write(resp.text)
+        sys.stdout.flush()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="HelpDesk API CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("stream-response", help="Stream AI ticket response")
+    p.set_defaults(func=stream_response)
+
+    p = sub.add_parser("create-ticket", help="Create a helpdesk ticket")
+    p.set_defaults(func=create_ticket)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    asyncio.run(args.func(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `tools/cli.py` providing `stream-response` and `create-ticket`
- add tests for the CLI using ASGITransport
- document CLI usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ddb7b4f8832b989aead7b12fca46