### PR TITLE
Remove delete ticket API

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ LEFT JOIN Priority_Levels p ON p.ID = t.Priority_ID;
 - `GET /tickets/search` - search tickets by subject or body. Accepts the same
   optional fields as `/tickets` plus `sort=oldest|newest` to control ordering
 - `PUT /ticket/{id}` - update an existing ticket
-- `DELETE /ticket/{id}` - remove a ticket
 - `POST /ai/suggest_response` - generate an AI ticket reply
 - `POST /ai/suggest_response/stream` - stream an AI reply as it is generated
 - Ticket body and resolution fields now accept large text values; the previous

--- a/api/routes.py
+++ b/api/routes.py
@@ -18,7 +18,6 @@ from limiter import limiter
 from tools.ticket_tools import (
     create_ticket,
     update_ticket,
-    delete_ticket,
     get_ticket_expanded,
     list_tickets_expanded,
     search_tickets_expanded,
@@ -218,15 +217,6 @@ async def update_ticket_endpoint(
         raise HTTPException(status_code=404, detail="Ticket not found or no changes")
     return TicketOut.model_validate(updated)
 
-@ticket_router.delete("/{ticket_id}", status_code=200)
-async def delete_ticket_endpoint(
-    ticket_id: int, db: AsyncSession = Depends(get_db)
-) -> Dict[str, bool]:
-    success = await delete_ticket(db, ticket_id)
-    if not success:
-        logger.warning("Ticket %s not found for deletion", ticket_id)
-        raise HTTPException(status_code=404, detail="Ticket not found")
-    return {"deleted": True}
 
 @ticket_router.get(
     "/{ticket_id}/messages",

--- a/tests/test_ticket_lifecycle.py
+++ b/tests/test_ticket_lifecycle.py
@@ -38,9 +38,6 @@ def test_ticket_full_lifecycle():
     assert close_resp.status_code == 200
     assert close_resp.json()["Ticket_Status_ID"] == 3
 
-    delete_resp = client.delete(f"/ticket/{tid}")
-    assert delete_resp.status_code == 200
-    assert delete_resp.json() == {"deleted": True}
 
 
 def test_update_ticket_not_found():
@@ -48,9 +45,9 @@ def test_update_ticket_not_found():
     assert resp.status_code == 404
 
 
-def test_delete_ticket_not_found():
+def test_delete_ticket_not_allowed():
     resp = client.delete("/ticket/99999")
-    assert resp.status_code == 404
+    assert resp.status_code == 405
 
 
 def test_create_ticket_validation_error():


### PR DESCRIPTION
## Summary
- update API routes to drop the DELETE `/ticket/{id}` handler
- adjust lifecycle tests to expect `405` when deleting
- drop DELETE ticket mention from README

## Testing
- `flake8`
- `pytest tests/test_ticket_lifecycle.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687a575e5a34832bb7e06e2100de9574