### PR TITLE
Adjust tool verification for new response format

### DIFF
--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -21,7 +21,8 @@ async def test_tools_list_route():
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/tools")
         assert resp.status_code == 200
-        tools = resp.json()
+        data = resp.json()
+        tools = data["tools"]
         assert any(t["name"] == "get_ticket" and t["category"] == "ticket" for t in tools)
         assert any(t["name"] == "ticket_count" and t["category"] == "analytics" for t in tools)
         assert any(t["name"] == "ai_echo" and t["category"] == "ai" for t in tools)

--- a/verify_tools.py
+++ b/verify_tools.py
@@ -11,11 +11,12 @@ EXPECTED_TOOLS: Dict[str, Set[str]] = {
 
 
 def verify(base_url: str) -> bool:
-    """Fetch /tools and verify the available tool names."""
+    """Fetch `/tools` and verify the available tool names."""
     url = base_url.rstrip('/') + '/tools'
     resp = requests.get(url, timeout=10)
     resp.raise_for_status()
-    tools = resp.json()
+    data = resp.json()
+    tools = data["tools"]
 
     reported = {t["name"] for t in tools}
     expected = set().union(*EXPECTED_TOOLS.values())


### PR DESCRIPTION
## Summary
- parse updated `/tools` response in `verify_tools.py`
- update dynamic tools test to expect `{"tools": [...]}`

## Testing
- `pytest -q` *(fails: Tool.__init__() got unexpected keyword argument 'category')*

------
https://chatgpt.com/codex/tasks/task_e_686e7a826ecc832bb3492c34010bfc57