### PR TITLE
Improve SLA breach analytics

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -363,9 +363,23 @@ async def api_open_tickets_by_site(
 
 @router.get("/analytics/sla_breaches")
 async def api_sla_breaches(
-    sla_days: int = 2, db: AsyncSession = Depends(get_db)
+    request: Request,
+    sla_days: int = 2,
+    status_id: list[int] | None = None,
+    db: AsyncSession = Depends(get_db),
 ) -> dict:
-    return {"breaches": await sla_breaches(db, sla_days)}
+    params = request.query_params
+    filters = {
+        k: v for k, v in params.items() if k not in {"sla_days", "status_id"}
+    }
+    status_ids = status_id or [int(s) for s in params.getlist("status_id")]
+    if not status_ids:
+        status_ids = None
+    return {
+        "breaches": await sla_breaches(
+            db, sla_days, filters=filters or None, status_ids=status_ids
+        )
+    }
 
 @router.get("/analytics/open_by_user")
 async def api_open_tickets_by_user(

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -106,3 +106,33 @@ async def test_analytics_waiting_on_user(client: AsyncClient):
     data = {item[0]: item[1] for item in resp.json()}
     assert data == {"user1@example.com": 2, "user2@example.com": 1}
 
+
+@pytest.mark.asyncio
+async def test_sla_breaches_with_filters(client: AsyncClient):
+    old = datetime.now(UTC) - timedelta(days=5)
+    await _add_ticket(
+        Created_Date=old,
+        Assigned_Email="tech@example.com",
+        Ticket_Status_ID=1,
+    )
+    await _add_ticket(
+        Created_Date=old,
+        Assigned_Email="other@example.com",
+        Ticket_Status_ID=1,
+    )
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=3)
+
+    resp = await client.get(
+        "/analytics/sla_breaches",
+        params={"Assigned_Email": "tech@example.com", "sla_days": 2},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"breaches": 1}
+
+    resp = await client.get(
+        "/analytics/sla_breaches",
+        params={"status_id": [3], "sla_days": 2},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"breaches": 1}
+


### PR DESCRIPTION
## Summary
- extend `sla_breaches` to accept optional filters and status lists
- expose new query params in `/analytics/sla_breaches`
- test filtering behaviour

## Testing
- `flake8` *(fails: E128, E122, ...)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868913eb084832b9775c489a6199d97