### PR TITLE
Enhance AI response helpers

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,6 +1,8 @@
 from typing import Any, AsyncGenerator, List
+import json
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, ValidationError
 from fastapi.responses import StreamingResponse
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -254,4 +256,87 @@ async def api_get_ticket_attachments(ticket_id: int, db: AsyncSession = Depends(
 
 
 @router.get("/ticket/{ticket_id}/messages", response_model=List[TicketMessageOut])
-async def api_get_ticket_messages(ticket_
+async def api_get_ticket_messages(
+    ticket_id: int, db: AsyncSession = Depends(get_db)
+) -> List[TicketMessageOut]:
+    msgs = await get_ticket_messages(db, ticket_id)
+    return [TicketMessageOut.model_validate(m) for m in msgs]
+
+
+@router.post("/ticket/{ticket_id}/messages", response_model=TicketMessageOut)
+async def api_post_ticket_messages(
+    ticket_id: int, message: MessageIn, db: AsyncSession = Depends(get_db)
+) -> TicketMessageOut:
+    msg = await post_ticket_message(
+        db, ticket_id, message.message, message.sender_code, message.sender_name
+    )
+    return TicketMessageOut.model_validate(msg)
+
+
+@router.get("/analytics/status", response_model=List[StatusCount])
+async def api_analytics_status(db: AsyncSession = Depends(get_db)) -> List[StatusCount]:
+    return await tickets_by_status(db)
+
+
+@router.get("/analytics/open_by_site", response_model=List[SiteOpenCount])
+async def api_analytics_open_by_site(db: AsyncSession = Depends(get_db)) -> List[SiteOpenCount]:
+    return await open_tickets_by_site(db)
+
+
+@router.get("/analytics/sla_breaches")
+async def api_analytics_sla_breaches(
+    request: Request,
+    sla_days: int = 2,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    filters = {
+        k: v
+        for k, v in request.query_params.items()
+        if k not in {"sla_days", "status_id"}
+    }
+    status_ids = [int(s) for s in request.query_params.getlist("status_id")]
+    if not status_ids:
+        status_ids = None
+    count = await sla_breaches(db, sla_days, filters or None, status_ids)
+    return {"breaches": count}
+
+
+@router.get("/analytics/open_by_user", response_model=List[UserOpenCount])
+async def api_analytics_open_by_user(db: AsyncSession = Depends(get_db)) -> List[UserOpenCount]:
+    return await open_tickets_by_user(db)
+
+
+@router.get("/analytics/waiting_on_user", response_model=List[WaitingOnUserCount])
+async def api_analytics_waiting_on_user(db: AsyncSession = Depends(get_db)) -> List[WaitingOnUserCount]:
+    return await tickets_waiting_on_user(db)
+
+
+@router.get("/oncall", response_model=OnCallShiftOut)
+async def api_get_current_oncall(db: AsyncSession = Depends(get_db)) -> OnCallShiftOut:
+    shift = await get_current_oncall(db)
+    if not shift:
+        raise HTTPException(status_code=404, detail="On-call shift not found")
+    return OnCallShiftOut.model_validate(shift)
+
+
+@router.post("/ai/suggest_response", response_model=dict)
+async def api_ai_suggest_response_route(ticket: dict) -> dict:
+    try:
+        result = await ai_suggest_response(ticket)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return result
+
+
+@router.post("/ai/suggest_response/stream")
+async def api_ai_suggest_response_stream(ticket: dict) -> StreamingResponse:
+    try:
+        TicketOut.model_validate(ticket)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    async def _generate() -> AsyncGenerator[str, None]:
+        async for chunk in ai_stream_response(ticket):
+            yield f"data: {json.dumps(chunk)}\n\n"
+
+    return StreamingResponse(_generate(), media_type="text/event-stream")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,8 +48,8 @@ async def test_stream_response_cli(cli_setup, capsys, monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     async def dummy_stream(ticket, context=""):
-        yield "part1"
-        yield "part2"
+        yield {"content": "part1", "model_used": "x", "generated_at": "now"}
+        yield {"content": "part2", "model_used": "x", "generated_at": "now"}
 
     monkeypatch.setattr("tools.ai_tools.ai_stream_response", dummy_stream)
     monkeypatch.setattr("api.routes.ai_stream_response", dummy_stream)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,6 +1,7 @@
 import pytest
 from httpx import AsyncClient, ASGITransport
 from main import app
+import json
 
 import pytest_asyncio
 
@@ -15,8 +16,8 @@ async def client():
 @pytest.mark.asyncio
 async def test_ai_suggest_response_stream(client, monkeypatch):
     async def dummy_stream(ticket, context=""):
-        yield "part1"
-        yield "part2"
+        yield {"content": "part1", "model_used": "x", "generated_at": "now"}
+        yield {"content": "part2", "model_used": "x", "generated_at": "now"}
 
     monkeypatch.setattr("tools.ai_tools.ai_stream_response", dummy_stream)
     monkeypatch.setattr("api.routes.ai_stream_response", dummy_stream)
@@ -34,10 +35,12 @@ async def test_ai_suggest_response_stream(client, monkeypatch):
         assert resp.status_code == 200
         chunks = [chunk async for chunk in resp.aiter_text()]
 
-    # verify SSE framing and plain text reconstruction
+    # verify SSE framing and JSON reconstruction
     all_text = "".join(chunks)
     lines = [line for line in all_text.splitlines() if line.startswith("data:")]
     assert lines
     assert all(line.startswith("data:") for line in lines)
-    text = "".join(line.removeprefix("data:").strip() for line in lines)
+    text = "".join(
+        json.loads(line.removeprefix("data:").strip())["content"] for line in lines
+    )
     assert text == "part1part2"

--- a/tools/ai_tools.py
+++ b/tools/ai_tools.py
@@ -2,6 +2,10 @@
 
 from typing import Any, AsyncGenerator, Dict
 import logging
+from datetime import datetime, UTC
+
+from pydantic import ValidationError
+from schemas.ticket import TicketOut
 
 from ai.mcp_agent import (
     suggest_ticket_response as mcp_suggest_response,
@@ -11,14 +15,73 @@ from ai.mcp_agent import (
 logger = logging.getLogger(__name__)
 
 
-async def ai_suggest_response(ticket: Dict[str, Any], context: str = "") -> str:
-    """Return a suggested response using the MCP backend."""
-    return await mcp_suggest_response(ticket, context)
+async def ai_suggest_response(ticket: Dict[str, Any], context: str = "") -> Dict[str, Any]:
+    """Return a suggested response using the MCP backend.
+
+    Parameters
+    ----------
+    ticket: dict
+        Ticket information validated against :class:`schemas.ticket.TicketOut`.
+    context: str, optional
+        Additional conversation context for the AI model.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``content`` with the generated text,
+        ``model_used`` describing the backend and ``generated_at`` with the
+        timestamp.
+    """
+
+    try:
+        TicketOut.model_validate(ticket)
+    except ValidationError as exc:
+        logger.error("Invalid ticket provided to ai_suggest_response: %s", exc)
+        raise
+
+    try:
+        content = await mcp_suggest_response(ticket, context)
+    except Exception as exc:  # pragma: no cover - network/agent errors
+        logger.exception("mcp_agent request failed: %s", exc)
+        content = ""
+
+    return {
+        "content": content,
+        "model_used": "mcp_agent",
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
 
 
 async def ai_stream_response(
     ticket: Dict[str, Any], context: str = ""
-) -> AsyncGenerator[str, None]:
-    """Stream a suggested response to the ticket."""
-    async for chunk in mcp_stream_ticket_response(ticket, context):
-        yield chunk
+) -> AsyncGenerator[Dict[str, Any], None]:
+    """Stream a suggested response to the ticket.
+
+    Parameters
+    ----------
+    ticket: dict
+        Ticket information validated against :class:`schemas.ticket.TicketOut`.
+    context: str, optional
+        Additional conversation context for the AI model.
+
+    Yields
+    ------
+    dict
+        Dictionaries with the same structure as :func:`ai_suggest_response`.
+    """
+
+    try:
+        TicketOut.model_validate(ticket)
+    except ValidationError as exc:
+        logger.error("Invalid ticket provided to ai_stream_response: %s", exc)
+        return
+
+    try:
+        async for chunk in mcp_stream_ticket_response(ticket, context):
+            yield {
+                "content": chunk,
+                "model_used": "mcp_agent",
+                "generated_at": datetime.now(UTC).isoformat(),
+            }
+    except Exception as exc:  # pragma: no cover - network/agent errors
+        logger.exception("mcp_agent streaming request failed: %s", exc)

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -28,7 +28,12 @@ async def stream_response(_args: argparse.Namespace) -> None:
                 resp.raise_for_status()
 
                 async for event in EventSource(resp).aiter_sse():
-                    sys.stdout.write(event.data)
+                    try:
+                        data = json.loads(event.data)
+                    except json.JSONDecodeError:
+                        data = {"content": event.data}
+
+                    sys.stdout.write(data.get("content", ""))
                     sys.stdout.flush()
         except httpx.HTTPError as exc:
             logger.exception("HTTP error in stream_response: %s", exc)


### PR DESCRIPTION
## Summary
- validate tickets in `ai_suggest_response` and `ai_stream_response`
- include metadata in returned dictionaries
- stream JSON events from the API and parse them in the CLI
- expose new `/ai/suggest_response` and `/ai/suggest_response/stream` routes
- update tests for the new response structure

## Testing
- `pytest -k stream -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868aa914c0c832b8f43fea66772d55b