### PR TITLE
Include tool schemas in OpenAPI docs

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,7 +140,16 @@ def build_endpoint(tool: Tool, schema: Dict[str, Any]):
 
 for tool in TOOLS:
     schema = tool.inputSchema if isinstance(tool.inputSchema, dict) else {}
-    app.post(f"/{tool.name}", operation_id=tool.name)(build_endpoint(tool, schema))
+    app.post(
+        f"/{tool.name}",
+        operation_id=tool.name,
+        summary=tool.description,
+        openapi_extra={
+            "requestBody": {
+                "content": {"application/json": {"schema": schema}}
+            }
+        },
+    )(build_endpoint(tool, schema))
 
 @app.get("/tools")
 async def list_tools() -> Dict[str, List[Dict[str, Any]]]:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -10,3 +10,14 @@ async def test_operation_ids_length():
             for operation in path_item.values():
                 operation_id = operation.get("operationId")
                 assert operation_id is None or len(operation_id) <= 50
+
+
+@pytest.mark.asyncio
+async def test_tool_request_body_present():
+    async with LifespanManager(app):
+        schema = app.openapi()
+        g_ticket_post = schema["paths"]["/g_ticket"]["post"]
+        assert "requestBody" in g_ticket_post
+        content = g_ticket_post["requestBody"]["content"]
+        assert "application/json" in content
+


### PR DESCRIPTION
## Summary
- expose each MCP tool's schema when creating endpoints
- ensure OpenAPI includes request body for tools
- test that `/g_ticket` has a JSON request body schema

## Testing
- `pytest -k openapi -q`

------
https://chatgpt.com/codex/tasks/task_e_687be86bfad0832ba1176263e0366441