### PR TITLE
Fix import for enhanced server

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,8 @@ from fastapi.encoders import jsonable_encoder
 from fastapi_mcp import FastApiMCP
 
 
-from src.enhanced_mcp_server import create_server, Tool
+# Import the server factory and Tool dataclass from the MCP package
+from src import create_enhanced_server, Tool
 
 from src.tool_list import TOOLS
 from api.routes import register_routes, get_db


### PR DESCRIPTION
## Summary
- import `create_enhanced_server` from `src` to avoid NameError

## Testing
- `pytest -k test_app_import -q` *(fails: TypeError: Tool.__init__() got an unexpected keyword argument 'category')*
- `uvicorn main:app --port 8080 --host 127.0.0.1 --loop asyncio` *(fails: TypeError: Tool.__init__() got an unexpected keyword argument 'category')*

------
https://chatgpt.com/codex/tasks/task_e_686e7a7f8580832b9ba783296953429d