### PR TITLE
Expose tool metadata with categories

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from fastapi_mcp import FastApiMCP
 
-from src.mcp_server import create_server, Tool
+from src.enhanced_mcp_server import create_server, Tool
 from src.tool_list import TOOLS
 from api.routes import register_routes, get_db
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp import types
+import anyio
+import json
+
+
+@dataclass
+class Tool:
+    """Representation of a callable tool with extra metadata."""
+
+    name: str
+    description: str
+    inputSchema: Dict[str, Any]
+    _implementation: Callable[..., Awaitable[Any]]
+    category: str
+    requires_auth: bool = False
+    rate_limit: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data.pop("_implementation", None)
+        return data
+
+
+def create_server() -> Server:
+    """Return a server instance exposing available tools."""
+
+    server = Server("helpdesk-ai-agent")
+
+    # Import inside function to avoid circular imports.
+    from .tool_list import TOOLS
+
+    @server.list_tools()
+    async def _list_tools() -> list[types.Tool]:
+        return [
+            types.Tool(name=t.name, description=t.description, inputSchema=t.inputSchema)
+            for t in TOOLS
+        ]
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: Dict[str, Any]) -> Iterable[types.Content]:
+        for tool in TOOLS:
+            if tool.name == name:
+                result = await tool._implementation(**arguments)
+                text = json.dumps(result)
+                return [types.TextContent(type="text", text=text)]
+        raise ValueError(f"Unknown tool: {name}")
+
+    return server
+
+
+def run_server() -> None:
+    """Run the MCP server using stdio transport."""
+
+    async def _main() -> None:
+        server = create_server()
+        async with stdio_server() as (read, write):
+            await server.run(read, write)
+
+    anyio.run(_main)

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List
 
-from .mcp_server import Tool
+from .enhanced_mcp_server import Tool
 from .tools import GET_TICKET, TICKET_COUNT, AI_ECHO
 
 TOOLS: List[Tool] = [

--- a/src/tools/ai_tools.py
+++ b/src/tools/ai_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from ..mcp_server import Tool
+from ..enhanced_mcp_server import Tool
 
 
 async def ai_echo(text: str) -> Dict[str, str]:
@@ -20,6 +20,9 @@ AI_ECHO = Tool(
         "properties": {"text": {"type": "string"}},
         "required": ["text"],
     },
+    category="ai",
+    requires_auth=False,
+    rate_limit=None,
     _implementation=ai_echo,
 )
 

--- a/src/tools/analytics_tools.py
+++ b/src/tools/analytics_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from ..mcp_server import Tool
+from ..enhanced_mcp_server import Tool
 
 
 async def ticket_count() -> Dict[str, int]:
@@ -17,6 +17,9 @@ TICKET_COUNT = Tool(
     name="ticket_count",
     description="Return the total number of tickets.",
     inputSchema={"type": "object", "properties": {}, "required": []},
+    category="analytics",
+    requires_auth=False,
+    rate_limit=None,
     _implementation=ticket_count,
 )
 

--- a/src/tools/ticket_tools.py
+++ b/src/tools/ticket_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from ..mcp_server import Tool
+from ..enhanced_mcp_server import Tool
 
 
 async def get_ticket(ticket_id: int) -> Dict[str, Any]:
@@ -20,6 +20,9 @@ GET_TICKET = Tool(
         "properties": {"ticket_id": {"type": "integer"}},
         "required": ["ticket_id"],
     },
+    category="ticket",
+    requires_auth=False,
+    rate_limit=None,
     _implementation=get_ticket,
 )
 

--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -22,4 +22,6 @@ async def test_tools_list_route():
         resp = await client.get("/tools")
         assert resp.status_code == 200
         tools = resp.json()
-        assert any(t["name"] == "get_ticket" for t in tools)
+        assert any(t["name"] == "get_ticket" and t["category"] == "ticket" for t in tools)
+        assert any(t["name"] == "ticket_count" and t["category"] == "analytics" for t in tools)
+        assert any(t["name"] == "ai_echo" and t["category"] == "ai" for t in tools)


### PR DESCRIPTION
## Summary
- add `enhanced_mcp_server` with metadata-aware `Tool`
- categorize demo tools and update tool list
- expose tool metadata through `/tools`
- test that tools are returned with correct categories

## Testing
- `pytest tests/test_dynamic_tools.py::test_tools_list_route -q`
- `pytest -q` *(fails: OperationalError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_686e6f851cc4832b9f4e74f8a053ed69