### PR TITLE
Add Sentry error tracking option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
    pip install -e .
    ```
 
-   The requirements include `aioodbc` for async ODBC connections and `requests` for standard HTTP calls; `pyodbc` is no longer required.
+   The requirements include `aioodbc` for async ODBC connections and `requests` for standard HTTP calls; `pyodbc` is no longer required. The optional `sentry_sdk` package enables error tracking when `ERROR_TRACKING_DSN` is set.
 2. **Environment variables**
 
    The application requires the following variables:
@@ -37,8 +37,9 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
   - `ENABLE_RATE_LIMITING` – enable the SlowAPI limiter middleware used by
     `/ai` endpoints. Set to `false` or `0` to disable it (default `true`).
 
-  - `ERROR_TRACKING_DSN` – optional DSN for an error tracking service such as
-    Sentry. Leave empty to disable integration.
+  - `ERROR_TRACKING_DSN` – optional DSN for Sentry or another error tracking
+    service. When set, the application initializes `sentry_sdk` on startup to
+    capture unhandled exceptions.
 
 
   They can be provided in the shell environment or in a `.env` file in the project root.

--- a/config.py
+++ b/config.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 DB_CONN_STRING: str | None = os.getenv("DB_CONN_STRING")
+ERROR_TRACKING_DSN: str | None = os.getenv("ERROR_TRACKING_DSN")
 
 try:
     env_module = importlib.import_module("config_env")

--- a/main.py
+++ b/main.py
@@ -21,6 +21,8 @@ from limiter import limiter
 from errors import ErrorResponse, NotFoundError, ValidationError, DatabaseError
 from db.models import Base
 from db.mssql import engine
+from config import ERROR_TRACKING_DSN
+import sentry_sdk
 
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
@@ -56,6 +58,10 @@ async def lifespan(app: FastAPI):
         format="%(asctime)s - %(levelname)s - %(correlation_id)s - %(name)s - %(message)s",
     )
     logging.getLogger().addFilter(CorrelationIdFilter())
+
+    if ERROR_TRACKING_DSN:
+        sentry_sdk.init(dsn=ERROR_TRACKING_DSN)
+        logger.info("Sentry error tracking enabled")
 
     app.state.limiter = limiter
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "asgi_lifespan==2.1.0",
     "requests==2.32.3",
     "flake8==7.3.0",
+    "sentry-sdk==2.2.0",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ aioodbc==0.5.0
 asgi_lifespan==2.1.0
 requests==2.32.3
 flake8==7.3.0
+sentry-sdk==2.2.0


### PR DESCRIPTION
## Summary
- add sentry-sdk dependency
- expose `ERROR_TRACKING_DSN` in `config.py`
- init Sentry during startup if DSN provided
- document error tracking in README

## Testing
- `bash scripts/setup-tests.sh`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68700bc91eb4832b8e25b9b63404eed0