### PR TITLE
Fix OpenAPI schema for sla_breaches status_id

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -327,7 +327,7 @@ async def waiting_on_user_endpoint(db: AsyncSession = Depends(get_db)) -> List[W
 async def sla_breaches_endpoint(
     request: Request,
     sla_days: int = Query(2, ge=0),
-    status_id: Optional[List[int]] = Query(None),
+    status_id: List[int] = Query(default_factory=list),
     db: AsyncSession = Depends(get_db),
 ) -> Dict[str, int]:
     filters = extract_filters(request)


### PR DESCRIPTION
## Summary
- ensure `status_id` query parameter is typed as a list

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870010cd600832b97bd29b7b2dae7eb