### PR TITLE
Fix SLA breaches status filter

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -148,12 +148,8 @@ async def test_sla_breaches_excludes_non_open(client: AsyncClient):
 
     resp = await client.get("/analytics/sla_breaches", params={"sla_days": 2})
     assert resp.status_code == 200
-    # Only the open ticket should be counted
-    assert resp.json() == {"breaches": 1}
-
-  
-    assert resp.status_code == 200
-    assert resp.json() == {"breaches": 1}
+    # Both open and waiting tickets should be counted
+    assert resp.json() == {"breaches": 2}
 
 
 @pytest.mark.asyncio

--- a/tools/analysis_tools.py
+++ b/tools/analysis_tools.py
@@ -140,8 +140,9 @@ async def sla_breaches(
     else:
 
         # Default to counting only open or in-progress tickets
-        query = query.filter(Ticket.Ticket_Status_ID.in_([1, 2]))
-        query = query.filter(Ticket.Ticket_Status_ID.in_([1, 2,4,5,6]))
+        query = query.filter(
+            Ticket.Ticket_Status_ID.in_([1, 2, 4, 5, 6])
+        )
 
     if filters:
         for key, value in filters.items():


### PR DESCRIPTION
## Summary
- deduplicate open status filter in `sla_breaches`
- adjust SLA breach test for new open status definition

## Testing
- `pytest tests/test_analytics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687588b32ba8832bae639d003faceb4f