### PR TITLE
Add tickets_by_timeframe tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,14 @@ expanded ticket records related to a specific user.
 curl "http://localhost:8000/tickets/by_user?identifier=user@example.com"
 ```
 
+`tickets_by_timeframe` lists tickets filtered by status and age. Provide a
+number of `days` and optional `status` such as `open` or `closed`.
+
+```bash
+curl -X POST http://localhost:8000/tickets_by_timeframe \
+  -d '{"status": "open", "days": 7, "limit": 5}'
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -225,6 +225,20 @@ ENHANCED_TOOLS: List[Tool] = [
         _implementation=_db_wrapper(ticket_tools.get_tickets_by_user),
     ),
     Tool(
+        name="tickets_by_timeframe",
+        description="List tickets by timeframe and status",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "status": {"type": "string"},
+                "days": {"type": "integer"},
+                "limit": {"type": "integer"},
+            },
+            "required": [],
+        },
+        _implementation=_db_wrapper(ticket_tools.tickets_by_timeframe),
+    ),
+    Tool(
         name="staff_rp",
         description="Summary counts of tickets for a technician",
         inputSchema={


### PR DESCRIPTION
## Summary
- implement `tickets_by_timeframe` in `ticket_tools`
- register new tool in `enhanced_mcp_server`
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab7995348832b9e7781c628e58c8b