### PR TITLE
Standardize MCP port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ GRAPH_CLIENT_SECRET=your-client-secret
 GRAPH_TENANT_ID=your-tenant-id
 
 # AI settings
+# MCP server URL (default port is 8008)
 MCP_URL=http://localhost:8008
 MCP_STREAM_TIMEOUT=30
 # Enable the enhanced MCP tool server (set to 0 for the basic server)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
   - `GRAPH_CLIENT_ID`, `GRAPH_CLIENT_SECRET`, `GRAPH_TENANT_ID` – optional credentials used for Microsoft Graph
     lookups in `tools.user_tools`. When omitted, stub responses are returned.
   - `MCP_URL` – optional MCP server URL used by AI helper functions
-    (default `http://localhost:8080`).
+    (default `http://localhost:8008`).
   - `MCP_STREAM_TIMEOUT` – timeout in seconds for streaming AI responses
     (default `30`).
 
@@ -86,6 +86,9 @@ Build the image and start the containers:
 docker build -t helpdesk-agent .
 docker-compose up
 ```
+
+The MCP server will be available on `http://localhost:8008` when the
+containers are running.
 
 Compose reads variables from `.env`. Copy `.env.example` to `.env` and set
 values for required options such as `DB_CONN_STRING` and `OPENAI_API_KEY`.

--- a/ai/mcp_agent.py
+++ b/ai/mcp_agent.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - optional dependency
     StreamableHttpParameters = None  # type: ignore
     TextContent = None  # type: ignore
 
-MCP_URL = os.getenv("MCP_URL", "http://localhost:8080")
+MCP_URL = os.getenv("MCP_URL", "http://localhost:8008")
 MCP_STREAM_TIMEOUT = int(os.getenv("MCP_STREAM_TIMEOUT", "30"))
 
 logger = logging.getLogger(__name__)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       ENABLE_RATE_LIMITING: ${ENABLE_RATE_LIMITING:-true}
       ERROR_TRACKING_DSN: ${ERROR_TRACKING_DSN:-}
+    # Exposes the MCP server on port 8008
     ports:
       - "8008:8008"
     healthcheck:


### PR DESCRIPTION
## Summary
- document port 8008 in example env and README
- expose port in compose
- update MCP agent default

## Testing
- `pip install -r requirements.txt`
- `pip install httpx==0.27.0`
- `pytest -q` *(fails: test_dynamic_tool_routes, test_tools_list_route)*

------
https://chatgpt.com/codex/tasks/task_e_686ed5cda7a0832baa63392989d5ea21