### PR TITLE
Fix import path and rate limiter usage

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -42,7 +42,8 @@ from tools.ai_tools import ai_suggest_response, ai_stream_response
 from tools.oncall_tools import get_current_oncall
 
 # Schemas
-from schemas.ticket import (
+# Ticket schemas
+from schemas import (
     TicketCreate,
     TicketOut,
     TicketUpdate,
@@ -293,7 +294,7 @@ ai_router = APIRouter(prefix="/ai", tags=["ai"])
 
 @ai_router.post("/suggest_response", response_model=Dict[str, str])
 @limiter.limit("10/minute")
-async def suggest_response(ticket: TicketOut) -> Dict[str, str]:
+async def suggest_response(request: Request, ticket: TicketOut) -> Dict[str, str]:
     try:
         return {"response": await ai_suggest_response(ticket.model_dump(), "")}
     except ValidationError as exc:
@@ -301,7 +302,7 @@ async def suggest_response(ticket: TicketOut) -> Dict[str, str]:
 
 @ai_router.post("/suggest_response/stream")
 @limiter.limit("10/minute")
-async def suggest_response_stream(ticket: TicketOut) -> StreamingResponse:
+async def suggest_response_stream(request: Request, ticket: TicketOut) -> StreamingResponse:
     ticket.model_validate(ticket.model_dump())
     async def _gen() -> AsyncGenerator[str, None]:
         async for chunk in ai_stream_response(ticket.model_dump(), ""):

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ from sqlalchemy import text
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
-from api.routes import router, get_db
+from api.routes import register_routes, get_db
 from sqlalchemy.ext.asyncio import AsyncSession
 from limiter import limiter
 
@@ -85,7 +85,7 @@ app.add_exception_handler(
     lambda request, exc: JSONResponse(status_code=429, content={"detail": "Rate limit exceeded"}),
 )
 app.add_middleware(SlowAPIMiddleware)
-app.include_router(router)
+register_routes(app)
 
 
 @app.middleware("http")


### PR DESCRIPTION
## Summary
- load schemas from package root
- accept Request objects in rate-limited AI endpoints
- register API routes via helper function

## Testing
- `pytest tests/test_health.py tests/test_validation.py tests/test_app.py -q`
- `pytest -q` *(fails: tests/test_cli.py::test_create_ticket_cli, tests/test_concurrency.py::test_concurrent_search)*

------
https://chatgpt.com/codex/tasks/task_e_686d2567b2ac832ba5b0c14102989bed