### PR TITLE
Fix Docker port setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application source
 COPY . .
 
-EXPOSE 8000
+EXPOSE 8008
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8008"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "8008:8008"
     # (Optional) healthcheck on your SQL Server connectivity:
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8008/health"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- ensure `Dockerfile` exposes the same port that Uvicorn uses
- point Docker Compose healthcheck to the right port

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ec94f160832b964a6c8932378e7e