### PR TITLE
Add enhanced MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ GRAPH_TENANT_ID=your-tenant-id
 # AI settings
 MCP_URL=http://localhost:8008
 MCP_STREAM_TIMEOUT=30
+# Enable the enhanced MCP tool server (set to 0 for the basic server)
+ENABLE_ENHANCED_MCP=1
 
 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
     (default `http://localhost:8080`).
   - `MCP_STREAM_TIMEOUT` – timeout in seconds for streaming AI responses
     (default `30`).
+  - `ENABLE_ENHANCED_MCP` – set to `0` to disable the enhanced MCP tool server
+    and use the basic implementation.
 
 
   They can be provided in the shell environment or in a `.env` file in the project root.

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from fastapi_mcp import FastApiMCP
 
-from src.mcp_server import create_server, Tool
+from src.mcp_server import create_enhanced_server, create_server, Tool
 from src.tool_list import TOOLS
 from api.routes import register_routes, get_db
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -70,7 +70,11 @@ app.add_middleware(SlowAPIMiddleware)
 register_routes(app)
 
 # --- Dynamically expose MCP tools as HTTP endpoints ---
-server = create_server()
+server = create_enhanced_server()
+if getattr(server, "is_enhanced", False):
+    logger.info("Enhanced MCP server active with %d tools", len(getattr(server, "_tools", [])))
+else:
+    logger.info("Basic MCP server active")
 
 def build_endpoint(tool: Tool, schema: Dict[str, Any]):
     async def endpoint(request: Request):
@@ -89,8 +93,12 @@ for tool in TOOLS:
     app.post(f"/{tool.name}", operation_id=tool.name)(build_endpoint(tool, schema))
 
 @app.get("/tools")
-async def list_tools() -> List[dict]:
-    return [t.to_dict() for t in TOOLS]
+async def list_tools() -> Dict[str, Any]:
+    return {
+        "enhanced": getattr(server, "is_enhanced", False),
+        "count": len(TOOLS),
+        "tools": [t.to_dict() for t in TOOLS],
+    }
 
 app.state.mcp = FastApiMCP(app)
 app.state.mcp.mount()
@@ -159,3 +167,12 @@ async def health(db: AsyncSession = Depends(get_db)) -> dict:
 
     uptime = (datetime.now(UTC) - START_TIME).total_seconds()
     return {"db": db_status, "uptime": uptime, "version": APP_VERSION}
+
+
+@app.get("/health/mcp")
+async def health_mcp() -> Dict[str, Any]:
+    """Return health information about the MCP server."""
+    return {
+        "enhanced": getattr(server, "is_enhanced", False),
+        "tool_count": len(TOOLS),
+    }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "1.0.0"
 
-from .mcp_server import Tool, create_server, run_server
+from .mcp_server import Tool, create_server, create_enhanced_server, run_server
 from mcp.server import Server
 
