### PR TITLE
Fix tool imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,8 +98,9 @@ for tool in TOOLS:
     app.post(f"/{tool.name}", operation_id=tool.name)(build_endpoint(tool, schema))
 
 @app.get("/tools")
-async def list_tools() -> List[Dict[str, Any]]:
-    return [t.to_dict() for t in TOOLS]
+async def list_tools() -> Dict[str, List[Dict[str, Any]]]:
+    """Return a mapping of available tools."""
+    return {"tools": [t.to_dict() for t in TOOLS]}
 
 app.state.mcp = FastApiMCP(app)
 app.state.mcp.mount()

--- a/src/tool_list.py
+++ b/src/tool_list.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List
 
 
-from .enhanced_mcp_server import Tool
+from .mcp_server import Tool
 from .tools import GET_TICKET, TICKET_COUNT, AI_ECHO
 
 TOOLS: List[Tool] = [

--- a/src/tools/ai_tools.py
+++ b/src/tools/ai_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from ..enhanced_mcp_server import Tool
+from ..mcp_server import Tool
 
 
 async def ai_echo(text: str) -> Dict[str, str]:

--- a/src/tools/analytics_tools.py
+++ b/src/tools/analytics_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from ..enhanced_mcp_server import Tool
+from ..mcp_server import Tool
 
 
 async def ticket_count() -> Dict[str, int]:

--- a/src/tools/ticket_tools.py
+++ b/src/tools/ticket_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from ..enhanced_mcp_server import Tool
+from ..mcp_server import Tool
 
 
 async def get_ticket(ticket_id: int) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- adjust dynamic `/tools` endpoint structure
- reference `Tool` from `mcp_server`

## Testing
- `pytest tests/test_dynamic_tools.py::test_tools_list_route --maxfail=1` *(fails: assert False)*

------
https://chatgpt.com/codex/tasks/task_e_686ed6a43c64832ba68f7119bf1d05b0