### PR TITLE
Add closed and last-modified fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ SELECT t.Ticket_ID,
        t.Assigned_Email,
        t.Priority_ID,
        t.Assigned_Vendor_ID,
+       t.Closed_Date,
+       t.LastModified,
        v.Name AS Assigned_Vendor_Name,
        t.Resolution,
        p.Level AS Priority_Level

--- a/db/models.py
+++ b/db/models.py
@@ -22,6 +22,8 @@ class Ticket(Base):
     Assigned_Email = Column(String)
     Priority_ID = Column(Integer)
     Assigned_Vendor_ID = Column(Integer)
+    Closed_Date = Column(DateTime)
+    LastModified = Column(DateTime)
     Resolution = Column(Text)
 
 
@@ -130,6 +132,8 @@ class VTicketMasterExpanded(ViewBase):
     Assigned_Email = Column(String)
     Priority_ID = Column(Integer)
     Assigned_Vendor_ID = Column(Integer)
+    Closed_Date = Column(DateTime)
+    LastModified = Column(DateTime)
 
     Assigned_Vendor_Name = Column(String)
     Resolution = Column(Text)

--- a/db/sql.py
+++ b/db/sql.py
@@ -18,6 +18,8 @@ SELECT t.Ticket_ID,
        t.Assigned_Email,
        t.Priority_ID,
        t.Assigned_Vendor_ID,
+       t.Closed_Date,
+       t.LastModified,
        v.Name AS Assigned_Vendor_Name,
        t.Resolution,
        p.Level AS Priority_Level

--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -133,5 +133,7 @@ class TicketExpandedOut(TicketOut):
 
     Assigned_Vendor_Name: Optional[str] = None
     Priority_Level: Optional[str] = None
+    Closed_Date: Optional[datetime] = None
+    LastModified: Optional[datetime] = None
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True, str_max_length=None)

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -37,7 +37,7 @@ async def test_tickets_expanded_endpoint(client: AsyncClient):
         "Ticket_Contact_Email": "t@example.com",
     }
     created = await client.post("/ticket", json=payload)
-    assert created.status_code == 200
+    assert created.status_code == 201
     tid = created.json()["Ticket_ID"]
 
     resp = await client.get("/tickets/expanded")
@@ -46,20 +46,31 @@ async def test_tickets_expanded_endpoint(client: AsyncClient):
     assert data["total"] == 1
     item = data["items"][0]
     assert item["Ticket_ID"] == tid
-    assert "status_label" in item
-    assert "category_label" in item
+    assert "Ticket_Status_Label" in item
+    assert "Ticket_Category_Label" in item
     assert "Site_Label" in item
     assert "Site_ID" in item
+    assert "Closed_Date" in item
+    assert item["Closed_Date"] is None
+    assert "LastModified" in item
+    assert item["LastModified"] is None
 
 
 from schemas.ticket import TicketExpandedOut
 
 
 def test_ticket_expanded_schema():
-    data = {"Ticket_ID": 1, "Subject": "s", "Ticket_Status_Label": "Open", "Site_ID": 1}
+    data = {
+        "Ticket_ID": 1,
+        "Subject": "s",
+        "Ticket_Status_Label": "Open",
+        "Site_ID": 1,
+    }
     obj = TicketExpandedOut(**data)
     assert obj.Ticket_ID == 1
     assert obj.status_label == "Open"
+    assert obj.Closed_Date is None
+    assert obj.LastModified is None
 
 
 @pytest.mark.asyncio
@@ -129,3 +140,5 @@ def test_ticket_expanded_from_orm_blank_assigned_email():
     )
     obj = TicketExpandedOut.model_validate(ticket)
     assert obj.Assigned_Email is None
+    assert obj.Closed_Date is None
+    assert obj.LastModified is None


### PR DESCRIPTION
## Summary
- include `Closed_Date` and `LastModified` in ticket models
- expose new fields in `TicketExpandedOut`
- update expanded ticket tests
- document columns in view section

## Testing
- `pytest tests/test_tickets_expanded.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687588b10134832b80789bc72cdbdae7