### PR TITLE
Support filtering tickets by user status

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ LEFT JOIN Priority_Levels p ON p.ID = t.Priority_ID;
   `include_closed` to search closed tickets. Returns structured results sorted
   by relevance.
 - `GET /tickets/by_user` - list tickets where the user is the contact,
-  assigned technician or has posted a message. Provide a name or email via the
-  `identifier` query parameter.
+  assigned technician or has posted a message. Provide an `identifier` and
+  optionally filter by `status` (open, closed or progress). Additional query
+  parameters are applied as column filters on `V_Ticket_Master_Expanded`.
 - `PUT /ticket/{id}` - update an existing ticket
 - Ticket body and resolution fields now accept large text values; the previous
   2000-character limit has been removed.
@@ -352,10 +353,11 @@ Include this check in deployment pipelines to catch configuration issues early.
 ### Tool Reference
 
 The MCP server exposes several JSON-RPC tools. `tickets_by_user` returns
-expanded ticket records related to a specific user.
+expanded ticket records for a user. It accepts an `identifier`, optional
+`status` and arbitrary `filters`.
 
 ```bash
-curl "http://localhost:8000/tickets/by_user?identifier=user@example.com"
+curl "http://localhost:8000/tickets/by_user?identifier=user@example.com&status=open"
 ```
 
 Tool endpoints validate request bodies against each tool's `inputSchema` using

--- a/api/routes.py
+++ b/api/routes.py
@@ -221,13 +221,34 @@ async def search_tickets_alias(
     operation_id="tickets_by_user",
 )
 async def tickets_by_user_endpoint(
+    request: Request,
     identifier: str = Query(..., min_length=1),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1),
+    status: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
 ) -> PaginatedResponse[TicketExpandedOut]:
-    items = await get_tickets_by_user(db, identifier, skip=skip, limit=limit)
-    total = len(await get_tickets_by_user(db, identifier, skip=0, limit=None))
+    filters = extract_filters(
+        request, exclude=["identifier", "skip", "limit", "status"]
+    )
+    items = await get_tickets_by_user(
+        db,
+        identifier,
+        skip=skip,
+        limit=limit,
+        status=status,
+        filters=filters or None,
+    )
+    total = len(
+        await get_tickets_by_user(
+            db,
+            identifier,
+            skip=0,
+            limit=None,
+            status=status,
+            filters=filters or None,
+        )
+    )
     validated: List[TicketExpandedOut] = [
         TicketExpandedOut.model_validate(t) for t in items
     ]

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -232,6 +232,8 @@ ENHANCED_TOOLS: List[Tool] = [
                 "identifier": {"type": "string"},
                 "skip": {"type": "integer"},
                 "limit": {"type": "integer"},
+                "status": {"type": "string"},
+                "filters": {"type": "object"},
             },
             "required": ["identifier"],
         },

--- a/tests/test_tickets_by_user.py
+++ b/tests/test_tickets_by_user.py
@@ -4,7 +4,7 @@ from datetime import datetime, UTC
 
 from main import app
 from db.mssql import SessionLocal
-from db.models import Ticket, TicketMessage
+from db.models import Ticket, TicketMessage, TicketStatus
 from tools.ticket_tools import create_ticket, get_tickets_by_user
 from src.mcp_server import create_enhanced_server
 
@@ -12,6 +12,10 @@ from src.mcp_server import create_enhanced_server
 async def test_get_tickets_by_user_function():
     async with SessionLocal() as db:
         now = datetime.now(UTC)
+        for sid, label in [(1, "Open"), (3, "Closed")]:
+            if not await db.get(TicketStatus, sid):
+                db.add(TicketStatus(ID=sid, Label=label))
+        await db.commit()
         t1 = Ticket(
             Subject="A",
             Ticket_Body="b",
@@ -40,6 +44,14 @@ async def test_get_tickets_by_user_function():
         await create_ticket(db, t1)
         await create_ticket(db, t2)
         await create_ticket(db, t3)
+        t4 = Ticket(
+            Subject="D",
+            Ticket_Body="b",
+            Ticket_Status_ID=3,
+            Ticket_Contact_Email="user@example.com",
+            Created_Date=now,
+        )
+        await create_ticket(db, t4)
         msg = TicketMessage(
             Ticket_ID=t3.Ticket_ID,
             Message="hi",
@@ -51,9 +63,12 @@ async def test_get_tickets_by_user_function():
         await db.commit()
         res = await get_tickets_by_user(db, "USER@EXAMPLE.COM")
         ids = {r.Ticket_ID for r in res}
-        assert ids == {t1.Ticket_ID, t2.Ticket_ID, t3.Ticket_ID}
+        assert ids == {t1.Ticket_ID, t2.Ticket_ID, t3.Ticket_ID, t4.Ticket_ID}
         limited = await get_tickets_by_user(db, "user@example.com", skip=1, limit=1)
         assert len(limited) == 1
+        closed_only = await get_tickets_by_user(db, "user@example.com", status="closed")
+        ids = {t.Ticket_ID for t in closed_only}
+        assert ids == {t4.Ticket_ID}
 
 
 @pytest.mark.asyncio
@@ -98,3 +113,62 @@ async def test_tickets_by_user_tool():
     res = await tool._implementation(identifier="tool@example.com")
     ids = {r.Ticket_ID for r in res}
     assert t.Ticket_ID in ids
+
+
+@pytest.mark.asyncio
+async def test_status_and_filtering():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        now = datetime.now(UTC)
+        async with SessionLocal() as db:
+            for sid, label in [(1, "Open"), (3, "Closed")]:
+                if not await db.get(TicketStatus, sid):
+                    db.add(TicketStatus(ID=sid, Label=label))
+            await db.commit()
+            open_t = Ticket(
+                Subject="OpenF",
+                Ticket_Body="b",
+                Ticket_Status_ID=1,
+                Ticket_Contact_Email="filter@example.com",
+                Site_ID=1,
+                Created_Date=now,
+            )
+            closed_t = Ticket(
+                Subject="ClosedF",
+                Ticket_Body="b",
+                Ticket_Status_ID=3,
+                Ticket_Contact_Email="filter@example.com",
+                Site_ID=2,
+                Created_Date=now,
+            )
+            await create_ticket(db, open_t)
+            await create_ticket(db, closed_t)
+
+        resp = await ac.get(
+            "/tickets/by_user",
+            params={"identifier": "filter@example.com", "status": "closed"},
+        )
+        assert resp.status_code == 200
+        ids = [i["Ticket_ID"] for i in resp.json()["items"]]
+        assert ids == [closed_t.Ticket_ID]
+
+        resp = await ac.get(
+            "/tickets/by_user",
+            params={"identifier": "filter@example.com", "Site_ID": 1},
+        )
+        assert resp.status_code == 200
+        ids = [i["Ticket_ID"] for i in resp.json()["items"]]
+        assert ids == [open_t.Ticket_ID]
+
+    server = create_enhanced_server()
+    tool = next(x for x in server._tools if x.name == "by_user")
+    res = await tool._implementation(
+        identifier="filter@example.com", status="closed"
+    )
+    ids = {r.Ticket_ID for r in res}
+    assert ids == {closed_t.Ticket_ID}
+    res = await tool._implementation(
+        identifier="filter@example.com", filters={"Site_ID": 1}
+    )
+    ids = {r.Ticket_ID for r in res}
+    assert ids == {open_t.Ticket_ID}


### PR DESCRIPTION
## Summary
- support `status` and `filters` in `get_tickets_by_user`
- extend by_user tool schema and REST endpoint
- update tests for new parameters
- document new options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac21821ac832bb4af1f704bcef302