### PR TITLE
Update dynamic tool tests

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -29,35 +29,37 @@ class MCPServer:
 def create_server() -> MCPServer:
     """Return a server instance exposing demo tools."""
 
-    async def echo(text: str) -> Dict[str, Any]:
-        return {"echo": text}
+    async def get_ticket(ticket_id: int) -> Dict[str, Any]:
+        """Return a simple representation of a ticket."""
+        return {"ticket_id": ticket_id}
 
-    async def add(a: int, b: int) -> Dict[str, Any]:
-        return {"result": a + b}
+    async def create_ticket(subject: str, body: str) -> Dict[str, Any]:
+        """Pretend to create a ticket and return its info."""
+        return {"ticket_id": 1, "subject": subject, "ticket_body": body}
 
     tools = [
         Tool(
-            name="echo",
-            description="Return the provided text.",
+            name="get_ticket",
+            description="Fetch a ticket by ID.",
             inputSchema={
                 "type": "object",
-                "properties": {"text": {"type": "string"}},
-                "required": ["text"],
+                "properties": {"ticket_id": {"type": "integer"}},
+                "required": ["ticket_id"],
             },
-            _implementation=echo,
+            _implementation=get_ticket,
         ),
         Tool(
-            name="add",
-            description="Add two integers.",
+            name="create_ticket",
+            description="Create a new ticket.",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "a": {"type": "integer"},
-                    "b": {"type": "integer"},
+                    "subject": {"type": "string"},
+                    "body": {"type": "string"},
                 },
-                "required": ["a", "b"],
+                "required": ["subject", "body"],
             },
-            _implementation=add,
+            _implementation=create_ticket,
         ),
     ]
 

--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -7,16 +7,12 @@ from main import app
 async def test_dynamic_tool_routes():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/echo", json={"text": "hi"})
+        resp = await client.post("/get_ticket", json={"ticket_id": 1})
         assert resp.status_code == 200
-        assert resp.json() == {"echo": "hi"}
+        assert resp.json() == {"ticket_id": 1}
 
-        resp = await client.post("/echo", json={"text": "hi", "extra": 1})
+        resp = await client.post("/get_ticket", json={"ticket_id": 1, "extra": 1})
         assert resp.status_code == 422
-
-        resp = await client.post("/add", json={"a": 2, "b": 3})
-        assert resp.status_code == 200
-        assert resp.json() == {"result": 5}
 
 
 @pytest.mark.asyncio
@@ -26,4 +22,4 @@ async def test_tools_list_route():
         resp = await client.get("/tools")
         assert resp.status_code == 200
         tools = resp.json()
-        assert any(t["name"] == "echo" for t in tools)
+        assert any(t["name"] == "get_ticket" for t in tools)


### PR DESCRIPTION
## Summary
- introduce simple `get_ticket` and `create_ticket` tools
- update dynamic tool tests to call `/get_ticket` and verify new tool name

## Testing
- `pytest -q tests/test_dynamic_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_686de4fd8f88832b97b6fe1b4c30ca3f