### PR TITLE
Fix mypy errors

### DIFF
--- a/alembic/versions/2e80bc0ee0ea_create_expanded_ticket_view.py
+++ b/alembic/versions/2e80bc0ee0ea_create_expanded_ticket_view.py
@@ -7,7 +7,7 @@ Create Date: 2025-07-03 04:12:26.131518
 """
 from typing import Sequence, Union
 
-from alembic import op
+from alembic import op  # type: ignore[attr-defined]
 from db.sql import CREATE_VTICKET_MASTER_EXPANDED_VIEW_SQL
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,7 +1,7 @@
 import logging
 import json
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Dict, List, Optional, Union
+from typing import Any, AsyncGenerator, Dict, List, Optional, Sequence, Union
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
@@ -83,7 +83,13 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 # ─── Utility ──────────────────────────────────────────────────────────────────
 def extract_filters(
     request: Request,
-    exclude: List[str] = ("skip", "limit", "sort", "sla_days", "status_id")
+    exclude: Sequence[str] = (
+        "skip",
+        "limit",
+        "sort",
+        "sla_days",
+        "status_id",
+    ),
 ) -> Dict[str, Any]:
     """
     Extract arbitrary query parameters for filtering, excluding reserved keys.

--- a/main.py
+++ b/main.py
@@ -215,7 +215,7 @@ async def handle_unexpected(request: Request, exc: Exception):
 @app.get("/health")
 async def health(db: AsyncSession = Depends(get_db)) -> dict:
     """Enhanced health check with dependency testing."""
-    health_status = {
+    health_status: Dict[str, Any] = {
         "status": "healthy",
         "timestamp": datetime.now(UTC).isoformat(),
         "version": APP_VERSION,

--- a/tools/ai_tools.py
+++ b/tools/ai_tools.py
@@ -187,9 +187,10 @@ class AITools:
         client = await self._ensure_client()
         async with client:
             try:
-                async for chunk in mcp_stream_ticket_response(
+                generator = await mcp_stream_ticket_response(
                     ticket.model_dump(), prompt
-                ):
+                )
+                async for chunk in generator:
                     yield {"content": chunk}
             except Exception:
                 logger.exception("MCP stream failed")
@@ -202,7 +203,8 @@ def ai_suggest_response(ticket: Dict[str, Any], context: str = "") -> Any:
 
 async def ai_stream_response(ticket: Dict[str, Any], context: str = "") -> AsyncGenerator[str, None]:
     """Legacy helper: stream response chunks as plain strings."""
-    async for chunk in mcp_stream_ticket_response(ticket, context):
+    generator = await mcp_stream_ticket_response(ticket, context)
+    async for chunk in generator:
         yield chunk
 
 


### PR DESCRIPTION
## Summary
- silence `alembic` op type error
- iterate over MCP streams after awaiting generator creation
- relax filter param typing
- type health status dict

## Testing
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi_mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6870075378b4832b91e54c3510690957