### PR TITLE
Fix routes and add analytics trend

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,4 +1,5 @@
 from typing import Any, AsyncGenerator, List
+from pydantic import BaseModel
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
@@ -34,6 +35,7 @@ from tools.analysis_tools import (
     sla_breaches,
     open_tickets_by_user,
     tickets_waiting_on_user,
+    ticket_trend,
 )
 from tools.oncall_tools import get_current_oncall
 from tools.ai_tools import ai_suggest_response, ai_stream_response
@@ -52,7 +54,13 @@ from schemas.basic import (
     TicketAttachmentOut,
     TicketMessageOut,
 )
-from schemas.analytics import StatusCount, SiteOpenCount, UserOpenCount, WaitingOnUserCount
+from schemas.analytics import (
+    StatusCount,
+    SiteOpenCount,
+    UserOpenCount,
+    WaitingOnUserCount,
+    TrendCount,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -254,4 +262,90 @@ async def api_get_ticket_attachments(ticket_id: int, db: AsyncSession = Depends(
 
 
 @router.get("/ticket/{ticket_id}/messages", response_model=List[TicketMessageOut])
-async def api_get_ticket_messages(ticket_
+async def api_get_ticket_messages(
+    ticket_id: int, db: AsyncSession = Depends(get_db)
+) -> List[TicketMessageOut]:
+    """Return all messages for a ticket."""
+    msgs = await get_ticket_messages(db, ticket_id)
+    return [TicketMessageOut.model_validate(m) for m in msgs]
+
+
+@router.post("/ticket/{ticket_id}/messages", response_model=TicketMessageOut)
+async def api_post_ticket_message(
+    ticket_id: int,
+    message: MessageIn,
+    db: AsyncSession = Depends(get_db),
+) -> TicketMessageOut:
+    """Create a new message on a ticket."""
+    msg = await post_ticket_message(
+        db,
+        ticket_id,
+        message.message,
+        message.sender_code,
+        message.sender_name,
+    )
+    return TicketMessageOut.model_validate(msg)
+
+
+@router.post("/ai/suggest_response")
+async def api_ai_suggest_response(ticket: dict[str, Any]) -> dict:
+    """Return an AI-generated reply for a ticket."""
+    result = await ai_suggest_response(ticket)
+    return {"response": result}
+
+
+@router.post("/ai/suggest_response/stream")
+async def api_ai_suggest_response_stream(ticket: dict[str, Any]) -> StreamingResponse:
+    """Stream an AI generated reply for a ticket."""
+
+    async def _generate() -> AsyncGenerator[str, None]:
+        async for chunk in ai_stream_response(ticket):
+            yield f"data: {chunk}\n\n"
+
+    return StreamingResponse(_generate(), media_type="text/event-stream")
+
+
+@router.get("/analytics/status", response_model=List[StatusCount])
+async def api_analytics_status(db: AsyncSession = Depends(get_db)) -> List[StatusCount]:
+    return await tickets_by_status(db)
+
+
+@router.get("/analytics/open_by_site", response_model=List[SiteOpenCount])
+async def api_analytics_open_by_site(db: AsyncSession = Depends(get_db)) -> List[SiteOpenCount]:
+    return await open_tickets_by_site(db)
+
+
+@router.get("/analytics/sla_breaches")
+async def api_analytics_sla_breaches(
+    request: Request,
+    sla_days: int = 2,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    params = request.query_params
+    statuses = [int(s) for s in params.getlist("status_id")] if params.getlist("status_id") else None
+    filters = {k: v for k, v in params.items() if k not in {"sla_days", "status_id"}}
+    count = await sla_breaches(db, sla_days=sla_days, filters=filters or None, status_ids=statuses)
+    return {"breaches": count}
+
+
+@router.get("/analytics/open_by_user", response_model=List[UserOpenCount])
+async def api_analytics_open_by_user(db: AsyncSession = Depends(get_db)) -> List[UserOpenCount]:
+    return await open_tickets_by_user(db)
+
+
+@router.get("/analytics/waiting_on_user", response_model=List[WaitingOnUserCount])
+async def api_analytics_waiting_on_user(db: AsyncSession = Depends(get_db)) -> List[WaitingOnUserCount]:
+    return await tickets_waiting_on_user(db)
+
+
+@router.get("/analytics/trend", response_model=List[TrendCount])
+async def api_ticket_trend(days: int = 7, db: AsyncSession = Depends(get_db)) -> List[TrendCount]:
+    return await ticket_trend(db, days)
+
+
+@router.get("/oncall", response_model=OnCallShiftOut)
+async def api_get_current_oncall(db: AsyncSession = Depends(get_db)) -> OnCallShiftOut:
+    shift = await get_current_oncall(db)
+    if not shift:
+        raise HTTPException(status_code=404, detail="No active shift")
+    return OnCallShiftOut.model_validate(shift)

--- a/schemas/analytics.py
+++ b/schemas/analytics.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import Optional
+from datetime import date
 
 class StatusCount(BaseModel):
     status_id: Optional[int]
@@ -23,4 +24,11 @@ class WaitingOnUserCount(BaseModel):
     """Count of tickets waiting on a contact reply."""
 
     contact_email: Optional[str]
+    count: int
+
+
+class TrendCount(BaseModel):
+    """Ticket count grouped by creation date."""
+
+    date: date
     count: int

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,23 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from main import app
+import pytest_asyncio
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_ai_suggest_response(client, monkeypatch):
+    async def fake(ticket, context=""):
+        return "hello"
+
+    monkeypatch.setattr("tools.ai_tools.ai_suggest_response", fake)
+    monkeypatch.setattr("api.routes.ai_suggest_response", fake)
+
+    resp = await client.post("/ai/suggest_response", json={"Ticket_ID": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {"response": "hello"}

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -136,3 +136,16 @@ async def test_sla_breaches_with_filters(client: AsyncClient):
     assert resp.status_code == 200
     assert resp.json() == {"breaches": 1}
 
+
+@pytest.mark.asyncio
+async def test_ticket_trend(client: AsyncClient):
+    now = datetime.now(UTC)
+    await _add_ticket(Created_Date=now - timedelta(days=2))
+    await _add_ticket(Created_Date=now - timedelta(days=1))
+    await _add_ticket(Created_Date=now - timedelta(days=1))
+
+    resp = await client.get("/analytics/trend", params={"days": 3})
+    assert resp.status_code == 200
+    data = {item["date"]: item["count"] for item in resp.json()}
+    assert data[(now - timedelta(days=2)).date().isoformat()] == 1
+    assert data[(now - timedelta(days=1)).date().isoformat()] == 2


### PR DESCRIPTION
## Summary
- finalize ticket message APIs
- add AI response endpoints
- implement analytics routes including new trend metrics
- support trend analytics helper
- test AI response structure and trend metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868aa9748b0832b8429b6c7321abd8d