### PR TITLE
Add search ticket summaries

### DIFF
--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -5,6 +5,7 @@ from .ticket import (
     TicketOut,
     TicketExpandedOut,
 )
+from .search import TicketSearchOut
 from .oncall import OnCallShiftOut
 from .paginated import PaginatedResponse
 from .basic import (
@@ -22,6 +23,7 @@ __all__ = [
     'TicketUpdate',
     'TicketOut',
     'TicketExpandedOut',
+    'TicketSearchOut',
     'OnCallShiftOut',
     'PaginatedResponse',
     'AssetOut',

--- a/schemas/search.py
+++ b/schemas/search.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, ConfigDict
+from typing import Optional
+
+class TicketSearchOut(BaseModel):
+    """Summary information returned by the search endpoint."""
+
+    Ticket_ID: int
+    Subject: str
+    body_preview: str
+    status_label: Optional[str] = None
+    priority_level: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -32,7 +32,8 @@ async def test_search_tickets():
 
         await create_ticket(db, t)
         results = await search_tickets_expanded(db, "Network")
-        assert results and results[0].Subject == "Network issue"
+        assert results and results[0]["Subject"] == "Network issue"
+        assert "body_preview" in results[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -38,4 +38,6 @@ async def test_search_skips_oversized_ticket_body():
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
-        assert data[0]["Ticket_ID"] == valid_id
+        item = data[0]
+        assert item["Ticket_ID"] == valid_id
+        assert set(["Ticket_ID", "Subject", "body_preview", "status_label", "priority_level"]) <= item.keys()


### PR DESCRIPTION
## Summary
- add TicketSearchOut schema for search results
- summarize search results in ticket tools
- return TicketSearchOut from /tickets/search
- fix routes module with message endpoints
- adjust tests for new search format

## Testing
- `pytest tests/test_search.py tests/test_search_endpoint.py tests/test_concurrency.py::test_concurrent_search -q`
- `pytest -q` *(fails: analytics and CLI tests return 404)*

------
https://chatgpt.com/codex/tasks/task_e_6868aa9440a0832ba55942028cb6a5eb