### PR TITLE
Fix MCP server image typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   helpdeskmcpserver:
-    image: bbeeken/helpdeskmcpcerver:latest
+    image: bbeeken/helpdeskmcpserver:latest
     env_file:
       - .env
     ports:


### PR DESCRIPTION
## Summary
- fix MCP server container image typo in docker-compose

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: sqlalchemy OperationalError)*
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6fa03ca8832ba10096898c896d41