### PR TITLE
Add schema examples for ticket create/update

### DIFF
--- a/schemas/ticket.py
+++ b/schemas/ticket.py
@@ -40,12 +40,28 @@ class TicketCreate(TicketBase):
     model_config = ConfigDict(
         str_max_length=None,
         json_schema_extra={
-            "example": {
-                "Subject": "Printer not working",
-                "Ticket_Body": "The office printer is jammed",
-                "Ticket_Contact_Name": "Jane Doe",
-                "Ticket_Contact_Email": "jane@example.com",
-            }
+            "examples": [
+                {
+                    "Subject": "Printer not working",
+                    "Ticket_Body": "The office printer is jammed and displays error code 34.",
+                    "Ticket_Contact_Name": "Jane Doe",
+                    "Ticket_Contact_Email": "jane@example.com",
+                    "Asset_ID": 5,
+                    "Site_ID": 2,
+                    "Ticket_Category_ID": 1,
+                },
+                {
+                    "Subject": "Website down",
+                    "Ticket_Body": "The main website returns a 500 Internal Server Error.",
+                    "Ticket_Contact_Name": "Alice Admin",
+                    "Ticket_Contact_Email": "alice@example.com",
+                    "Assigned_Name": "Bob Ops",
+                    "Assigned_Email": "bob.ops@example.com",
+                    "Ticket_Status_ID": 1,
+                    "Site_ID": 3,
+                    "Severity_ID": 3,
+                },
+            ]
         }
     )
 
@@ -67,7 +83,17 @@ class TicketUpdate(BaseModel):
     Assigned_Vendor_ID: Optional[int] = None
     Resolution: Optional[str] = None
 
-    model_config = ConfigDict(extra="forbid", str_max_length=None)
+    model_config = ConfigDict(
+        extra="forbid",
+        str_max_length=None,
+        json_schema_extra={
+            "examples": [
+                {"Subject": "Updated"},
+                {"Assigned_Name": "Agent", "Ticket_Status_ID": 2},
+                {"Ticket_Status_ID": 3},
+            ]
+        },
+    )
 
 
 class TicketIn(BaseModel):


### PR DESCRIPTION
## Summary
- expand examples for `TicketCreate`
- include API payload examples for `TicketUpdate`

## Testing
- `pytest -q` *(fails: AttributeError: module 'tools.cli' has no attribute 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687bf4b6fc80832ba96f2a746b0799e3