### PR TITLE
Centralize expanded view SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ related labels such as status, asset, site, and vendor. Endpoints like
 `/tickets/expanded` and `/tickets/search` rely on this view to return a
 fully populated ticket record.
 
-Create the view with SQL similar to the following:
+Create the view with SQL similar to the following (the full statement is also
+available in `db/sql.py` as `CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL`):
 
 
 ```sql

--- a/alembic/versions/2e80bc0ee0ea_create_expanded_ticket_view.py
+++ b/alembic/versions/2e80bc0ee0ea_create_expanded_ticket_view.py
@@ -8,6 +8,7 @@ Create Date: 2025-07-03 04:12:26.131518
 from typing import Sequence, Union
 
 from alembic import op
+from db.sql import CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL
 
 
 # revision identifiers, used by Alembic.
@@ -17,37 +18,7 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-CREATE_VIEW_SQL = """
-CREATE VIEW V_Ticket_Master_Expanded AS
-SELECT t.Ticket_ID,
-       t.Subject,
-       t.Ticket_Body,
-       t.Ticket_Status_ID,
-       ts.Label AS Ticket_Status_Label,
-       t.Ticket_Contact_Name,
-       t.Ticket_Contact_Email,
-       t.Asset_ID,
-       a.Label AS Asset_Label,
-       t.Site_ID,
-       s.Label AS Site_Label,
-       t.Ticket_Category_ID,
-       c.Label AS Ticket_Category_Label,
-       t.Created_Date,
-       t.Assigned_Name,
-       t.Assigned_Email,
-       t.Priority_ID,
-       t.Assigned_Vendor_ID,
-       v.Name AS Assigned_Vendor_Name,
-       t.Resolution,
-       p.Level AS Priority_Level
-FROM Tickets_Master t
-LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
-LEFT JOIN Assets a ON a.ID = t.Asset_ID
-LEFT JOIN Sites s ON s.ID = t.Site_ID
-LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
-LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID
-LEFT JOIN Priorities p ON p.ID = t.Priority_ID
-"""
+CREATE_VIEW_SQL = CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL
 
 
 def upgrade() -> None:

--- a/db/sql.py
+++ b/db/sql.py
@@ -1,0 +1,31 @@
+CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL = """
+CREATE VIEW V_Ticket_Master_Expanded AS
+SELECT t.Ticket_ID,
+       t.Subject,
+       t.Ticket_Body,
+       t.Ticket_Status_ID,
+       ts.Label AS Ticket_Status_Label,
+       t.Ticket_Contact_Name,
+       t.Ticket_Contact_Email,
+       t.Asset_ID,
+       a.Label AS Asset_Label,
+       t.Site_ID,
+       s.Label AS Site_Label,
+       t.Ticket_Category_ID,
+       c.Label AS Ticket_Category_Label,
+       t.Created_Date,
+       t.Assigned_Name,
+       t.Assigned_Email,
+       t.Priority_ID,
+       t.Assigned_Vendor_ID,
+       v.Name AS Assigned_Vendor_Name,
+       t.Resolution,
+       p.Level AS Priority_Level
+FROM Tickets_Master t
+LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
+LEFT JOIN Assets a ON a.ID = t.Asset_ID
+LEFT JOIN Sites s ON s.ID = t.Site_ID
+LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
+LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID
+LEFT JOIN Priorities p ON p.ID = t.Priority_ID
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.pool import StaticPool
 from db.models import Base
 from sqlalchemy import text
+from db.sql import CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL
 import pytest_asyncio
 
 # Use a StaticPool so the in-memory DB is shared across threads
@@ -34,39 +35,7 @@ async def db_setup():
         await conn.execute(text("DROP VIEW IF EXISTS V_Ticket_Master_Expanded"))
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
-        await conn.execute(text(
-            """
-            CREATE VIEW V_Ticket_Master_Expanded AS
-            SELECT t.Ticket_ID,
-                   t.Subject,
-                   t.Ticket_Body,
-                   t.Ticket_Status_ID,
-                   ts.Label AS Ticket_Status_Label,
-                   t.Ticket_Contact_Name,
-                   t.Ticket_Contact_Email,
-                   t.Asset_ID,
-                   a.Label AS Asset_Label,
-                   t.Site_ID,
-                   s.Label AS Site_Label,
-                   t.Ticket_Category_ID,
-                   c.Label AS Ticket_Category_Label,
-                   t.Created_Date,
-                   t.Assigned_Name,
-                   t.Assigned_Email,
-                   t.Priority_ID,
-                   t.Assigned_Vendor_ID,
-                   v.Name AS Assigned_Vendor_Name,
-                   t.Resolution,
-                   p.Level AS Priority_Level
-            FROM Tickets_Master t
-            LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
-            LEFT JOIN Assets a ON a.ID = t.Asset_ID
-            LEFT JOIN Sites s ON s.ID = t.Site_ID
-            LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
-            LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID
-            LEFT JOIN Priorities p ON p.ID = t.Priority_ID
-            """
-        ))
+        await conn.execute(text(CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL))
     yield
     async with mssql.engine.begin() as conn:
         await conn.execute(text("DROP VIEW IF EXISTS V_Ticket_Master_Expanded"))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,6 +5,7 @@ from db.models import Base, Ticket
 from db.mssql import engine, SessionLocal
 from datetime import datetime, UTC
 from tools.ticket_tools import create_ticket, search_tickets_expanded
+from db.sql import CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL
 
 os.environ.setdefault("DB_CONN_STRING", "sqlite+aiosqlite:///:memory:")
 
@@ -13,39 +14,7 @@ async def _setup_models():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
         await conn.exec_driver_sql("DROP VIEW IF EXISTS V_Ticket_Master_Expanded")
-        await conn.exec_driver_sql(
-            """
-            CREATE VIEW V_Ticket_Master_Expanded AS
-            SELECT t.Ticket_ID,
-                   t.Subject,
-                   t.Ticket_Body,
-                   t.Ticket_Status_ID,
-                   ts.Label AS Ticket_Status_Label,
-                   t.Ticket_Contact_Name,
-                   t.Ticket_Contact_Email,
-                   t.Asset_ID,
-                   a.Label AS Asset_Label,
-                   t.Site_ID,
-                   s.Label AS Site_Label,
-                   t.Ticket_Category_ID,
-                   c.Label AS Ticket_Category_Label,
-                   t.Created_Date,
-                   t.Assigned_Name,
-                   t.Assigned_Email,
-                   t.Priority_ID,
-                   t.Assigned_Vendor_ID,
-                   v.Name AS Assigned_Vendor_Name,
-                   t.Resolution,
-                   p.Level AS Priority_Level
-            FROM Tickets_Master t
-            LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
-            LEFT JOIN Assets a ON a.ID = t.Asset_ID
-            LEFT JOIN Sites s ON s.ID = t.Site_ID
-            LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
-            LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID
-            LEFT JOIN Priorities p ON p.ID = t.Priority_ID
-            """
-        )
+        await conn.exec_driver_sql(CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL)
 
 asyncio.get_event_loop().run_until_complete(_setup_models())
 

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -4,38 +4,7 @@ import pytest_asyncio
 from main import app
 from db.mssql import engine
 from db.models import VTicketMasterExpanded
-
-CREATE_VIEW_SQL = """
-CREATE VIEW IF NOT EXISTS V_Ticket_Master_Expanded AS
-SELECT t.Ticket_ID,
-       t.Subject,
-       t.Ticket_Body,
-       t.Ticket_Status_ID,
-       ts.Label AS Ticket_Status_Label,
-       t.Ticket_Contact_Name,
-       t.Ticket_Contact_Email,
-       t.Asset_ID,
-       a.Label AS Asset_Label,
-       t.Site_ID,
-       s.Label AS Site_Label,
-       t.Ticket_Category_ID,
-       c.Label AS Ticket_Category_Label,
-       t.Created_Date,
-       t.Assigned_Name,
-       t.Assigned_Email,
-       t.Priority_ID,
-       t.Assigned_Vendor_ID,
-       v.Name AS Assigned_Vendor_Name,
-       t.Resolution,
-       p.Level AS Priority_Level
-FROM Tickets_Master t
-LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
-LEFT JOIN Assets a ON a.ID = t.Asset_ID
-LEFT JOIN Sites s ON s.ID = t.Site_ID
-LEFT JOIN Ticket_Categories c ON c.ID = t.Ticket_Category_ID
-LEFT JOIN Vendors v ON v.ID = t.Assigned_Vendor_ID
-LEFT JOIN Priorities p ON p.ID = t.Priority_ID
-"""
+from db.sql import CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL as CREATE_VIEW_SQL
 
 DROP_VIEW_SQL = "DROP VIEW IF EXISTS V_Ticket_Master_Expanded"
 


### PR DESCRIPTION
## Summary
- add `db/sql.py` with the CREATE VIEW statement
- import the constant from tests and alembic migration
- mention the constant in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: httpx.StreamConsumed)*

------
https://chatgpt.com/codex/tasks/task_e_6867e9d3d508832b856e930159b09620