### PR TITLE
Fix comment about tool count

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -228,7 +228,8 @@ ENHANCED_TOOLS: List[Tool] = [
         _implementation=user_tools.get_user_by_email,
     ),
 ]
-"""Approximately 27 tools. Update count carefully if editing."""
+# Keep track of how many tools are defined for easier maintenance.
+TOOL_COUNT: int = len(ENHANCED_TOOLS)
 
 
 def create_server() -> Server:


### PR DESCRIPTION
## Summary
- replace outdated note about number of tools in `enhanced_mcp_server`
- dynamically store the tool count for easier maintenance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68700753239c832b9e786aa017736bcc