### PR TITLE
Add test setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install -r requirements.txt
-      - run: pip install mypy
+      - run: bash scripts/setup-tests.sh
       - run: flake8
       - name: Start API and run smoke tests
         run: |

--- a/README.md
+++ b/README.md
@@ -77,10 +77,20 @@ uvicorn main:app --reload
 
 ## Running tests
 
-Install the testing dependencies and run `flake8` and `pytest`:
+Install the dependencies from `requirements.txt` and the package itself before
+running the linters and tests. A helper script is provided to automate this
+setup:
 
 ```bash
-pip install -e .
+# install packages and verify required tools are available
+bash scripts/setup-tests.sh
+```
+
+The script installs everything with `pip install -r requirements.txt` and
+`pip install -e .`, then prints the versions of `flake8`, `pytest` and
+`httpx`. After running it (or manually installing the packages) execute:
+
+```bash
 flake8
 pytest
 ```

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# Install Python packages required for running tests
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+pip install -e .
+
+# Verify important packages are installed
+python - <<'PY'
+import flake8, pytest, httpx
+print('flake8', flake8.__version__)
+print('pytest', pytest.__version__)
+print('httpx', httpx.__version__)
+PY
+


### PR DESCRIPTION
## Summary
- add `scripts/setup-tests.sh` to install requirements and print versions
- document the script in `README.md`
- use the script in the CI workflow

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687007534150832babb196852e930c0e