### PR TITLE
Add modular server and tools package

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""Core package exposing MCP server utilities and tools."""
+
+from .mcp_server import Tool, MCPServer, create_server
+
+__all__ = ["Tool", "MCPServer", "create_server"]

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Awaitable, Callable, Dict, List
+
+
+@dataclass
+class Tool:
+    """Simple representation of a callable tool."""
+
+    name: str
+    description: str
+    inputSchema: Dict[str, Any]
+    _implementation: Callable[..., Awaitable[Any]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data.pop("_implementation", None)
+        return data
+
+
+class MCPServer:
+    """Container for available tools."""
+
+    def __init__(self, tools: List[Tool]) -> None:
+        self.tools = tools
+
+
+def create_server() -> MCPServer:
+    """Return a server instance exposing tools from :mod:`tool_list`."""
+    from .tool_list import TOOLS
+
+    return MCPServer(list(TOOLS))

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -1,0 +1,14 @@
+"""List of all available tools used by :func:`create_server`."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .mcp_server import Tool
+from .tools import GET_TICKET, TICKET_COUNT, AI_ECHO
+
+TOOLS: List[Tool] = [
+    GET_TICKET,
+    TICKET_COUNT,
+    AI_ECHO,
+]

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,7 @@
+"""Collection of demonstration tools."""
+
+from .ticket_tools import GET_TICKET
+from .analytics_tools import TICKET_COUNT
+from .ai_tools import AI_ECHO
+
+__all__ = ["GET_TICKET", "TICKET_COUNT", "AI_ECHO"]

--- a/src/tools/ai_tools.py
+++ b/src/tools/ai_tools.py
@@ -1,0 +1,26 @@
+"""AI helper tools."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..mcp_server import Tool
+
+
+async def ai_echo(text: str) -> Dict[str, str]:
+    """Echo the provided text. Stand-in for an AI generated response."""
+    return {"content": text}
+
+
+AI_ECHO = Tool(
+    name="ai_echo",
+    description="Echo text using the AI system.",
+    inputSchema={
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    },
+    _implementation=ai_echo,
+)
+
+__all__ = ["AI_ECHO"]

--- a/src/tools/analytics_tools.py
+++ b/src/tools/analytics_tools.py
@@ -1,0 +1,23 @@
+"""Analytics related tools."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..mcp_server import Tool
+
+
+async def ticket_count() -> Dict[str, int]:
+    """Return the number of tickets (dummy implementation)."""
+    # In a real implementation this would query a database.
+    return {"count": 0}
+
+
+TICKET_COUNT = Tool(
+    name="ticket_count",
+    description="Return the total number of tickets.",
+    inputSchema={"type": "object", "properties": {}, "required": []},
+    _implementation=ticket_count,
+)
+
+__all__ = ["TICKET_COUNT"]

--- a/src/tools/ticket_tools.py
+++ b/src/tools/ticket_tools.py
@@ -1,0 +1,26 @@
+"""Minimal ticket management tools used for demonstration."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..mcp_server import Tool
+
+
+async def get_ticket(ticket_id: int) -> Dict[str, Any]:
+    """Return details for a ticket."""
+    return {"ticket_id": ticket_id, "status": "open"}
+
+
+GET_TICKET = Tool(
+    name="get_ticket",
+    description="Return details for a ticket by id.",
+    inputSchema={
+        "type": "object",
+        "properties": {"ticket_id": {"type": "integer"}},
+        "required": ["ticket_id"],
+    },
+    _implementation=get_ticket,
+)
+
+__all__ = ["GET_TICKET"]


### PR DESCRIPTION
## Summary
- add `src` package with `create_server` and dataclass `Tool`
- define demonstration tools under `src/tools`
- register tools via `src/tool_list`

## Testing
- `pytest -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_686de4f7b20c832baa31cdbc9a2e2075