### PR TITLE
Add MCP SSE endpoint and test

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 
-from fastapi import FastAPI, Request, Depends
+from fastapi import FastAPI, Request, Depends, Response
 
 import logging
 
@@ -7,7 +7,7 @@ import logging
 logging.basicConfig(level=logging.INFO)
 
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from sqlalchemy import text
 
@@ -19,6 +19,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from limiter import limiter
 
 from datetime import datetime, UTC
+import uuid
+import asyncio
+import json
+import typing
 
 # Application version
 APP_VERSION = "0.1.0"
@@ -84,3 +88,37 @@ async def health(db: AsyncSession = Depends(get_db)) -> dict:
 
     uptime = (datetime.now(UTC) - START_TIME).total_seconds()
     return {"db": db_status, "uptime": uptime, "version": APP_VERSION}
+
+
+# --- Minimal MCP SSE endpoint used for testing ---
+_mcp_sessions: dict[str, asyncio.Queue] = {}
+
+
+@app.get("/mcp")
+async def mcp_stream() -> StreamingResponse:
+    """Establish a Server-Sent Events stream for MCP messages."""
+    session_id = uuid.uuid4().hex
+    post_url = f"/mcp/{session_id}"
+    queue: asyncio.Queue = asyncio.Queue()
+    _mcp_sessions[session_id] = queue
+
+    async def _generate() -> typing.AsyncGenerator[str, None]:
+        yield f"event: endpoint\ndata: {post_url}\n\n"
+        try:
+            while True:
+                data = await queue.get()
+                yield f"event: message\ndata: {json.dumps(data)}\n\n"
+        finally:
+            _mcp_sessions.pop(session_id, None)
+
+    return StreamingResponse(_generate(), media_type="text/event-stream")
+
+
+@app.post("/mcp/{session_id}")
+async def mcp_post(session_id: str, request: Request) -> Response:
+    queue = _mcp_sessions.get(session_id)
+    if not queue:
+        return Response(status_code=404)
+    payload = await request.json()
+    await queue.put(payload)
+    return Response(status_code=202)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,28 @@
+import json
+import asyncio
+import pytest
+from httpx import AsyncClient, ASGITransport
+from httpx_sse import EventSource
+from main import app
+
+@pytest.mark.asyncio
+async def test_mcp_roundtrip():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with client.stream("GET", "/mcp") as resp:
+            assert resp.status_code == 200
+            source = EventSource(resp)
+            events = source.aiter_sse()
+            first = await asyncio.wait_for(anext(events), timeout=1)
+            assert first.event == "endpoint"
+            post_url = first.data
+            assert post_url.startswith("/mcp/")
+
+            payload = {"jsonrpc": "2.0", "id": 1, "result": "pong"}
+            post_resp = await client.post(post_url, json=payload)
+            assert post_resp.status_code == 202
+
+            second = await asyncio.wait_for(anext(events), timeout=1)
+            assert second.event == "message"
+            assert json.loads(second.data) == payload
+            await source.aclose()


### PR DESCRIPTION
## Summary
- implement a minimal `/mcp` SSE endpoint and post handler
- add async test verifying SSE connection and JSON-RPC roundtrip

## Testing
- `pytest tests/test_mcp.py -vv -s` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686866ba68f8832bb519cc0b44c6a05e