### PR TITLE
Make rate limiter optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ MCP_STREAM_TIMEOUT=30
 ENABLE_ENHANCED_MCP=1
 
 # Enhanced options
+# Enable SlowAPI rate limiter (set to false, 0, or no to disable)
 ENABLE_RATE_LIMITING=true
 ERROR_TRACKING_DSN=
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
     and use the basic implementation.
 
   - `ENABLE_RATE_LIMITING` – enable the SlowAPI limiter middleware used by
-    `/ai` endpoints. Set to `false` or `0` to disable it (default `true`).
+    `/ai` endpoints. Set to `false`, `0`, or `no` to disable it (default `true`).
 
   - `ERROR_TRACKING_DSN` – optional DSN for an error tracking service such as
     Sentry. Leave empty to disable integration.

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import text
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+import os
 
 from limiter import limiter
 from errors import ErrorResponse, NotFoundError, ValidationError, DatabaseError
@@ -72,7 +73,8 @@ app.add_exception_handler(
     RateLimitExceeded,
     lambda request, exc: JSONResponse(status_code=429, content={"detail": "Rate limit exceeded"}),
 )
-app.add_middleware(SlowAPIMiddleware)
+if os.getenv("ENABLE_RATE_LIMITING", "true").lower() not in {"0", "false", "no"}:
+    app.add_middleware(SlowAPIMiddleware)
 
 register_routes(app)
 


### PR DESCRIPTION
## Summary
- enable SlowAPI middleware only when `ENABLE_RATE_LIMITING` isn't `0`, `false`, or `no`
- clarify disabling rate limiting in README and `.env.example`

## Testing
- `bash scripts/setup-tests.sh`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68700bcaa190832bb8c7099e4c8f6965