### PR TITLE
Remove test SSE endpoint

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,4 +1,3 @@
-import json
 import asyncio
 import pytest
 from httpx import AsyncClient, ASGITransport
@@ -6,7 +5,7 @@ from httpx_sse import EventSource
 from main import app
 
 @pytest.mark.asyncio
-async def test_mcp_roundtrip():
+async def test_mcp_endpoint():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         async with client.stream("GET", "/mcp") as resp:
@@ -16,13 +15,6 @@ async def test_mcp_roundtrip():
             first = await asyncio.wait_for(anext(events), timeout=1)
             assert first.event == "endpoint"
             post_url = first.data
-            assert post_url.startswith("/mcp/")
-
-            payload = {"jsonrpc": "2.0", "id": 1, "result": "pong"}
-            post_resp = await client.post(post_url, json=payload)
-            assert post_resp.status_code == 202
-
-            second = await asyncio.wait_for(anext(events), timeout=1)
-            assert second.event == "message"
-            assert json.loads(second.data) == payload
+            assert post_url.startswith("/mcp/messages/")
             await source.aclose()
+


### PR DESCRIPTION
## Summary
- remove in-app SSE testing endpoints
- clean up associated MCP test

## Testing
- `pytest tests/test_mcp.py -q` *(fails: sqlite OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_686dc0431008832bb1e8ee5f1fc644c0