### PR TITLE
Add resilience patterns, pooling and caching

### DIFF
--- a/ai/mcp_agent.py
+++ b/ai/mcp_agent.py
@@ -20,30 +20,45 @@ MCP_STREAM_TIMEOUT = int(os.getenv("MCP_STREAM_TIMEOUT", "30"))
 logger = logging.getLogger(__name__)
 
 _client: ClientSessionGroup | None = None
+_connection_failures = 0
+_max_failures = 3
+_circuit_open = False
 
 
-async def _get_client() -> "ClientSessionGroup":
-    """Return a connected MCP client instance.
+async def _get_client() -> "ClientSessionGroup | None":
+    """Return a connected MCP client instance with circuit breaker."""
 
-    The global client may be closed after use in a context manager. This
-    helper recreates and reconnects the client if no active sessions are
-    present so callers always get a usable connection.
-    """
+    global _client, _connection_failures, _circuit_open
+
+    if _circuit_open:
+        logger.warning("MCP circuit breaker is open, skipping connection")
+        return None
 
     if ClientSessionGroup is None:
         raise ImportError("mcp package is required for MCP operations")
 
-    global _client
     if _client is None or not getattr(_client, "sessions", []):
-        _client = ClientSessionGroup()
-        await _client.connect_to_server(
-            StreamableHttpParameters(url=MCP_URL)
-        )
+        try:
+            _client = ClientSessionGroup()
+            await asyncio.wait_for(
+                _client.connect_to_server(StreamableHttpParameters(url=MCP_URL)),
+                timeout=MCP_STREAM_TIMEOUT,
+            )
+            _connection_failures = 0
+        except (asyncio.TimeoutError, Exception) as e:
+            logger.error("MCP connection failed: %s", e)
+            _connection_failures += 1
+            if _connection_failures >= _max_failures:
+                _circuit_open = True
+                logger.error("MCP circuit breaker opened")
+            return None
     return _client
 
 
 async def suggest_ticket_response(ticket: Dict[str, Any], context: str = "") -> str:
     client = await _get_client()
+    if not client:
+        return ""
     async with client:
         try:
             result = await client.call_tool(
@@ -65,37 +80,44 @@ async def stream_ticket_response(
     """Yield a suggested ticket response using MCP's progress streaming."""
     client = await _get_client()
 
-    queue: asyncio.Queue[str | None] = asyncio.Queue()
+    async def _generator() -> AsyncGenerator[str, None]:
+        if not client:
+            if False:
+                yield ""
+            return
 
-    async def _progress(progress: float, total: float | None, message: str | None) -> None:
-        if message:
-            await queue.put(message)
+        queue: asyncio.Queue[str | None] = asyncio.Queue()
 
-    async def _call() -> None:
-        try:
-            session = client._tool_to_session["suggest_ticket_response"]
-            session_tool_name = client.tools["suggest_ticket_response"].name
-            result = await session.call_tool(
-                session_tool_name,
-                {"ticket": ticket, "context": context},
-                progress_callback=_progress,
-            )
-            # If the server did not stream any chunks, fall back to final content
-            if result.content:
-                for block in result.content:
-                    if isinstance(block, TextContent):
-                        await queue.put(block.text)
-        except Exception:
-            logger.exception("MCP streaming request failed")
-        finally:
-            await queue.put(None)
+        async def _progress(progress: float, total: float | None, message: str | None) -> None:
+            if message:
+                await queue.put(message)
 
-    async with client:
-        task = asyncio.create_task(_call())
-        while True:
-            chunk = await queue.get()
-            if chunk is None:
-                break
-            yield chunk
-        await task
+        async def _call() -> None:
+            try:
+                session = client._tool_to_session["suggest_ticket_response"]
+                session_tool_name = client.tools["suggest_ticket_response"].name
+                result = await session.call_tool(
+                    session_tool_name,
+                    {"ticket": ticket, "context": context},
+                    progress_callback=_progress,
+                )
+                if result.content:
+                    for block in result.content:
+                        if isinstance(block, TextContent):
+                            await queue.put(block.text)
+            except Exception:
+                logger.exception("MCP streaming request failed")
+            finally:
+                await queue.put(None)
+
+        async with client:
+            task = asyncio.create_task(_call())
+            while True:
+                chunk = await queue.get()
+                if chunk is None:
+                    break
+                yield chunk
+            await task
+
+    return _generator()
 

--- a/db/mssql.py
+++ b/db/mssql.py
@@ -1,8 +1,16 @@
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy.pool import AsyncAdaptedQueuePool
 from config import DB_CONN_STRING
 import logging
 
-engine_args: dict[str, object] = {}
+
+engine_args: dict[str, object] = {
+    "pool_size": 10,
+    "max_overflow": 20,
+    "pool_pre_ping": True,
+    "pool_recycle": 3600,
+    "poolclass": AsyncAdaptedQueuePool,
+}
 
 if DB_CONN_STRING and DB_CONN_STRING.startswith("mssql"):
     if DB_CONN_STRING.startswith("mssql+pyodbc"):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -8,5 +8,6 @@ def test_health_ok():
     resp = client.get("/health")
     assert resp.status_code == 200
     data = resp.json()
-    assert set(data.keys()) == {"db", "uptime", "version"}
-    assert data["db"] == "ok"
+    assert set(data.keys()) == {"status", "timestamp", "version", "uptime", "checks"}
+    assert data["status"] in {"healthy", "degraded", "unhealthy"}
+    assert "database" in data["checks"]

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -39,9 +39,16 @@ async def list_tickets_expanded(
     query = select(VTicketMasterExpanded)
 
     if filters:
+        filter_conditions = []
         for key, value in filters.items():
             if hasattr(VTicketMasterExpanded, key):
-                query = query.filter(getattr(VTicketMasterExpanded, key) == value)
+                attr = getattr(VTicketMasterExpanded, key)
+                if isinstance(value, list):
+                    filter_conditions.append(attr.in_(value))
+                else:
+                    filter_conditions.append(attr == value)
+        if filter_conditions:
+            query = query.filter(and_(*filter_conditions))
 
     if sort:
         if isinstance(sort, str):
@@ -64,7 +71,7 @@ async def list_tickets_expanded(
         if order_columns:
             query = query.order_by(*order_columns)
     else:
-        query = query.order_by(VTicketMasterExpanded.Ticket_ID)
+        query = query.order_by(VTicketMasterExpanded.Ticket_ID.desc())
 
     if skip:
         query = query.offset(skip)


### PR DESCRIPTION
## Summary
- improve DB connection pooling using AsyncAdaptedQueuePool
- add request timeout and body size limit middleware
- enhance `/health` endpoint with dependency checks
- improve ticket filtering/sorting logic
- cache analytics results for tickets by status
- add MCP connection circuit breaker
- update health test

## Testing
- `pytest tests/test_health.py::test_health_ok -q`
- `pytest -q` *(failed: timeout / KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686edb75772c832bbe94c25644f1d6d2