### PR TITLE
Add docstrings to API routes

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -101,6 +101,20 @@ class MessageIn(BaseModel):
     response_model_by_alias=False,
 )
 async def api_get_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> TicketExpandedOut:
+    """Retrieve a single ticket with related details.
+
+    Parameters
+    ----------
+    ticket_id : int
+        Identifier of the ticket to fetch.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    TicketExpandedOut
+        Ticket record including joined labels and fields.
+    """
     ticket = await get_ticket_expanded(db, ticket_id)
     if not ticket:
         logger.warning("Ticket %s not found", ticket_id)
@@ -120,6 +134,24 @@ async def api_list_tickets(
     limit: int = 10,
     db: AsyncSession = Depends(get_db),
 ) -> PaginatedResponse[TicketExpandedOut]:
+    """List tickets with optional query filters and pagination.
+
+    Parameters
+    ----------
+    request : Request
+        Incoming request containing query parameters for filtering and sorting.
+    skip : int, optional
+        Number of records to skip from the start.
+    limit : int, optional
+        Maximum number of tickets to return.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    PaginatedResponse[TicketExpandedOut]
+        Paginated ticket results.
+    """
     params = request.query_params
     filters = {
         k: v
@@ -158,6 +190,24 @@ async def api_list_tickets_expanded(
     limit: int = 10,
     db: AsyncSession = Depends(get_db),
 ) -> PaginatedResponse[TicketExpandedOut]:
+    """Return expanded ticket information with pagination.
+
+    Parameters
+    ----------
+    request : Request
+        Request containing filter and sort query parameters.
+    skip : int, optional
+        Number of records to offset the query by.
+    limit : int, optional
+        Maximum number of results to return.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    PaginatedResponse[TicketExpandedOut]
+        Paginated expanded ticket data.
+    """
     params = request.query_params
     filters = {
         k: v
@@ -198,6 +248,22 @@ async def api_search_tickets(
     q: str, limit: int = 10, db: AsyncSession = Depends(get_db)
 
 ) -> list[TicketExpandedOut]:
+    """Search tickets by text and return expanded results.
+
+    Parameters
+    ----------
+    q : str
+        Text to search for in ticket subjects or bodies.
+    limit : int, optional
+        Maximum number of matches to return.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[TicketExpandedOut]
+        Matching tickets in expanded form.
+    """
 
     logger.info("API search tickets query=%s limit=%s", q, limit)
     results = await search_tickets_expanded(db, q, limit)
@@ -207,6 +273,20 @@ async def api_search_tickets(
 async def api_create_ticket(
     ticket: TicketCreate, db: AsyncSession = Depends(get_db)
 ) -> Ticket:
+    """Create a new ticket entry.
+
+    Parameters
+    ----------
+    ticket : TicketCreate
+        Ticket details used to create the record.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    TicketOut
+        The created ticket.
+    """
     obj = Ticket(**ticket.model_dump(), Created_Date=datetime.now(UTC))
     logger.info("API create ticket")
     created = await create_ticket(db, obj)
@@ -216,6 +296,22 @@ async def api_create_ticket(
 async def api_update_ticket(
     ticket_id: int, updates: TicketUpdate, db: AsyncSession = Depends(get_db)
 ) -> Ticket:
+    """Update an existing ticket.
+
+    Parameters
+    ----------
+    ticket_id : int
+        Identifier of the ticket to update.
+    updates : TicketUpdate
+        Fields to modify on the ticket.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    TicketOut
+        The updated ticket record or 404 if not found.
+    """
     ticket = await update_ticket(db, ticket_id, updates)
     if not ticket:
         logger.warning("Ticket %s not found for update", ticket_id)
@@ -225,6 +321,20 @@ async def api_update_ticket(
 
 @router.delete("/ticket/{ticket_id}")
 async def api_delete_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) -> dict:
+    """Delete a ticket by ID.
+
+    Parameters
+    ----------
+    ticket_id : int
+        Identifier of the ticket to remove.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    dict
+        ``{"deleted": True}`` when the ticket is removed.
+    """
     if not await delete_ticket(db, ticket_id):
 
         logger.warning("Ticket %s not found for delete", ticket_id)
@@ -234,6 +344,20 @@ async def api_delete_ticket(ticket_id: int, db: AsyncSession = Depends(get_db)) 
 
 @router.get("/asset/{asset_id}", response_model=AssetOut)
 async def api_get_asset(asset_id: int, db: AsyncSession = Depends(get_db)) -> AssetOut:
+    """Fetch a single asset by its identifier.
+
+    Parameters
+    ----------
+    asset_id : int
+        Identifier of the asset to retrieve.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    AssetOut
+        Asset information.
+    """
 
     asset = await get_asset(db, asset_id)
     if not asset:
@@ -246,11 +370,41 @@ async def api_get_asset(asset_id: int, db: AsyncSession = Depends(get_db)) -> As
 async def api_list_assets(
     skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
 ) -> list[AssetOut]:
+    """Return a list of assets.
+
+    Parameters
+    ----------
+    skip : int, optional
+        Offset into the asset list.
+    limit : int, optional
+        Maximum number of assets to return.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[AssetOut]
+        Requested slice of assets.
+    """
     assets = await list_assets(db, skip, limit)
     return [AssetOut.model_validate(a) for a in assets]
 
 @router.get("/vendor/{vendor_id}", response_model=VendorOut)
 async def api_get_vendor(vendor_id: int, db: AsyncSession = Depends(get_db)) -> VendorOut:
+    """Retrieve a vendor record by ID.
+
+    Parameters
+    ----------
+    vendor_id : int
+        Identifier of the vendor to fetch.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    VendorOut
+        The vendor information.
+    """
 
     vendor = await get_vendor(db, vendor_id)
     if not vendor:
@@ -263,11 +417,41 @@ async def api_get_vendor(vendor_id: int, db: AsyncSession = Depends(get_db)) -> 
 async def api_list_vendors(
     skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
 ) -> list[VendorOut]:
+    """List vendors with pagination.
+
+    Parameters
+    ----------
+    skip : int, optional
+        Offset into the vendor list.
+    limit : int, optional
+        Maximum number of vendors to return.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[VendorOut]
+        Requested slice of vendors.
+    """
     vendors = await list_vendors(db, skip, limit)
     return [VendorOut.model_validate(v) for v in vendors]
 
 @router.get("/site/{site_id}", response_model=SiteOut)
 async def api_get_site(site_id: int, db: AsyncSession = Depends(get_db)) -> SiteOut:
+    """Retrieve a site by ID.
+
+    Parameters
+    ----------
+    site_id : int
+        Identifier of the site to fetch.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    SiteOut
+        The site information.
+    """
 
     site = await get_site(db, site_id)
     if not site:
@@ -280,16 +464,56 @@ async def api_get_site(site_id: int, db: AsyncSession = Depends(get_db)) -> Site
 async def api_list_sites(
     skip: int = 0, limit: int = 10, db: AsyncSession = Depends(get_db)
 ) -> list[SiteOut]:
+    """Return a paginated list of sites.
+
+    Parameters
+    ----------
+    skip : int, optional
+        Offset into the site list.
+    limit : int, optional
+        Maximum number of sites to return.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[SiteOut]
+        Requested slice of sites.
+    """
     sites = await list_sites(db, skip, limit)
     return [SiteOut.model_validate(s) for s in sites]
 
 @router.get("/categories", response_model=List[TicketCategoryOut])
 async def api_list_categories(db: AsyncSession = Depends(get_db)) -> list[TicketCategoryOut]:
+    """List available ticket categories.
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[TicketCategoryOut]
+        Ticket categories ordered by ID.
+    """
     cats = await list_categories(db)
     return [TicketCategoryOut.model_validate(c) for c in cats]
 
 @router.get("/statuses", response_model=List[TicketStatusOut])
 async def api_list_statuses(db: AsyncSession = Depends(get_db)) -> list[TicketStatusOut]:
+    """Return all ticket status values.
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[TicketStatusOut]
+        Available ticket statuses.
+    """
     statuses = await list_statuses(db)
     return [TicketStatusOut.model_validate(s) for s in statuses]
 
@@ -297,6 +521,20 @@ async def api_list_statuses(db: AsyncSession = Depends(get_db)) -> list[TicketSt
 async def api_get_ticket_attachments(
     ticket_id: int, db: AsyncSession = Depends(get_db)
 ) -> list[TicketAttachmentOut]:
+    """Return attachments for a given ticket.
+
+    Parameters
+    ----------
+    ticket_id : int
+        Ticket identifier whose attachments should be listed.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[TicketAttachmentOut]
+        Attachment metadata for the ticket.
+    """
     atts = await get_ticket_attachments(db, ticket_id)
     return [TicketAttachmentOut.model_validate(a) for a in atts]
 
@@ -304,6 +542,20 @@ async def api_get_ticket_attachments(
 async def api_get_ticket_messages(
     ticket_id: int, db: AsyncSession = Depends(get_db)
 ) -> list[TicketMessageOut]:
+    """List messages associated with a ticket.
+
+    Parameters
+    ----------
+    ticket_id : int
+        Identifier of the ticket.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[TicketMessageOut]
+        Messages sorted by timestamp.
+    """
     msgs = await get_ticket_messages(db, ticket_id)
     return [TicketMessageOut.model_validate(m) for m in msgs]
 
@@ -313,6 +565,22 @@ async def api_post_ticket_message(
     msg: MessageIn,
     db: AsyncSession = Depends(get_db),
 ) -> TicketMessageOut:
+    """Post a message to a ticket.
+
+    Parameters
+    ----------
+    ticket_id : int
+        Identifier of the ticket.
+    msg : MessageIn
+        Message body and sender details.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    TicketMessageOut
+        The saved message record.
+    """
     created = await post_ticket_message(
         db, ticket_id, msg.message, msg.sender_code, msg.sender_name
     )
@@ -323,6 +591,22 @@ async def api_post_ticket_message(
 async def api_ai_suggest_response(
     request: Request, ticket: TicketOut, context: str = ""
 ) -> dict:
+    """Return an AI-generated reply suggestion for a ticket.
+
+    Parameters
+    ----------
+    request : Request
+        FastAPI request object used for rate limiting.
+    ticket : TicketOut
+        Ticket data to base the suggestion on.
+    context : str, optional
+        Additional conversation context.
+
+    Returns
+    -------
+    dict
+        ``{"response": str}`` containing the suggested reply text.
+    """
 
     return {"response": await ai_suggest_response(ticket.model_dump(), context)}
 
@@ -332,6 +616,22 @@ async def api_ai_suggest_response(
 async def api_ai_suggest_response_stream(
     request: Request, ticket: TicketOut, context: str = ""
 ) -> StreamingResponse:
+    """Stream an AI-generated reply suggestion for a ticket.
+
+    Parameters
+    ----------
+    request : Request
+        FastAPI request object used for rate limiting.
+    ticket : TicketOut
+        Ticket data used to generate suggestions.
+    context : str, optional
+        Additional conversation context.
+
+    Returns
+    -------
+    StreamingResponse
+        Server-sent events stream with response chunks.
+    """
 
     async def _generate() -> AsyncGenerator[str, None]:
         async for chunk in ai_stream_response(ticket.model_dump(), context):
@@ -345,6 +645,18 @@ async def api_ai_suggest_response_stream(
 async def api_tickets_by_status(
     db: AsyncSession = Depends(get_db),
 ) -> list[StatusCount]:
+    """Count tickets grouped by status.
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[StatusCount]
+        Aggregated counts per status value.
+    """
 
     return [
         StatusCount(status_id=sid, status_label=label, count=count)
@@ -355,6 +667,18 @@ async def api_tickets_by_status(
 async def api_open_tickets_by_site(
     db: AsyncSession = Depends(get_db),
 ) -> list[SiteOpenCount]:
+    """Summarize open tickets per site.
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[SiteOpenCount]
+        Count of open tickets for each site.
+    """
 
     return [
         SiteOpenCount(site_id=sid, site_label=label, count=count)
@@ -365,12 +689,38 @@ async def api_open_tickets_by_site(
 async def api_sla_breaches(
     sla_days: int = 2, db: AsyncSession = Depends(get_db)
 ) -> dict:
+    """Count tickets older than the SLA threshold.
+
+    Parameters
+    ----------
+    sla_days : int, optional
+        Age in days to consider a ticket in breach.
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    dict
+        ``{"breaches": int}`` with the number of tickets exceeding the SLA.
+    """
     return {"breaches": await sla_breaches(db, sla_days)}
 
 @router.get("/analytics/open_by_user")
 async def api_open_tickets_by_user(
     db: AsyncSession = Depends(get_db),
 ) -> list[tuple[str | None, int]]:
+    """List open ticket counts grouped by assigned user.
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[tuple[str | None, int]]
+        Tuples of user email and open ticket count.
+    """
 
     return await open_tickets_by_user(db)
 
@@ -378,9 +728,33 @@ async def api_open_tickets_by_user(
 async def api_tickets_waiting_on_user(
     db: AsyncSession = Depends(get_db),
 ) -> list[tuple[str | None, int]]:
+    """Count tickets waiting for user response.
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    list[tuple[str | None, int]]
+        Tuples of contact email and waiting ticket count.
+    """
 
     return await tickets_waiting_on_user(db)
 
 @router.get("/oncall", response_model=OnCallShiftOut | None)
 async def api_get_oncall(db: AsyncSession = Depends(get_db)) -> Any:
+    """Return the current on-call shift if available.
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Database session dependency.
+
+    Returns
+    -------
+    OnCallShiftOut | None
+        Details of the active on-call user or ``None`` when no shift is active.
+    """
     return await get_current_oncall(db)


### PR DESCRIPTION
## Summary
- document all route handlers in `api/routes.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868741ef5a4832ba47d5b674356b075