### PR TITLE
Add technician open-ticket filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ curl "http://localhost:8000/tickets/smart_search?q=unassigned+critical&limit=5"
   ]
   ```
 
+- `GET /analytics/open_by_assigned_user` - retrieve counts of open tickets for technicians. Use `Assigned_Email` or `Assigned_Name` query parameters to filter for a specific technician.
+
+  Example:
+
+  ```bash
+  curl "http://localhost:8000/analytics/open_by_assigned_user?Assigned_Email=tech@example.com"
+  ```
+
 
 ## CLI
 

--- a/prompt.ini
+++ b/prompt.ini
@@ -152,8 +152,9 @@ Based on general IT best practices:
 - `tickets_by_timeframe(status="open")`, `tickets_by_timeframe(status="recent")`  
 
 🏢 **Entity Lookups**  
-- `site_tools`, `asset_tools`, `vendor_tools`, `category_tools`  
-- `user_tools`: `resolve_user_display_name`  
+- `site_tools`, `asset_tools`, `vendor_tools`, `category_tools`
+- `user_tools`: `resolve_user_display_name`
+- `open_by_assigned_user` to count open tickets for a technician; pass `Assigned_Email` or `Assigned_Name` as needed.
 
 ━━━━━━━━ QUALITY INDICATORS ━━━━━━━━  
 

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -58,6 +58,12 @@ async def _search_tickets_smart(
     )
 
 
+async def _open_tickets_by_user_tool(db: Any, **kwargs: Any) -> Any:
+    """Pass kwargs as filters to open_tickets_by_user."""
+    filters = kwargs or None
+    return await analysis_tools.open_tickets_by_user(db, filters=filters)
+
+
 ENHANCED_TOOLS: List[Tool] = [
     Tool(
         name="g_asset",
@@ -207,8 +213,15 @@ ENHANCED_TOOLS: List[Tool] = [
     Tool(
         name="op_user",
         description="Open ticket counts by user",
-        inputSchema={"type": "object", "properties": {}, "required": []},
-        _implementation=_db_wrapper(analysis_tools.open_tickets_by_user),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "Assigned_Email": {"type": "string"},
+                "Assigned_Name": {"type": "string"},
+            },
+            "required": [],
+        },
+        _implementation=_db_wrapper(_open_tickets_by_user_tool),
     ),
     Tool(
         name="by_user",


### PR DESCRIPTION
## Summary
- support filtering in `op_user` MCP tool
- document technician ticket counts in prompt and README
- add missing `ai` package to install tests

## Testing
- `bash scripts/setup-tests.sh`
- `flake8` *(fails: E501 and others)*
- `pytest tests/test_analytics.py::test_analytics_open_by_assigned_user -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab79b28c8832baec1df388ec7580b