### PR TITLE
Add OPENAI key example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,5 @@ GRAPH_TENANT_ID=your-tenant-id
 MCP_URL=http://localhost:8008
 MCP_STREAM_TIMEOUT=30
 
-
-
+# OpenAI settings
+OPENAI_API_KEY=your-api-key

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
     (default `http://localhost:8080`).
   - `MCP_STREAM_TIMEOUT` – timeout in seconds for streaming AI responses
     (default `30`).
+  - `OPENAI_API_KEY` – API key used by OpenAI-based tools.
 
 
   They can be provided in the shell environment or in a `.env` file in the project root.


### PR DESCRIPTION
## Summary
- note OPENAI_API_KEY in setup instructions
- add placeholder OPENAI_API_KEY to `.env.example`

## Testing
- `pip install -e .`
- `pytest -q` *(fails: OperationalError - no such table: main.Priorities)*

------
https://chatgpt.com/codex/tasks/task_e_686e6f9f4380832b95cbf9ee21a6885e