### PR TITLE
Update deletion endpoint response

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -207,12 +207,15 @@ async def update_ticket_endpoint(
         raise HTTPException(status_code=404, detail="Ticket not found or no changes")
     return TicketOut.model_validate(updated)
 
-@ticket_router.delete("/{ticket_id}", status_code=204)
-async def delete_ticket_endpoint(ticket_id: int, db: AsyncSession = Depends(get_db)):
+@ticket_router.delete("/{ticket_id}", status_code=200)
+async def delete_ticket_endpoint(
+    ticket_id: int, db: AsyncSession = Depends(get_db)
+) -> Dict[str, bool]:
     success = await delete_ticket(db, ticket_id)
     if not success:
         logger.warning("Ticket %s not found for deletion", ticket_id)
         raise HTTPException(status_code=404, detail="Ticket not found")
+    return {"deleted": True}
 
 @ticket_router.get(
     "/{ticket_id}/messages",

--- a/tests/test_ticket_lifecycle.py
+++ b/tests/test_ticket_lifecycle.py
@@ -13,7 +13,7 @@ def create_sample_ticket():
         "Ticket_Contact_Email": "tester@example.com",
     }
     response = client.post("/ticket", json=payload)
-    assert response.status_code == 200
+    assert response.status_code == 201
     return response.json()
 
 


### PR DESCRIPTION
## Summary
- return JSON body after deleting a ticket
- expect 201 on ticket creation during lifecycle tests

## Testing
- `pytest -q tests/test_ticket_lifecycle.py`

------
https://chatgpt.com/codex/tasks/task_e_68700bc89038832ba9e8895a8a148911