-__all__ = ["Tool", "Server", "create_server", "run_server"]
+__all__ = ["Tool", "Server", "create_server", "create_enhanced_server", "run_server"]

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, Iterable, List
+
+from mcp.server import Server
+from mcp import types
+
+from db.mssql import SessionLocal
+from .mcp_server import Tool
+
+# Business logic modules
+from tools import (
+    ai_tools,
+    analysis_tools,
+    asset_tools,
+    attachment_tools,
+    category_tools,
+    message_tools,
+    oncall_tools,
+    site_tools,
+    status_tools,
+    ticket_tools,
+    user_tools,
+    vendor_tools,
+)
+
+
+async def _with_session(func: Callable[..., Awaitable[Any]], **kwargs: Any) -> Any:
+    async with SessionLocal() as db:
+        return await func(db, **kwargs)
+
+
+def _db_wrapper(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+    async def wrapper(**kwargs: Any) -> Any:
+        return await _with_session(func, **kwargs)
+
+    return wrapper
+
+
+ENHANCED_TOOLS: List[Tool] = [
+    Tool(
+        name="get_asset",
+        description="Retrieve an asset by ID",
+        inputSchema={"type": "object", "properties": {"asset_id": {"type": "integer"}}, "required": ["asset_id"]},
+        _implementation=_db_wrapper(asset_tools.get_asset),
+    ),
+    Tool(
+        name="list_assets",
+        description="List assets",
+        inputSchema={"type": "object", "properties": {"skip": {"type": "integer"}, "limit": {"type": "integer"}}, "required": []},
+        _implementation=_db_wrapper(asset_tools.list_assets),
+    ),
+    Tool(
+        name="get_vendor",
+        description="Retrieve a vendor by ID",
+        inputSchema={"type": "object", "properties": {"vendor_id": {"type": "integer"}}, "required": ["vendor_id"]},
+        _implementation=_db_wrapper(vendor_tools.get_vendor),
+    ),
+    Tool(
+        name="list_vendors",
+        description="List vendors",
+        inputSchema={"type": "object", "properties": {"skip": {"type": "integer"}, "limit": {"type": "integer"}}, "required": []},
+        _implementation=_db_wrapper(vendor_tools.list_vendors),
+    ),
+    Tool(
+        name="get_site",
+        description="Retrieve a site by ID",
+        inputSchema={"type": "object", "properties": {"site_id": {"type": "integer"}}, "required": ["site_id"]},
+        _implementation=_db_wrapper(site_tools.get_site),
+    ),
+    Tool(
+        name="list_sites",
+        description="List sites",
+        inputSchema={"type": "object", "properties": {"skip": {"type": "integer"}, "limit": {"type": "integer"}}, "required": []},
+        _implementation=_db_wrapper(site_tools.list_sites),
+    ),
+    Tool(
+        name="list_categories",
+        description="List ticket categories",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+        _implementation=_db_wrapper(category_tools.list_categories),
+    ),
+    Tool(
+        name="list_statuses",
+        description="List ticket statuses",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+        _implementation=_db_wrapper(status_tools.list_statuses),
+    ),
+    Tool(
+        name="get_ticket",
+        description="Get expanded ticket by ID",
+        inputSchema={"type": "object", "properties": {"ticket_id": {"type": "integer"}}, "required": ["ticket_id"]},
+        _implementation=_db_wrapper(ticket_tools.get_ticket_expanded),
+    ),
+    Tool(
+        name="list_tickets",
+        description="List expanded tickets",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "skip": {"type": "integer"},
+                "limit": {"type": "integer"},
+            },
+            "required": [],
+        },
+        _implementation=_db_wrapper(ticket_tools.list_tickets_expanded),
+    ),
+    Tool(
+        name="search_tickets",
+        description="Search tickets",
+        inputSchema={"type": "object", "properties": {"query": {"type": "string"}, "limit": {"type": "integer"}}, "required": ["query"]},
+        _implementation=_db_wrapper(ticket_tools.search_tickets_expanded),
+    ),
+    Tool(
+        name="create_ticket",
+        description="Create a ticket",
+        inputSchema={"type": "object", "properties": {"ticket_obj": {"type": "object"}}, "required": ["ticket_obj"]},
+        _implementation=_db_wrapper(ticket_tools.create_ticket),
+    ),
+    Tool(
+        name="update_ticket",
+        description="Update a ticket",
+        inputSchema={"type": "object", "properties": {"ticket_id": {"type": "integer"}, "updates": {"type": "object"}}, "required": ["ticket_id", "updates"]},
+        _implementation=_db_wrapper(ticket_tools.update_ticket),
+    ),
+    Tool(
+        name="delete_ticket",
+        description="Delete a ticket",
+        inputSchema={"type": "object", "properties": {"ticket_id": {"type": "integer"}}, "required": ["ticket_id"]},
+        _implementation=_db_wrapper(ticket_tools.delete_ticket),
+    ),
+    Tool(
+        name="get_ticket_messages",
+        description="List messages for a ticket",
+        inputSchema={"type": "object", "properties": {"ticket_id": {"type": "integer"}}, "required": ["ticket_id"]},
+        _implementation=_db_wrapper(message_tools.get_ticket_messages),
+    ),
+    Tool(
+        name="post_ticket_message",
+        description="Post a new ticket message",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "ticket_id": {"type": "integer"},
+                "message": {"type": "string"},
+                "sender_code": {"type": "string"},
+                "sender_name": {"type": "string"},
+            },
+            "required": ["ticket_id", "message", "sender_code", "sender_name"],
+        },
+        _implementation=_db_wrapper(message_tools.post_ticket_message),
+    ),
+    Tool(
+        name="get_ticket_attachments",
+        description="Get attachments for a ticket",
+        inputSchema={"type": "object", "properties": {"ticket_id": {"type": "integer"}}, "required": ["ticket_id"]},
+        _implementation=_db_wrapper(attachment_tools.get_ticket_attachments),
+    ),
+    Tool(
+        name="tickets_by_status",
+        description="Count tickets by status",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+        _implementation=_db_wrapper(analysis_tools.tickets_by_status),
+    ),
+    Tool(
+        name="open_tickets_by_site",
+        description="Open ticket counts by site",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+        _implementation=_db_wrapper(analysis_tools.open_tickets_by_site),
+    ),
+    Tool(
+        name="open_tickets_by_user",
+        description="Open ticket counts by user",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+        _implementation=_db_wrapper(analysis_tools.open_tickets_by_user),
+    ),
+    Tool(
+        name="tickets_waiting_on_user",
+        description="Tickets waiting on user",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+        _implementation=_db_wrapper(analysis_tools.tickets_waiting_on_user),
+    ),
+    Tool(
+        name="sla_breaches",
+        description="Count SLA breaches",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "sla_days": {"type": "integer"},
+            },
+            "required": [],
+        },
+        _implementation=_db_wrapper(analysis_tools.sla_breaches),
+    ),
+    Tool(
+        name="ticket_trend",
+        description="Ticket trend",
+        inputSchema={"type": "object", "properties": {"days": {"type": "integer"}}, "required": []},
+        _implementation=_db_wrapper(analysis_tools.ticket_trend),
+    ),
+    Tool(
+        name="get_current_oncall",
+        description="Get current on-call shift",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+        _implementation=_db_wrapper(oncall_tools.get_current_oncall),
+    ),
+    Tool(
+        name="list_oncall_schedule",
+        description="List on-call schedule",
+        inputSchema={"type": "object", "properties": {"skip": {"type": "integer"}, "limit": {"type": "integer"}}, "required": []},
+        _implementation=_db_wrapper(oncall_tools.list_oncall_schedule),
+    ),
+    Tool(
+        name="ai_suggest_response",
+        description="AI suggested ticket response",
+        inputSchema={"type": "object", "properties": {"ticket": {"type": "object"}}, "required": ["ticket"]},
+        _implementation=ai_tools.ai_suggest_response,
+    ),
+    Tool(
+        name="get_user_by_email",
+        description="Look up user information by email",
+        inputSchema={"type": "object", "properties": {"email": {"type": "string"}}, "required": ["email"]},
+        _implementation=user_tools.get_user_by_email,
+    ),
+]
+"""Approximately 27 tools. Update count carefully if editing."""
+
+
+def create_server() -> Server:
+    server = Server("helpdesk-ai-agent")
+
+    @server.list_tools()
+    async def _list_tools() -> list[types.Tool]:
+        return [
+            types.Tool(name=t.name, description=t.description, inputSchema=t.inputSchema)
+            for t in ENHANCED_TOOLS
+        ]
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: Dict[str, Any]) -> Iterable[types.Content]:
+        for tool in ENHANCED_TOOLS:
+            if tool.name == name:
+                result = await tool._implementation(**arguments)
+                return [types.TextContent(type="text", text=json.dumps(result))]
+        raise ValueError(f"Unknown tool: {name}")
+
+    server._tools = ENHANCED_TOOLS
+    server.is_enhanced = True
+    return server

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, asdict
 from typing import Any, Awaitable, Callable, Dict, Iterable, List
