### PR TITLE
Fix SLA breach status ID handling

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -138,6 +138,20 @@ async def test_sla_breaches_with_filters(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_sla_breaches_single_status_id(client: AsyncClient):
+    old = datetime.now(UTC) - timedelta(days=5)
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=3)
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=1)
+
+    resp = await client.get(
+        "/analytics/sla_breaches",
+        params={"status_id": 3, "sla_days": 2},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"breaches": 1}
+
+
+@pytest.mark.asyncio
 async def test_ticket_trend(client: AsyncClient):
     now = datetime.now(UTC)
     await _add_ticket(Created_Date=now - timedelta(days=2))

--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -120,7 +120,7 @@ async def sla_breaches(
     db: AsyncSession,
     sla_days: int = 2,
     filters: Optional[Dict[str, Any]] = None,
-    status_ids: Optional[List[int]] = None,
+    status_ids: Optional[List[int] | int] = None,
 ) -> int:
     """Count tickets older than `sla_days` with optional filtering."""
     logger.info(
@@ -133,6 +133,8 @@ async def sla_breaches(
     query = select(func.count(Ticket.Ticket_ID)).filter(Ticket.Created_Date < cutoff)
 
     if status_ids is not None:
+        if isinstance(status_ids, int):
+            status_ids = [status_ids]
         query = query.filter(Ticket.Ticket_Status_ID.in_(status_ids))
     else:
         query = query.filter(Ticket.Ticket_Status_ID != 3)


### PR DESCRIPTION
## Summary
- allow `sla_breaches` to accept a single int for `status_ids`
- test that the endpoint works with a single status ID in the query

## Testing
- `flake8` *(fails: various style violations)*
- `pytest -k sla_breaches_single_status_id -q`


------
https://chatgpt.com/codex/tasks/task_e_687018e92d9c832b89d372684e7310e1