### PR TITLE
Clean up empty services package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["ai", "alembic", "api", "db", "schemas", "services", "tools", "src"]
+packages = ["ai", "alembic", "api", "db", "schemas", "tools", "src"]
 
 [tool.flake8]
 max-line-length = 100


### PR DESCRIPTION
## Summary
- remove empty services package
- stop including `services` in distribution package list

## Testing
- `pip install -e .`
- `flake8`
- `mypy .` *(fails: need type annotation for `server`)*
- `pytest -q` *(fails: AssertionError & TypeError in dynamic tools tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ed5ce934c832b9e31a2763318a289