### PR TITLE
Add tickets_by_user lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ LEFT JOIN Priority_Levels p ON p.ID = t.Priority_ID;
   `q` for the query, `limit` for number of results (default `10`), and
   `include_closed` to search closed tickets. Returns structured results sorted
   by relevance.
+- `GET /tickets/by_user` - list tickets where the user is the contact,
+  assigned technician or has posted a message. Provide a name or email via the
+  `identifier` query parameter.
 - `PUT /ticket/{id}` - update an existing ticket
 - `POST /ai/suggest_response` - generate an AI ticket reply
 - `POST /ai/suggest_response/stream` - stream an AI reply as it is generated
@@ -317,6 +320,15 @@ python verify_tools.py http://localhost:8000
 ```
 
 Include this check in deployment pipelines to catch configuration issues early.
+
+### Tool Reference
+
+The MCP server exposes several JSON-RPC tools. `tickets_by_user` returns
+expanded ticket records related to a specific user.
+
+```bash
+curl "http://localhost:8000/tickets/by_user?identifier=user@example.com"
+```
 
 ## License
 

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -212,6 +212,20 @@ ENHANCED_TOOLS: List[Tool] = [
         _implementation=_db_wrapper(analysis_tools.open_tickets_by_user),
     ),
     Tool(
+        name="tickets_by_user",
+        description="List tickets related to a user",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "identifier": {"type": "string"},
+                "skip": {"type": "integer"},
+                "limit": {"type": "integer"},
+            },
+            "required": ["identifier"],
+        },
+        _implementation=_db_wrapper(ticket_tools.get_tickets_by_user),
+    ),
+    Tool(
         name="staff_ticket_report",
         description="Summary counts of tickets for a technician",
         inputSchema={

--- a/tests/test_tickets_by_user.py
+++ b/tests/test_tickets_by_user.py
@@ -1,0 +1,100 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from datetime import datetime, UTC
+
+from main import app
+from db.mssql import SessionLocal
+from db.models import Ticket, TicketMessage
+from tools.ticket_tools import create_ticket, get_tickets_by_user
+from src.mcp_server import create_enhanced_server
+
+@pytest.mark.asyncio
+async def test_get_tickets_by_user_function():
+    async with SessionLocal() as db:
+        now = datetime.now(UTC)
+        t1 = Ticket(
+            Subject="A",
+            Ticket_Body="b",
+            Ticket_Status_ID=1,
+            Ticket_Contact_Name="X",
+            Ticket_Contact_Email="user@example.com",
+            Created_Date=now,
+        )
+        t2 = Ticket(
+            Subject="B",
+            Ticket_Body="b",
+            Ticket_Status_ID=1,
+            Ticket_Contact_Name="Y",
+            Ticket_Contact_Email="y@example.com",
+            Assigned_Email="user@example.com",
+            Created_Date=now,
+        )
+        t3 = Ticket(
+            Subject="C",
+            Ticket_Body="b",
+            Ticket_Status_ID=1,
+            Ticket_Contact_Name="Z",
+            Ticket_Contact_Email="z@example.com",
+            Created_Date=now,
+        )
+        await create_ticket(db, t1)
+        await create_ticket(db, t2)
+        await create_ticket(db, t3)
+        msg = TicketMessage(
+            Ticket_ID=t3.Ticket_ID,
+            Message="hi",
+            SenderUserCode="user@example.com",
+            SenderUserName="User",
+            DateTimeStamp=now,
+        )
+        db.add(msg)
+        await db.commit()
+        res = await get_tickets_by_user(db, "USER@EXAMPLE.COM")
+        ids = {r.Ticket_ID for r in res}
+        assert ids == {t1.Ticket_ID, t2.Ticket_ID, t3.Ticket_ID}
+        limited = await get_tickets_by_user(db, "user@example.com", skip=1, limit=1)
+        assert len(limited) == 1
+
+
+@pytest.mark.asyncio
+async def test_tickets_by_user_endpoint():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        now = datetime.now(UTC)
+        async with SessionLocal() as db:
+            t = Ticket(
+                Subject="E",
+                Ticket_Body="b",
+                Ticket_Status_ID=1,
+                Ticket_Contact_Name="U",
+                Ticket_Contact_Email="endpoint@example.com",
+                Created_Date=now,
+            )
+            await create_ticket(db, t)
+        resp = await ac.get("/tickets/by_user", params={"identifier": "endpoint@example.com"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1
+        ids = [item["Ticket_ID"] for item in data["items"]]
+        assert t.Ticket_ID in ids
+
+
+@pytest.mark.asyncio
+async def test_tickets_by_user_tool():
+    now = datetime.now(UTC)
+    async with SessionLocal() as db:
+        t = Ticket(
+            Subject="Tool",
+            Ticket_Body="b",
+            Ticket_Status_ID=1,
+            Ticket_Contact_Name="T",
+            Ticket_Contact_Email="tool@example.com",
+            Created_Date=now,
+        )
+        await create_ticket(db, t)
+
+    server = create_enhanced_server()
+    tool = next(x for x in server._tools if x.name == "tickets_by_user")
+    res = await tool._implementation(identifier="tool@example.com")
+    ids = {r.Ticket_ID for r in res}
+    assert t.Ticket_ID in ids


### PR DESCRIPTION
## Summary
- support lookup of tickets by user
- expose tickets_by_user API endpoint and MCP tool
- document new capability
- test new tool and route

## Testing
- `bash scripts/setup-tests.sh`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a65c37be4832b8f7dfe1b4022828c