### PR TITLE
Add filtering to open ticket analytics

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -313,9 +313,12 @@ async def tickets_by_status_endpoint(db: AsyncSession = Depends(get_db)) -> List
 async def open_by_site_endpoint(db: AsyncSession = Depends(get_db)) -> List[SiteOpenCount]:
     return await open_tickets_by_site(db)
 
-@analytics_router.get("/open_by_user", response_model=List[UserOpenCount])
-async def open_by_user_endpoint(db: AsyncSession = Depends(get_db)) -> List[UserOpenCount]:
-    return await open_tickets_by_user(db)
+@analytics_router.get("/open_by_assigned_user", response_model=List[UserOpenCount])
+async def open_by_assigned_user_endpoint(
+    request: Request, db: AsyncSession = Depends(get_db)
+) -> List[UserOpenCount]:
+    filters = extract_filters(request)
+    return await open_tickets_by_user(db, filters or None)
 
 
 @analytics_router.get("/staff_report", response_model=StaffTicketReport)

--- a/schemas/analytics.py
+++ b/schemas/analytics.py
@@ -17,6 +17,7 @@ class UserOpenCount(BaseModel):
     """Open ticket count grouped by assigned technician."""
 
     assigned_email: Optional[str]
+    assigned_name: Optional[str]
     count: int
 
 


### PR DESCRIPTION
## Summary
- add `assigned_name` to `UserOpenCount`
- allow filter parameters in `open_tickets_by_user`
- rename endpoint to `/analytics/open_by_assigned_user`
- expand analytics tests

## Testing
- `pytest -q tests/test_analytics.py::test_analytics_open_by_assigned_user -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6632918c832b8c569d8ee9529457