### PR TITLE
Add FastAPI MCP integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 
 from fastapi import FastAPI, Request, Depends
+from fastapi_mcp import FastApiMCP
 
 import logging
 
@@ -36,6 +37,10 @@ app.add_exception_handler(
 )
 app.add_middleware(SlowAPIMiddleware)
 app.include_router(router)
+
+# Expose API operations via MCP
+app.state.mcp = FastApiMCP(app)
+app.state.mcp.mount()
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "sqlalchemy==2.0.41",
     "pydantic==2.11.7",
     "fastmcp==2.10.1",
+    "fastapi-mcp==0.3.4",
     "python-dotenv==1.1.1",
     "pytest==8.4.1",
     "pytest-asyncio==0.23.6",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn==0.35.0
 sqlalchemy==2.0.41
 pydantic==2.11.7
 fastmcp==2.10.1
+fastapi-mcp==0.3.4
 python-dotenv==1.1.1
 pytest==8.4.1
 pytest-asyncio==0.23.6


### PR DESCRIPTION
## Summary
- add `fastapi-mcp` dependency
- expose `/mcp` and `/mcp/messages/` via `FastApiMCP`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686866b74344832b82b763dadcdefc3b