### PR TITLE
Fix FastAPI initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,9 +55,6 @@ from db.models import Base
 from db.mssql import engine
 
 
-app = FastAPI(title="Truck Stop MCP Helpdesk API")
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Configure logging and initialize application components."""


### PR DESCRIPTION
## Summary
- remove redundant `FastAPI` initialization in `main.py`

## Testing
- `pytest tests/test_concurrency.py::test_concurrent_search -q` *(fails: no such table `main.Priorities`)*
- `pytest -k "not test_concurrent_search" -q` *(passes)*

------
https://chatgpt.com/codex/tasks/task_e_686dc043c78c832b95f03c161337479d