### PR TITLE
Add OperationResult abstraction

### DIFF
--- a/tests/test_operation_result.py
+++ b/tests/test_operation_result.py
@@ -1,0 +1,38 @@
+import pytest
+from datetime import datetime, UTC
+
+from db.mssql import SessionLocal
+from db.models import Ticket
+from tools.ticket_tools import create_ticket
+from tools.analysis_tools import tickets_by_status
+from tools.operation_result import OperationResult
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_returns_operation_result():
+    async with SessionLocal() as db:
+        ticket = Ticket(
+            Subject="OpRes",
+            Ticket_Body="b",
+            Ticket_Contact_Name="n",
+            Ticket_Contact_Email="e@example.com",
+            Created_Date=datetime.now(UTC),
+            Ticket_Status_ID=1,
+        )
+        result = await create_ticket(db, ticket)
+        assert isinstance(result, OperationResult)
+        assert result.success
+        assert isinstance(result.data, Ticket)
+
+
+@pytest.mark.asyncio
+async def test_tickets_by_status_failure(monkeypatch):
+    async with SessionLocal() as db:
+        async def fail_execute(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(db, "execute", fail_execute)
+        result = await tickets_by_status(db)
+        assert isinstance(result, OperationResult)
+        assert not result.success
+        assert result.error

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,1 +1,3 @@
 """Utility helpers for the HelpDesk API."""
+
+from .operation_result import OperationResult

--- a/tools/operation_result.py
+++ b/tools/operation_result.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+@dataclass
+class OperationResult(Generic[T]):
+    """Generic result wrapper for tool operations."""
+
+    success: bool
+    data: Optional[T] = None
+    error: Optional[str] = None


### PR DESCRIPTION
## Summary
- add `OperationResult` dataclass
- update ticket creation and analytics functions to return `OperationResult`
- adjust API routes to interpret the new return type
- test successful and failure cases for `OperationResult`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a700d8364832bbe47e002fa3b6f55