### PR TITLE
Fix CLI streaming to handle SSE once

### DIFF
--- a/tools/cli.py
+++ b/tools/cli.py
@@ -21,12 +21,6 @@ async def stream_response(_args: argparse.Namespace) -> None:
         async with client.stream("POST", "/ai/suggest_response/stream", json=ticket) as resp:
             resp.raise_for_status()
 
-            async for chunk in resp.aiter_text():
-                for line in chunk.splitlines():
-                    if line.startswith("data:"):
-                        sys.stdout.write(line.removeprefix("data:").strip())
-                        sys.stdout.flush()
-
             async for event in EventSource(resp).aiter_sse():
                 sys.stdout.write(event.data)
                 sys.stdout.flush()


### PR DESCRIPTION
## Summary
- fix event stream iteration in `stream_response`
- ensure SSE body is consumed only once by removing duplicate loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e9d1b16c832b9e6ebd59c2b3c625