### PR TITLE
Fix tests by removing API key env setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import os
 # Pydantic 1.x fails on Python 3.12 unless this shim is disabled
 os.environ.setdefault("PYDANTIC_DISABLE_STD_TYPES_SHIM", "1")
 
-os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")
 
 import db.mssql as mssql

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -8,7 +8,6 @@ from db.models import Ticket
 from db.mssql import SessionLocal
 from tools.ticket_tools import create_ticket
 
-os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,6 @@
 import os
 
 # Provide defaults so importing the app doesn't fail
-os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")
 
 from main import app

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -14,7 +14,6 @@ async def client():
 
 @pytest.mark.asyncio
 async def test_ai_suggest_response_stream(client, monkeypatch):
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     async def dummy_stream(ticket, context=""):
         yield "part1"
         yield "part2"


### PR DESCRIPTION
## Summary
- clean up test environment variables for `OPENAI_API_KEY`
- drop OPENAI key cleanup in stream test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ded8a340832bbe80970e2a1f4110