### PR TITLE
Fix email validator to use normalized address

### DIFF
--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -27,7 +27,7 @@ class TicketBase(BaseModel):
         if isinstance(v, str) and (v == "" or v.lower() == "null"):
             return None
         try:
-            return validate_email(v, check_deliverability=False).email
+            return validate_email(v, check_deliverability=False).normalized
         except EmailNotValidError as e:
             raise ValueError(str(e))
 
@@ -90,7 +90,7 @@ class TicketIn(BaseModel):
         if isinstance(v, str) and (v == "" or v.lower() == "null"):
             return None
         try:
-            return validate_email(v, check_deliverability=False).email
+            return validate_email(v, check_deliverability=False).normalized
         except EmailNotValidError as e:
             raise ValueError(str(e))
 


### PR DESCRIPTION
## Summary
- use `ValidatedEmail.normalized` instead of deprecated `.email` in `schemas/ticket.py`
- confirm updated email validation via tests

## Testing
- `pytest tests/test_validation.py::test_invalid_email -q`
- `pytest -q` *(fails: 15 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6868984447d4832b8aea3a9f3bc3bb87