### PR TITLE
Update pyproject dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ dependencies = [
     "uvicorn==0.35.0",
     "sqlalchemy==2.0.41",
     "pydantic==2.11.7",
-    "fastmcp==2.10.1",
-    "fastapi-mcp==0.3.4",
+    "mcp>=1.9.4",
+    "fastapi-mcp>=0.3.4",
     "python-dotenv==1.1.1",
     "pytest==8.4.1",
     "pytest-asyncio==0.23.6",
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["ai", "alembic", "api", "db", "schemas", "services", "tools"]
+packages = ["ai", "alembic", "api", "db", "schemas", "services", "tools", "src"]
 
 [tool.flake8]
 max-line-length = 100


### PR DESCRIPTION
## Summary
- replace `fastmcp` with `mcp>=1.9.4`
- use `fastapi-mcp>=0.3.4`
- include `src` when packaging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686de4fad780832bab37fd63c5ffbdd6