### PR TITLE
Fix SQLAlchemy imports

### DIFF
--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel
 
-from sqlalchemy import select
+from sqlalchemy import select, or_, and_
 from fastapi import HTTPException
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
## Summary
- include or_ and and_ in `tools.ticket_tools`

## Testing
- `python -m pyflakes tools/ticket_tools.py`
- `pytest -q` *(fails: OperationalError no such table: Priorities)*

------
https://chatgpt.com/codex/tasks/task_e_686df06bf43c832bafc859cedcda6eea