### PR TITLE
Fix tool docstrings

### DIFF
--- a/tools/asset_tools.py
+++ b/tools/asset_tools.py
@@ -1,7 +1,4 @@
-
-"""Helpers for retrieving and listing asset records from the database."""
-
-"""Database helpers for reading asset information."""
+"""Database helpers for retrieving and listing asset information."""
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select

--- a/tools/vendor_tools.py
+++ b/tools/vendor_tools.py
@@ -1,8 +1,4 @@
-
-"""Helpers for retrieving and listing vendor records from the database."""
-
-"""Helpers for listing vendor records."""
-
+"""Database helpers for retrieving and listing vendor information."""
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select


### PR DESCRIPTION
## Summary
- fix redundant docstrings in asset_tools/vendor_tools
- ensure module-level docs have no preceding blank lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ec9483bc832bac0157e299456d29