### PR TITLE
Add verify_tools script

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,19 @@ values from `.env`. `DB_CONN_STRING` is set automatically to connect to the
 `postgres` container using the provided `POSTGRES_USER`, `POSTGRES_PASSWORD`, and
 `POSTGRES_DB` values.
 
+## Verifying Available Tools
+
+Run `verify_tools.py` after deploying to ensure the server exposes the expected
+set of tool endpoints. The script fetches the `/tools` route and compares the
+returned tool names against a predefined mapping. It exits with a non-zero
+status when any tools are missing or unexpected.
+
+```bash
+python verify_tools.py http://localhost:8000
+```
+
+Include this check in deployment pipelines to catch configuration issues early.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/verify_tools.py
+++ b/verify_tools.py
@@ -1,0 +1,51 @@
+import requests
+import sys
+from typing import Dict, Set
+
+# Expected mapping of tool categories to tool names
+EXPECTED_TOOLS: Dict[str, Set[str]] = {
+    "ticket": {"get_ticket"},
+    "analytics": {"ticket_count"},
+    "ai": {"ai_echo"},
+}
+
+
+def verify(base_url: str) -> bool:
+    """Fetch /tools and verify the available tool names."""
+    url = base_url.rstrip('/') + '/tools'
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    tools = resp.json()
+
+    reported = {t["name"] for t in tools}
+    expected = set().union(*EXPECTED_TOOLS.values())
+
+    missing = expected - reported
+    unexpected = reported - expected
+
+    ok = True
+
+    if missing:
+        print("Missing tools:", ", ".join(sorted(missing)))
+        ok = False
+    if unexpected:
+        print("Unexpected tools:", ", ".join(sorted(unexpected)))
+        ok = False
+
+    if ok:
+        print("All expected tools present.")
+    return ok
+
+
+def main(argv: list[str]) -> int:
+    base_url = argv[1] if len(argv) > 1 else "http://localhost:8000"
+    try:
+        success = verify(base_url)
+    except Exception as exc:
+        print(f"Verification failed: {exc}")
+        return 1
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- implement simple verify_tools.py to compare expected tool names with `/tools`
- document running the verification step in README

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_concurrency.py::test_concurrent_search -q` *(fails: sqlite3.OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_686e6f77df3c832b90d5b4b6e7fc66d8