### PR TITLE
Improve analysis tool return types

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -61,7 +61,12 @@ from schemas.basic import (
 )
 
 
-from schemas.analytics import StatusCount, SiteOpenCount
+from schemas.analytics import (
+    StatusCount,
+    SiteOpenCount,
+    UserOpenCount,
+    WaitingOnUserCount,
+)
 
 from db.models import (
     Ticket,
@@ -346,20 +351,14 @@ async def api_tickets_by_status(
     db: AsyncSession = Depends(get_db),
 ) -> list[StatusCount]:
 
-    return [
-        StatusCount(status_id=sid, status_label=label, count=count)
-        for sid, label, count in await tickets_by_status(db)
-    ]
+    return await tickets_by_status(db)
 
 @router.get("/analytics/open_by_site", response_model=list[SiteOpenCount])
 async def api_open_tickets_by_site(
     db: AsyncSession = Depends(get_db),
 ) -> list[SiteOpenCount]:
 
-    return [
-        SiteOpenCount(site_id=sid, site_label=label, count=count)
-        for sid, label, count in await open_tickets_by_site(db)
-    ]
+    return await open_tickets_by_site(db)
 
 @router.get("/analytics/sla_breaches")
 async def api_sla_breaches(
@@ -367,17 +366,17 @@ async def api_sla_breaches(
 ) -> dict:
     return {"breaches": await sla_breaches(db, sla_days)}
 
-@router.get("/analytics/open_by_user")
+@router.get("/analytics/open_by_user", response_model=list[UserOpenCount])
 async def api_open_tickets_by_user(
     db: AsyncSession = Depends(get_db),
-) -> list[tuple[str | None, int]]:
+) -> list[UserOpenCount]:
 
     return await open_tickets_by_user(db)
 
-@router.get("/analytics/waiting_on_user")
+@router.get("/analytics/waiting_on_user", response_model=list[WaitingOnUserCount])
 async def api_tickets_waiting_on_user(
     db: AsyncSession = Depends(get_db),
-) -> list[tuple[str | None, int]]:
+) -> list[WaitingOnUserCount]:
 
     return await tickets_waiting_on_user(db)
 

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -35,6 +35,11 @@ __all__ = [
 
 
 
-from .analytics import StatusCount, SiteOpenCount
+from .analytics import (
+    StatusCount,
+    SiteOpenCount,
+    UserOpenCount,
+    WaitingOnUserCount,
+)
 
 

--- a/schemas/analytics.py
+++ b/schemas/analytics.py
@@ -10,3 +10,17 @@ class SiteOpenCount(BaseModel):
     site_id: Optional[int]
     site_label: Optional[str]
     count: int
+
+
+class UserOpenCount(BaseModel):
+    """Open ticket count grouped by assigned technician."""
+
+    assigned_email: Optional[str]
+    count: int
+
+
+class WaitingOnUserCount(BaseModel):
+    """Count of tickets waiting on a contact reply."""
+
+    contact_email: Optional[str]
+    count: int

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -91,7 +91,7 @@ async def test_analytics_open_by_user(client: AsyncClient):
 
     resp = await client.get("/analytics/open_by_user")
     assert resp.status_code == 200
-    data = {item[0]: item[1] for item in resp.json()}
+    data = {item["assigned_email"]: item["count"] for item in resp.json()}
     assert data == {"tech@example.com": 2, "other@example.com": 1}
 
 @pytest.mark.asyncio
@@ -103,6 +103,6 @@ async def test_analytics_waiting_on_user(client: AsyncClient):
 
     resp = await client.get("/analytics/waiting_on_user")
     assert resp.status_code == 200
-    data = {item[0]: item[1] for item in resp.json()}
+    data = {item["contact_email"]: item["count"] for item in resp.json()}
     assert data == {"user1@example.com": 2, "user2@example.com": 1}
 


### PR DESCRIPTION
## Summary
- define `UserOpenCount` and `WaitingOnUserCount` models
- return those models from analysis helpers
- update API routes to use new types
- enhance docstrings for clearer tuple contents
- adjust analytics tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68687420dea4832b946a652fef9e785f