+import logging
+import os
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -55,6 +57,8 @@ def create_server() -> Server:
                 return [types.TextContent(type="text", text=text)]
         raise ValueError(f"Unknown tool: {name}")
 
+    server._tools = TOOLS
+    server.is_enhanced = False
     return server
 
 
@@ -67,4 +71,25 @@ def run_server() -> None:
             await server.run(read, write)
 
     anyio.run(_main)
+
+
+def create_enhanced_server() -> Server:
+    """Attempt to create the enhanced server. Fallback to :func:`create_server`."""
+
+    env = os.getenv("ENABLE_ENHANCED_MCP", "1").lower()
+    if env in {"0", "false", "no"}:
+        logging.info("Enhanced MCP disabled via environment")
+        return create_server()
+
+    try:
+        from .enhanced_mcp_server import create_server as _create
+        server = _create()
+        server.is_enhanced = True
+        logging.info("Enhanced MCP server loaded with %d tools", len(server._tools))
+        return server
+    except Exception as exc:  # pragma: no cover - unexpected
+        logging.exception("Failed to load enhanced server: %s", exc)
+        base = create_server()
+        base.is_enhanced = False
+        return base
 

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from typing import List
 
-from .mcp_server import Tool
-from .tools import GET_TICKET, TICKET_COUNT, AI_ECHO
+from .mcp_server import Tool, create_enhanced_server
 
-TOOLS: List[Tool] = [
-    GET_TICKET,
-    TICKET_COUNT,
-    AI_ECHO,
-]
+try:
+    _server = create_enhanced_server()
+    TOOLS: List[Tool] = list(getattr(_server, "_tools", []))
+    if not TOOLS:
+        raise RuntimeError("no enhanced tools")
+except Exception:
+    from .tools import GET_TICKET, TICKET_COUNT, AI_ECHO
+
+    TOOLS = [GET_TICKET, TICKET_COUNT, AI_ECHO]

--- a/tests/test_enhanced_integration.py
+++ b/tests/test_enhanced_integration.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.mcp_server import create_enhanced_server
+from src.tool_list import TOOLS
+
+
+@pytest.mark.asyncio
+async def test_enhanced_server_tools(monkeypatch):
+    async def fake(ticket, context=""):
+        return {"ok": True}
+
+    monkeypatch.setattr("tools.ai_tools.ai_suggest_response", fake)
+
+    server = create_enhanced_server()
+    assert getattr(server, "is_enhanced", False)
+    assert len(TOOLS) >= 20
+    names = [t.name for t in TOOLS]
+    assert "ai_suggest_response" in names
+
+    tool = next(t for t in TOOLS if t.name == "ai_suggest_response")
+    tool._implementation = fake
+    result = await tool._implementation(ticket={})
+    assert result == {"ok": True}


### PR DESCRIPTION
## Summary
- build a collection of ~27 tools in `enhanced_mcp_server`
- allow main server to load an enhanced server if available
- expose metadata via `/tools` and `/health/mcp`
- expose environment variable `ENABLE_ENHANCED_MCP`
- add tests for the enhanced server

## Testing
- `pytest tests/test_enhanced_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6f89060c832bb84264967564adc7