### PR TITLE
Fix dockerfile formatting

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -19,4 +19,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application source
 COPY . .
 
-EXPOSE 8000CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- separate `EXPOSE` and `CMD` instructions in dockerfile

## Testing
- `pip install -e .`
- `pytest` *(fails: tests/test_concurrency.py::test_concurrent_search)*
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686deb120348832b93289c205b74fb84