### PR TITLE
Allow long text in ticket schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ LEFT JOIN Priorities p ON p.ID = t.Priority_ID;
 - `DELETE /ticket/{id}` - remove a ticket
 - `POST /ai/suggest_response` - generate an AI ticket reply
 - `POST /ai/suggest_response/stream` - stream an AI reply as it is generated
+- Ticket body and resolution fields now accept large text values; the previous
+  2000-character limit has been removed.
 
 
 ## CLI

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 class TicketBase(BaseModel):
     Subject: Annotated[str, Field(max_length=255)]
-    Ticket_Body: Annotated[str, Field(max_length=2000)]
+    Ticket_Body: Annotated[str, Field()]
     Ticket_Status_ID: Optional[int] = 1
     Ticket_Contact_Name: Annotated[str, Field(max_length=255)]
     Ticket_Contact_Email: EmailStr
@@ -18,7 +18,7 @@ class TicketBase(BaseModel):
     Assigned_Email: Optional[EmailStr] = None
     Priority_ID: Optional[int] = None
     Assigned_Vendor_ID: Optional[int] = None
-    Resolution: Optional[Annotated[str, Field(max_length=2000)]] = None
+    Resolution: Optional[Annotated[str, Field()]] = None
 
     @field_validator("Ticket_Contact_Email", "Assigned_Email", mode="before")
     def validate_emails(cls, v):
@@ -69,7 +69,7 @@ class TicketUpdate(BaseModel):
 
 class TicketIn(BaseModel):
     Subject: Optional[Annotated[str, Field(max_length=255)]] = None
-    Ticket_Body: Optional[Annotated[str, Field(max_length=2000)]] = None
+    Ticket_Body: Optional[Annotated[str, Field()]] = None
     Ticket_Status_ID: Optional[int] = None
     Ticket_Contact_Name: Optional[Annotated[str, Field(max_length=255)]] = None
     Ticket_Contact_Email: Optional[EmailStr] = None
@@ -81,7 +81,7 @@ class TicketIn(BaseModel):
     Assigned_Email: Optional[EmailStr] = None
     Priority_ID: Optional[int] = None
     Assigned_Vendor_ID: Optional[int] = None
-    Resolution: Optional[Annotated[str, Field(max_length=2000)]] = None
+    Resolution: Optional[Annotated[str, Field()]] = None
 
     @field_validator("Ticket_Contact_Email", "Assigned_Email", mode="before")
     def validate_emails(cls, v):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,3 +21,16 @@ def test_subject_too_long():
             Ticket_Contact_Name="Name",
             Ticket_Contact_Email="test@example.com",
         )
+
+
+def test_long_body_allowed():
+    long_text = "x" * 3000
+    obj = TicketCreate(
+        Subject="Test",
+        Ticket_Body=long_text,
+        Ticket_Contact_Name="Name",
+        Ticket_Contact_Email="test@example.com",
+        Resolution=long_text,
+    )
+    assert obj.Ticket_Body == long_text
+    assert obj.Resolution == long_text


### PR DESCRIPTION
## Summary
- remove length limits on `Ticket_Body` and `Resolution`
- allow long ticket body in schema tests
- document new unlimited text capability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686898413a9c832b885a546edb0a8f6f