### PR TITLE
Fix /tools response structure

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,8 +98,9 @@ for tool in TOOLS:
     app.post(f"/{tool.name}", operation_id=tool.name)(build_endpoint(tool, schema))
 
 @app.get("/tools")
-async def list_tools() -> List[Dict[str, Any]]:
-    return [t.to_dict() for t in TOOLS]
+async def list_tools() -> Dict[str, List[Dict[str, Any]]]:
+    """Return a dictionary of available tools."""
+    return {"tools": [t.to_dict() for t in TOOLS]}
 
 app.state.mcp = FastApiMCP(app)
 app.state.mcp.mount()


### PR DESCRIPTION
## Summary
- return tools in a JSON object

## Testing
- `ENABLE_ENHANCED_MCP=0 pytest tests/test_dynamic_tools.py::test_tools_list_route -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed6a6bf8c832b8409730f985af544