### PR TITLE
Add optional metadata fields to Tool dataclass

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -21,11 +21,20 @@ class Tool:
     description: str
     inputSchema: Dict[str, Any]
     _implementation: Callable[..., Awaitable[Any]]
+    category: str | None = None
+    requires_auth: bool = False
+    rate_limit: str | None = None
 
     def to_dict(self) -> Dict[str, Any]:
-        data = asdict(self)
-        data.pop("_implementation", None)
-        return data
+        # Serialize public fields while omitting the implementation callable
+        return {
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self.inputSchema,
+            "category": self.category,
+            "requires_auth": self.requires_auth,
+            "rate_limit": self.rate_limit,
+        }
 
 
 def create_server() -> Server:


### PR DESCRIPTION
## Summary
- allow Tool to track category, auth, and rate limits
- expose these new fields in `to_dict`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: NameError in `create_enhanced_server`)*

------
https://chatgpt.com/codex/tasks/task_e_686e7a802a44832bbaf151b08c541917