### PR TITLE
Fix search ticket validation

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -267,7 +267,15 @@ async def api_search_tickets(
 
     logger.info("API search tickets query=%s limit=%s", q, limit)
     results = await search_tickets_expanded(db, q, limit)
-    return [TicketExpandedOut.model_validate(r) for r in results]
+    ticket_out: list[TicketExpandedOut] = []
+    for r in results:
+        try:
+            ticket_out.append(TicketExpandedOut.model_validate(r))
+        except Exception as e:
+            logger.error(
+                "Invalid ticket %s: %s", getattr(r, "Ticket_ID", "?"), e
+            )
+    return ticket_out
 
 @router.post("/ticket", response_model=TicketOut)
 async def api_create_ticket(

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -1,0 +1,41 @@
+from datetime import datetime, UTC
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from main import app
+from db.mssql import SessionLocal
+from db.models import Ticket
+from tools.ticket_tools import create_ticket
+
+
+@pytest.mark.asyncio
+async def test_search_skips_oversized_ticket_body():
+    async with SessionLocal() as db:
+        valid = Ticket(
+            Subject="Query", 
+            Ticket_Body="valid", 
+            Ticket_Contact_Name="T", 
+            Ticket_Contact_Email="t@example.com",
+            Created_Date=datetime.now(UTC),
+            Ticket_Status_ID=1,
+        )
+        invalid = Ticket(
+            Subject="Query",
+            Ticket_Body="x" * 2100,
+            Ticket_Contact_Name="T",
+            Ticket_Contact_Email="t@example.com",
+            Created_Date=datetime.now(UTC),
+            Ticket_Status_ID=1,
+        )
+        await create_ticket(db, valid)
+        await create_ticket(db, invalid)
+        valid_id = valid.Ticket_ID
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/tickets/search", params={"q": "Query"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["Ticket_ID"] == valid_id


### PR DESCRIPTION
## Summary
- handle invalid data during ticket search
- test search results with invalid ticket row

## Testing
- `pytest -q tests/test_search_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_686898434be4832ba24c655e7d96c8c4