### PR TITLE
Fix SLA breaching logic for closed tickets

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -138,6 +138,27 @@ async def test_sla_breaches_with_filters(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_sla_breaches_excludes_non_open(client: AsyncClient):
+    """Closed or waiting tickets should not count towards SLA breaches."""
+    old = datetime.now(UTC) - timedelta(days=5)
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=1)
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=4)
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=3)
+
+    resp = await client.get("/analytics/sla_breaches", params={"sla_days": 2})
+    assert resp.status_code == 200
+    # Only the open ticket should be counted
+    assert resp.json() == {"breaches": 1}
+
+    resp = await client.get(
+        "/analytics/sla_breaches",
+        params={"status_id": [3], "sla_days": 2},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"breaches": 1}
+
+
+@pytest.mark.asyncio
 async def test_ticket_trend(client: AsyncClient):
     now = datetime.now(UTC)
     await _add_ticket(Created_Date=now - timedelta(days=2))

--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -135,7 +135,8 @@ async def sla_breaches(
     if status_ids is not None:
         query = query.filter(Ticket.Ticket_Status_ID.in_(status_ids))
     else:
-        query = query.filter(Ticket.Ticket_Status_ID != 3)
+        # Default to counting only open or in-progress tickets
+        query = query.filter(Ticket.Ticket_Status_ID.in_([1, 2]))
 
     if filters:
         for key, value in filters.items():


### PR DESCRIPTION
## Summary
- restrict SLA breach check to open/in-progress ticket statuses
- add regression test that closed or waiting tickets do not count towards breaches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701856c484832b8d333842371a1a75