### PR TITLE
Fix MCP client reconnect logic

### DIFF
--- a/ai/mcp_agent.py
+++ b/ai/mcp_agent.py
@@ -23,10 +23,18 @@ _client: ClientSessionGroup | None = None
 
 
 async def _get_client() -> "ClientSessionGroup":
+    """Return a connected MCP client instance.
+
+    The global client may be closed after use in a context manager. This
+    helper recreates and reconnects the client if no active sessions are
+    present so callers always get a usable connection.
+    """
+
     if ClientSessionGroup is None:
         raise ImportError("mcp package is required for MCP operations")
+
     global _client
-    if _client is None:
+    if _client is None or not getattr(_client, "sessions", []):
         _client = ClientSessionGroup()
         await _client.connect_to_server(
             StreamableHttpParameters(url=MCP_URL)


### PR DESCRIPTION
## Summary
- recreate MCP client in `_get_client` when previous one was closed
- explain reconnection behaviour in `_get_client` docstring

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed6a746dc832b8e30f8126c17115a