### PR TITLE
Add asgi_lifespan to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "slowapi==0.1.9",
     "aiosqlite==0.21.0",
     "aioodbc==0.5.0",
+    "asgi_lifespan==2.1.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- add asgi_lifespan to project dependencies

## Testing
- `pip install -e .`
- `pytest -q` *(fails: OperationalError in test_concurrency)*

------
https://chatgpt.com/codex/tasks/task_e_686def767fe0832b8b36248b185daf06