### PR TITLE
Add MCP server endpoints

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -92,6 +92,7 @@ def extract_filters(
 
 # ─── Tickets Sub-Router ───────────────────────────────────────────────────────
 ticket_router = APIRouter(prefix="/ticket", tags=["tickets"])
+tickets_router = APIRouter(prefix="/tickets", tags=["tickets"])
 
 class MessageIn(BaseModel):
     message: str = Field(..., example="Thanks for the update")
@@ -131,6 +132,24 @@ async def list_tickets(
 
     return PaginatedResponse(items=validated, total=total, skip=skip, limit=limit)
 
+@tickets_router.get("", response_model=PaginatedResponse[TicketExpandedOut])
+async def list_tickets_alias(
+    request: Request,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(10, ge=1),
+    db: AsyncSession = Depends(get_db),
+) -> PaginatedResponse[TicketExpandedOut]:
+    return await list_tickets(request, skip, limit, db)
+
+@tickets_router.get("/expanded", response_model=PaginatedResponse[TicketExpandedOut])
+async def list_tickets_expanded_alias(
+    request: Request,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(10, ge=1),
+    db: AsyncSession = Depends(get_db),
+) -> PaginatedResponse[TicketExpandedOut]:
+    return await list_tickets(request, skip, limit, db)
+
 @ticket_router.get("/search", response_model=List[TicketSearchOut])
 async def search_tickets(
     q: str = Query(..., min_length=1),
@@ -146,6 +165,14 @@ async def search_tickets(
         except ValidationError as exc:
             logger.error("Invalid search result %s: %s", r.get("Ticket_ID", "?"), exc)
     return validated
+
+@tickets_router.get("/search", response_model=List[TicketSearchOut])
+async def search_tickets_alias(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(10, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> List[TicketSearchOut]:
+    return await search_tickets(q=q, limit=limit, db=db)
 
 @ticket_router.post("", response_model=TicketOut, status_code=201)
 async def create_ticket_endpoint(
@@ -320,6 +347,7 @@ async def get_oncall_shift(db: AsyncSession = Depends(get_db)) -> Optional[OnCal
 # ─── Application Registration ─────────────────────────────────────────────────
 def register_routes(app: FastAPI) -> None:
     app.include_router(ticket_router)
+    app.include_router(tickets_router)
     app.include_router(lookup_router)
     app.include_router(analytics_router)
     app.include_router(ai_router)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Awaitable, Callable, Dict, List
+
+
+@dataclass
+class Tool:
+    """Simple representation of a callable tool."""
+
+    name: str
+    description: str
+    inputSchema: Dict[str, Any]
+    _implementation: Callable[..., Awaitable[Any]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data.pop("_implementation", None)
+        return data
+
+
+class MCPServer:
+    """Container for available tools."""
+
+    def __init__(self, tools: List[Tool]) -> None:
+        self.tools = tools
+
+
+def create_server() -> MCPServer:
+    """Return a server instance exposing demo tools."""
+
+    async def echo(text: str) -> Dict[str, Any]:
+        return {"echo": text}
+
+    async def add(a: int, b: int) -> Dict[str, Any]:
+        return {"result": a + b}
+
+    tools = [
+        Tool(
+            name="echo",
+            description="Return the provided text.",
+            inputSchema={
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+            _implementation=echo,
+        ),
+        Tool(
+            name="add",
+            description="Add two integers.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            },
+            _implementation=add,
+        ),
+    ]
+
+    return MCPServer(tools)

--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -1,0 +1,29 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from main import app
+
+
+@pytest.mark.asyncio
+async def test_dynamic_tool_routes():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/echo", json={"text": "hi"})
+        assert resp.status_code == 200
+        assert resp.json() == {"echo": "hi"}
+
+        resp = await client.post("/echo", json={"text": "hi", "extra": 1})
+        assert resp.status_code == 422
+
+        resp = await client.post("/add", json={"a": 2, "b": 3})
+        assert resp.status_code == 200
+        assert resp.json() == {"result": 5}
+
+
+@pytest.mark.asyncio
+async def test_tools_list_route():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/tools")
+        assert resp.status_code == 200
+        tools = resp.json()
+        assert any(t["name"] == "echo" for t in tools)

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -114,7 +114,9 @@ async def search_tickets_expanded(
     return summaries
 
 
-async def create_ticket(db: AsyncSession, ticket_obj: Ticket) -> Ticket:
+async def create_ticket(db: AsyncSession, ticket_obj: Ticket | Dict[str, Any]) -> Ticket:
+    if isinstance(ticket_obj, dict):
+        ticket_obj = Ticket(**ticket_obj)
     db.add(ticket_obj)
     try:
         await db.commit()


### PR DESCRIPTION
## Summary
- implement minimal mcp_server with demo tools
- dynamically mount tools as routes in `main.py`
- expose `/tools` route and mount `FastApiMCP` after registering tool routes
- allow dict payloads when creating tickets
- provide `/tickets` aliases for existing ticket routes
- test new dynamic tool endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d94eb26e0832b8c9eeeb03275cc16