### PR TITLE
Enable filtering and ordering for reference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ LEFT JOIN Priority_Levels p ON p.ID = t.Priority_ID;
   assigned technician or has posted a message. Provide an `identifier` and
   optionally filter by `status` (open, closed or progress). Additional query
   parameters are applied as column filters on `V_Ticket_Master_Expanded`.
+- Lookup endpoints (`/lookup/assets`, `/lookup/vendors`, `/lookup/sites`,
+  `/lookup/categories`, `/lookup/statuses`) now accept arbitrary `filters`
+  and a `sort` parameter to order by any column.
 - `PUT /ticket/{id}` - update an existing ticket
 - Ticket body and resolution fields now accept large text values; the previous
   2000-character limit has been removed.

--- a/api/routes.py
+++ b/api/routes.py
@@ -428,11 +428,14 @@ lookup_router = APIRouter(prefix="/lookup", tags=["lookup"])
     operation_id="list_assets",
 )
 async def list_assets_endpoint(
+    request: Request,
     skip: int = Query(0, ge=0),
     limit: int = Query(10, ge=1),
     db: AsyncSession = Depends(get_db),
 ) -> List[AssetOut]:
-    assets = await list_assets(db, skip, limit)
+    filters = extract_filters(request)
+    sort = request.query_params.getlist("sort") or None
+    assets = await list_assets(db, skip, limit, filters=filters or None, sort=sort)
     return [AssetOut.model_validate(a) for a in assets]
 
 
@@ -454,11 +457,14 @@ async def get_asset_endpoint(asset_id: int, db: AsyncSession = Depends(get_db)) 
     operation_id="list_vendors",
 )
 async def list_vendors_endpoint(
+    request: Request,
     skip: int = Query(0, ge=0),
     limit: int = Query(10, ge=1),
     db: AsyncSession = Depends(get_db),
 ) -> List[VendorOut]:
-    vs = await list_vendors(db, skip, limit)
+    filters = extract_filters(request)
+    sort = request.query_params.getlist("sort") or None
+    vs = await list_vendors(db, skip, limit, filters=filters or None, sort=sort)
     return [VendorOut.model_validate(v) for v in vs]
 
 
@@ -480,11 +486,14 @@ async def get_vendor_endpoint(vendor_id: int, db: AsyncSession = Depends(get_db)
     operation_id="list_sites",
 )
 async def list_sites_endpoint(
+    request: Request,
     skip: int = Query(0, ge=0),
     limit: int = Query(10, ge=1),
     db: AsyncSession = Depends(get_db),
 ) -> List[SiteOut]:
-    ss = await list_sites(db, skip, limit)
+    filters = extract_filters(request)
+    sort = request.query_params.getlist("sort") or None
+    ss = await list_sites(db, skip, limit, filters=filters or None, sort=sort)
     return [SiteOut.model_validate(s) for s in ss]
 
 
@@ -505,8 +514,12 @@ async def get_site_endpoint(site_id: int, db: AsyncSession = Depends(get_db)) ->
     response_model=List[TicketCategoryOut],
     operation_id="list_categories",
 )
-async def list_categories_endpoint(db: AsyncSession = Depends(get_db)) -> List[TicketCategoryOut]:
-    cats = await list_categories(db)
+async def list_categories_endpoint(
+    request: Request, db: AsyncSession = Depends(get_db)
+) -> List[TicketCategoryOut]:
+    filters = extract_filters(request)
+    sort = request.query_params.getlist("sort") or None
+    cats = await list_categories(db, filters=filters or None, sort=sort)
     return [TicketCategoryOut.model_validate(c) for c in cats]
 
 
@@ -515,8 +528,12 @@ async def list_categories_endpoint(db: AsyncSession = Depends(get_db)) -> List[T
     response_model=List[TicketStatusOut],
     operation_id="list_statuses",
 )
-async def list_statuses_endpoint(db: AsyncSession = Depends(get_db)) -> List[TicketStatusOut]:
-    stats = await list_statuses(db)
+async def list_statuses_endpoint(
+    request: Request, db: AsyncSession = Depends(get_db)
+) -> List[TicketStatusOut]:
+    filters = extract_filters(request)
+    sort = request.query_params.getlist("sort") or None
+    stats = await list_statuses(db, filters=filters or None, sort=sort)
     return [TicketStatusOut.model_validate(s) for s in stats]
 
 

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -74,7 +74,16 @@ ENHANCED_TOOLS: List[Tool] = [
     Tool(
         name="l_assets",
         description="List assets",
-        inputSchema={"type": "object", "properties": {"skip": {"type": "integer"}, "limit": {"type": "integer"}}, "required": []},
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "skip": {"type": "integer"},
+                "limit": {"type": "integer"},
+                "filters": {"type": "object"},
+                "sort": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": [],
+        },
         _implementation=_db_wrapper(asset_tools.list_assets),
     ),
     Tool(
@@ -86,7 +95,16 @@ ENHANCED_TOOLS: List[Tool] = [
     Tool(
         name="l_vends",
         description="List vendors",
-        inputSchema={"type": "object", "properties": {"skip": {"type": "integer"}, "limit": {"type": "integer"}}, "required": []},
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "skip": {"type": "integer"},
+                "limit": {"type": "integer"},
+                "filters": {"type": "object"},
+                "sort": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": [],
+        },
         _implementation=_db_wrapper(vendor_tools.list_vendors),
     ),
     Tool(
@@ -98,19 +116,42 @@ ENHANCED_TOOLS: List[Tool] = [
     Tool(
         name="l_sites",
         description="List sites",
-        inputSchema={"type": "object", "properties": {"skip": {"type": "integer"}, "limit": {"type": "integer"}}, "required": []},
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "skip": {"type": "integer"},
+                "limit": {"type": "integer"},
+                "filters": {"type": "object"},
+                "sort": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": [],
+        },
         _implementation=_db_wrapper(site_tools.list_sites),
     ),
     Tool(
         name="l_cats",
         description="List ticket categories",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "filters": {"type": "object"},
+                "sort": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": [],
+        },
         _implementation=_db_wrapper(category_tools.list_categories),
     ),
     Tool(
         name="l_status",
         description="List ticket statuses",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "filters": {"type": "object"},
+                "sort": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": [],
+        },
         _implementation=_db_wrapper(status_tools.list_statuses),
     ),
     Tool(
@@ -127,6 +168,8 @@ ENHANCED_TOOLS: List[Tool] = [
             "properties": {
                 "skip": {"type": "integer"},
                 "limit": {"type": "integer"},
+                "filters": {"type": "object"},
+                "sort": {"type": "array", "items": {"type": "string"}},
             },
             "required": [],
         },
@@ -135,7 +178,15 @@ ENHANCED_TOOLS: List[Tool] = [
     Tool(
         name="s_tkts",
         description="Search tickets",
-        inputSchema={"type": "object", "properties": {"query": {"type": "string"}, "limit": {"type": "integer"}}, "required": ["query"]},
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "limit": {"type": "integer"},
+                "params": {"type": "object"},
+            },
+            "required": ["query"],
+        },
         _implementation=_db_wrapper(ticket_tools.search_tickets_expanded),
     ),
     Tool(
@@ -280,6 +331,8 @@ ENHANCED_TOOLS: List[Tool] = [
             "type": "object",
             "properties": {
                 "sla_days": {"type": "integer"},
+                "filters": {"type": "object"},
+                "status_id": {"oneOf": [{"type": "integer"}, {"type": "array", "items": {"type": "integer"}}]},
             },
             "required": [],
         },
@@ -300,7 +353,16 @@ ENHANCED_TOOLS: List[Tool] = [
     Tool(
         name="oc_sched",
         description="List on-call schedule",
-        inputSchema={"type": "object", "properties": {"skip": {"type": "integer"}, "limit": {"type": "integer"}}, "required": []},
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "skip": {"type": "integer"},
+                "limit": {"type": "integer"},
+                "filters": {"type": "object"},
+                "sort": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": [],
+        },
         _implementation=_db_wrapper(oncall_tools.list_oncall_schedule),
     ),
     Tool(

--- a/tests/test_oncall.py
+++ b/tests/test_oncall.py
@@ -31,6 +31,20 @@ async def test_list_oncall_schedule():
 
 
 @pytest.mark.asyncio
+async def test_oncall_schedule_filters_and_sort():
+    now = datetime.now(UTC)
+    s1 = await _add_shift("x@example.com", now + timedelta(hours=1), now + timedelta(hours=2))
+    s2 = await _add_shift("y@example.com", now + timedelta(hours=3), now + timedelta(hours=4))
+
+    async with SessionLocal() as db:
+        filtered = await list_oncall_schedule(db, filters={"user_email": "y@example.com"})
+        assert [s.user_email for s in filtered] == ["y@example.com"]
+
+        ordered = await list_oncall_schedule(db, sort=["-start_time"])
+        assert [s.id for s in ordered][:2] == [s2.id, s1.id]
+
+
+@pytest.mark.asyncio
 async def test_get_current_oncall_route():
     now = datetime.now(UTC)
     await _add_shift("active@example.com", now - timedelta(minutes=30), now + timedelta(minutes=30))

--- a/tests/test_reference_data_filters.py
+++ b/tests/test_reference_data_filters.py
@@ -1,0 +1,59 @@
+import pytest
+from datetime import datetime, UTC
+
+from db.mssql import SessionLocal
+from db.models import Asset, Vendor, Site, Ticket
+from tools import asset_tools, vendor_tools, site_tools, ticket_tools
+
+
+@pytest.mark.asyncio
+async def test_asset_vendor_site_filters_and_sort():
+    async with SessionLocal() as db:
+        a1 = Asset(Label="A1", Site_ID=1)
+        a2 = Asset(Label="A2", Site_ID=2)
+        v1 = Vendor(Name="V1")
+        v2 = Vendor(Name="V2")
+        s1 = Site(Label="S1")
+        s2 = Site(Label="S2")
+        db.add_all([a1, a2, v1, v2, s1, s2])
+        await db.commit()
+        await db.refresh(a1); await db.refresh(a2)
+        await db.refresh(v1); await db.refresh(v2)
+        await db.refresh(s1); await db.refresh(s2)
+
+        assets = await asset_tools.list_assets(db, filters={"Site_ID": 2})
+        assert [a.ID for a in assets] == [a2.ID]
+
+        vendors = await vendor_tools.list_vendors(db, sort=["-ID"])
+        assert [v.ID for v in vendors][:2] == [v2.ID, v1.ID]
+
+        sites = await site_tools.list_sites(db, filters={"ID": [s1.ID, s2.ID]}, sort=["-Label"])
+        assert [s.Label for s in sites] == sorted([s1.Label, s2.Label], reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_ticket_list_filters_and_sort():
+    async with SessionLocal() as db:
+        t1 = Ticket(
+            Subject="F1",
+            Ticket_Body="b",
+            Ticket_Contact_Name="n",
+            Ticket_Contact_Email="e",
+            Created_Date=datetime(2023, 1, 1, tzinfo=UTC),
+        )
+        t2 = Ticket(
+            Subject="F2",
+            Ticket_Body="b",
+            Ticket_Contact_Name="n",
+            Ticket_Contact_Email="e",
+            Created_Date=datetime(2023, 1, 2, tzinfo=UTC),
+        )
+        await ticket_tools.create_ticket(db, t1)
+        await ticket_tools.create_ticket(db, t2)
+
+        res = await ticket_tools.list_tickets_expanded(db, filters={"Subject": "F2"})
+        assert len(res) == 1 and res[0].Subject == "F2"
+
+        ordered = await ticket_tools.list_tickets_expanded(db, sort=["-Created_Date"])
+        ids = [t.Ticket_ID for t in ordered]
+        assert ids == sorted(ids, reverse=True)

--- a/tools/asset_tools.py
+++ b/tools/asset_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import Asset
+from typing import Any
 
 from .reference_data import ReferenceDataManager
 
@@ -20,10 +21,16 @@ async def get_asset(db: AsyncSession, asset_id: int) -> Asset | None:
     return await _manager.get_asset(db, asset_id)
 
 
-async def list_assets(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Asset]:
+async def list_assets(
+    db: AsyncSession,
+    skip: int = 0,
+    limit: int = 10,
+    filters: dict[str, Any] | None = None,
+    sort: list[str] | None = None,
+) -> list[Asset]:
     warnings.warn(
         "list_assets is deprecated; use ReferenceDataManager.list_assets",
         DeprecationWarning,
         stacklevel=2,
     )
-    return await _manager.list_assets(db, skip=skip, limit=limit)
+    return await _manager.list_assets(db, skip=skip, limit=limit, filters=filters, sort=sort)

--- a/tools/category_tools.py
+++ b/tools/category_tools.py
@@ -5,16 +5,21 @@ from __future__ import annotations
 import warnings
 from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import TicketCategory
+from typing import Any
 
 from .reference_data import ReferenceDataManager
 
 _manager = ReferenceDataManager()
 
 
-async def list_categories(db: AsyncSession) -> list[TicketCategory]:
+async def list_categories(
+    db: AsyncSession,
+    filters: dict[str, Any] | None = None,
+    sort: list[str] | None = None,
+) -> list[TicketCategory]:
     warnings.warn(
         "list_categories is deprecated; use ReferenceDataManager.list_categories",
         DeprecationWarning,
         stacklevel=2,
     )
-    return await _manager.list_categories(db)
+    return await _manager.list_categories(db, filters=filters, sort=sort)

--- a/tools/oncall_tools.py
+++ b/tools/oncall_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import warnings
 from sqlalchemy.ext.asyncio import AsyncSession
-from typing import Sequence
+from typing import Sequence, Any, List
 
 from db.models import OnCallShift
 
@@ -22,10 +22,16 @@ async def get_current_oncall(db: AsyncSession) -> OnCallShift | None:
     return await _manager.get_current_oncall(db)
 
 
-async def list_oncall_schedule(db: AsyncSession, skip: int = 0, limit: int = 10) -> Sequence[OnCallShift]:
+async def list_oncall_schedule(
+    db: AsyncSession,
+    skip: int = 0,
+    limit: int = 10,
+    filters: dict[str, Any] | None = None,
+    sort: list[str] | None = None,
+) -> Sequence[OnCallShift]:
     warnings.warn(
         "list_oncall_schedule is deprecated; use UserManager.list_oncall_schedule",
         DeprecationWarning,
         stacklevel=2,
     )
-    return await _manager.list_oncall_schedule(db, skip=skip, limit=limit)
+    return await _manager.list_oncall_schedule(db, skip=skip, limit=limit, filters=filters, sort=sort)

--- a/tools/reference_data.py
+++ b/tools/reference_data.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Sequence, Type
+from typing import Any, Sequence, Type, List
 
-from sqlalchemy import select
+from sqlalchemy import select, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import Asset, Site, Vendor, TicketCategory, TicketStatus
@@ -20,41 +20,222 @@ class ReferenceDataManager:
         return await db.get(Asset, asset_id)
 
     async def list_assets(
-        self, db: AsyncSession, skip: int = 0, limit: int = 10
+        self,
+        db: AsyncSession,
+        skip: int = 0,
+        limit: int = 10,
+        filters: dict[str, Any] | None = None,
+        sort: list[str] | None = None,
     ) -> list[Asset]:
-        result = await db.execute(
-            select(Asset).order_by(Asset.ID).offset(skip).limit(limit)
-        )
+        query = select(Asset)
+        if filters:
+            conditions = []
+            for key, value in filters.items():
+                if hasattr(Asset, key):
+                    attr = getattr(Asset, key)
+                    conditions.append(attr.in_(value) if isinstance(value, list) else attr == value)
+            if conditions:
+                query = query.filter(and_(*conditions))
+        if sort:
+            if isinstance(sort, str):
+                sort = [sort]
+            order_cols = []
+            for s in sort:
+                direction = "asc"
+                column = s
+                if s.startswith("-"):
+                    column = s[1:]
+                    direction = "desc"
+                elif " " in s:
+                    column, dir_part = s.rsplit(" ", 1)
+                    if dir_part.lower() in {"asc", "desc"}:
+                        direction = dir_part.lower()
+                if hasattr(Asset, column):
+                    attr = getattr(Asset, column)
+                    order_cols.append(attr.desc() if direction == "desc" else attr.asc())
+            if order_cols:
+                query = query.order_by(*order_cols)
+        else:
+            query = query.order_by(Asset.ID)
+        if skip:
+            query = query.offset(skip)
+        if limit:
+            query = query.limit(limit)
+        result = await db.execute(query)
         return list(result.scalars().all())
 
     async def get_site(self, db: AsyncSession, site_id: int) -> Site | None:
         return await db.get(Site, site_id)
 
     async def list_sites(
-        self, db: AsyncSession, skip: int = 0, limit: int = 10
+        self,
+        db: AsyncSession,
+        skip: int = 0,
+        limit: int = 10,
+        filters: dict[str, Any] | None = None,
+        sort: list[str] | None = None,
     ) -> list[Site]:
-        result = await db.execute(
-            select(Site).order_by(Site.ID).offset(skip).limit(limit)
-        )
+        query = select(Site)
+        if filters:
+            conditions = []
+            for key, value in filters.items():
+                if hasattr(Site, key):
+                    attr = getattr(Site, key)
+                    conditions.append(attr.in_(value) if isinstance(value, list) else attr == value)
+            if conditions:
+                query = query.filter(and_(*conditions))
+        if sort:
+            if isinstance(sort, str):
+                sort = [sort]
+            order_cols = []
+            for s in sort:
+                direction = "asc"
+                column = s
+                if s.startswith("-"):
+                    column = s[1:]
+                    direction = "desc"
+                elif " " in s:
+                    column, dir_part = s.rsplit(" ", 1)
+                    if dir_part.lower() in {"asc", "desc"}:
+                        direction = dir_part.lower()
+                if hasattr(Site, column):
+                    attr = getattr(Site, column)
+                    order_cols.append(attr.desc() if direction == "desc" else attr.asc())
+            if order_cols:
+                query = query.order_by(*order_cols)
+        else:
+            query = query.order_by(Site.ID)
+        if skip:
+            query = query.offset(skip)
+        if limit:
+            query = query.limit(limit)
+        result = await db.execute(query)
         return list(result.scalars().all())
 
     async def get_vendor(self, db: AsyncSession, vendor_id: int) -> Vendor | None:
         return await db.get(Vendor, vendor_id)
 
     async def list_vendors(
-        self, db: AsyncSession, skip: int = 0, limit: int = 10
+        self,
+        db: AsyncSession,
+        skip: int = 0,
+        limit: int = 10,
+        filters: dict[str, Any] | None = None,
+        sort: list[str] | None = None,
     ) -> list[Vendor]:
-        result = await db.execute(
-            select(Vendor).order_by(Vendor.ID).offset(skip).limit(limit)
-        )
+        query = select(Vendor)
+        if filters:
+            conditions = []
+            for key, value in filters.items():
+                if hasattr(Vendor, key):
+                    attr = getattr(Vendor, key)
+                    conditions.append(attr.in_(value) if isinstance(value, list) else attr == value)
+            if conditions:
+                query = query.filter(and_(*conditions))
+        if sort:
+            if isinstance(sort, str):
+                sort = [sort]
+            order_cols = []
+            for s in sort:
+                direction = "asc"
+                column = s
+                if s.startswith("-"):
+                    column = s[1:]
+                    direction = "desc"
+                elif " " in s:
+                    column, dir_part = s.rsplit(" ", 1)
+                    if dir_part.lower() in {"asc", "desc"}:
+                        direction = dir_part.lower()
+                if hasattr(Vendor, column):
+                    attr = getattr(Vendor, column)
+                    order_cols.append(attr.desc() if direction == "desc" else attr.asc())
+            if order_cols:
+                query = query.order_by(*order_cols)
+        else:
+            query = query.order_by(Vendor.ID)
+        if skip:
+            query = query.offset(skip)
+        if limit:
+            query = query.limit(limit)
+        result = await db.execute(query)
         return list(result.scalars().all())
 
-    async def list_categories(self, db: AsyncSession) -> list[TicketCategory]:
-        result = await db.execute(select(TicketCategory))
+    async def list_categories(
+        self,
+        db: AsyncSession,
+        filters: dict[str, Any] | None = None,
+        sort: list[str] | None = None,
+    ) -> list[TicketCategory]:
+        query = select(TicketCategory)
+        if filters:
+            conditions = []
+            for key, value in filters.items():
+                if hasattr(TicketCategory, key):
+                    attr = getattr(TicketCategory, key)
+                    conditions.append(attr.in_(value) if isinstance(value, list) else attr == value)
+            if conditions:
+                query = query.filter(and_(*conditions))
+        if sort:
+            if isinstance(sort, str):
+                sort = [sort]
+            order_cols = []
+            for s in sort:
+                direction = "asc"
+                column = s
+                if s.startswith("-"):
+                    column = s[1:]
+                    direction = "desc"
+                elif " " in s:
+                    column, dir_part = s.rsplit(" ", 1)
+                    if dir_part.lower() in {"asc", "desc"}:
+                        direction = dir_part.lower()
+                if hasattr(TicketCategory, column):
+                    attr = getattr(TicketCategory, column)
+                    order_cols.append(attr.desc() if direction == "desc" else attr.asc())
+            if order_cols:
+                query = query.order_by(*order_cols)
+        else:
+            query = query.order_by(TicketCategory.ID)
+        result = await db.execute(query)
         return list(result.scalars().all())
 
-    async def list_statuses(self, db: AsyncSession) -> list[TicketStatus]:
-        result = await db.execute(select(TicketStatus))
+    async def list_statuses(
+        self,
+        db: AsyncSession,
+        filters: dict[str, Any] | None = None,
+        sort: list[str] | None = None,
+    ) -> list[TicketStatus]:
+        query = select(TicketStatus)
+        if filters:
+            conditions = []
+            for key, value in filters.items():
+                if hasattr(TicketStatus, key):
+                    attr = getattr(TicketStatus, key)
+                    conditions.append(attr.in_(value) if isinstance(value, list) else attr == value)
+            if conditions:
+                query = query.filter(and_(*conditions))
+        if sort:
+            if isinstance(sort, str):
+                sort = [sort]
+            order_cols = []
+            for s in sort:
+                direction = "asc"
+                column = s
+                if s.startswith("-"):
+                    column = s[1:]
+                    direction = "desc"
+                elif " " in s:
+                    column, dir_part = s.rsplit(" ", 1)
+                    if dir_part.lower() in {"asc", "desc"}:
+                        direction = dir_part.lower()
+                if hasattr(TicketStatus, column):
+                    attr = getattr(TicketStatus, column)
+                    order_cols.append(attr.desc() if direction == "desc" else attr.asc())
+            if order_cols:
+                query = query.order_by(*order_cols)
+        else:
+            query = query.order_by(TicketStatus.ID)
+        result = await db.execute(query)
         return list(result.scalars().all())
 
     async def get_by_id(

--- a/tools/site_tools.py
+++ b/tools/site_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import Site
+from typing import Any
 
 from .reference_data import ReferenceDataManager
 
@@ -20,10 +21,16 @@ async def get_site(db: AsyncSession, site_id: int) -> Site | None:
     return await _manager.get_site(db, site_id)
 
 
-async def list_sites(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Site]:
+async def list_sites(
+    db: AsyncSession,
+    skip: int = 0,
+    limit: int = 10,
+    filters: dict[str, Any] | None = None,
+    sort: list[str] | None = None,
+) -> list[Site]:
     warnings.warn(
         "list_sites is deprecated; use ReferenceDataManager.list_sites",
         DeprecationWarning,
         stacklevel=2,
     )
-    return await _manager.list_sites(db, skip=skip, limit=limit)
+    return await _manager.list_sites(db, skip=skip, limit=limit, filters=filters, sort=sort)

--- a/tools/status_tools.py
+++ b/tools/status_tools.py
@@ -5,16 +5,21 @@ from __future__ import annotations
 import warnings
 from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import TicketStatus
+from typing import Any
 
 from .reference_data import ReferenceDataManager
 
 _manager = ReferenceDataManager()
 
 
-async def list_statuses(db: AsyncSession) -> list[TicketStatus]:
+async def list_statuses(
+    db: AsyncSession,
+    filters: dict[str, Any] | None = None,
+    sort: list[str] | None = None,
+) -> list[TicketStatus]:
     warnings.warn(
         "list_statuses is deprecated; use ReferenceDataManager.list_statuses",
         DeprecationWarning,
         stacklevel=2,
     )
-    return await _manager.list_statuses(db)
+    return await _manager.list_statuses(db, filters=filters, sort=sort)

--- a/tools/ticket_tools.py
+++ b/tools/ticket_tools.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import Ticket, VTicketMasterExpanded
+from schemas.search_params import TicketSearchParams
 
 from .ticket_management import TicketManager, TicketTools
 
@@ -49,6 +50,8 @@ async def search_tickets_expanded(
         DeprecationWarning,
         stacklevel=2,
     )
+    if params is not None and not isinstance(params, TicketSearchParams):
+        params = TicketSearchParams(**params)
     return await _manager.search_tickets(db, query=query, limit=limit, params=params)
 
 

--- a/tools/user_services.py
+++ b/tools/user_services.py
@@ -103,11 +103,53 @@ class UserManager:
         return shift
 
     async def list_oncall_schedule(
-        self, db: AsyncSession, skip: int = 0, limit: int = 10
+        self,
+        db: AsyncSession,
+        skip: int = 0,
+        limit: int = 10,
+        filters: Dict[str, Any] | None = None,
+        sort: List[str] | None = None,
     ) -> Sequence[OnCallShift]:
-        result = await db.execute(
-            select(OnCallShift).order_by(OnCallShift.start_time).offset(skip).limit(limit)
-        )
+        query = select(OnCallShift)
+        if filters:
+            for key, value in list(filters.items()):
+                if key == "start_from":
+                    query = query.filter(OnCallShift.start_time >= value)
+                elif key == "start_to":
+                    query = query.filter(OnCallShift.start_time <= value)
+                elif key == "end_from":
+                    query = query.filter(OnCallShift.end_time >= value)
+                elif key == "end_to":
+                    query = query.filter(OnCallShift.end_time <= value)
+                elif hasattr(OnCallShift, key):
+                    attr = getattr(OnCallShift, key)
+                    query = query.filter(attr.in_(value) if isinstance(value, list) else attr == value)
+        if sort:
+            if isinstance(sort, str):
+                sort = [sort]
+            order_cols = []
+            for s in sort:
+                direction = "asc"
+                column = s
+                if s.startswith("-"):
+                    column = s[1:]
+                    direction = "desc"
+                elif " " in s:
+                    column, dir_part = s.rsplit(" ", 1)
+                    if dir_part.lower() in {"asc", "desc"}:
+                        direction = dir_part.lower()
+                if hasattr(OnCallShift, column):
+                    attr = getattr(OnCallShift, column)
+                    order_cols.append(attr.desc() if direction == "desc" else attr.asc())
+            if order_cols:
+                query = query.order_by(*order_cols)
+        else:
+            query = query.order_by(OnCallShift.start_time)
+        if skip:
+            query = query.offset(skip)
+        if limit:
+            query = query.limit(limit)
+        result = await db.execute(query)
         return result.scalars().all()
 
     # Context helpers ---------------------------------------------------

--- a/tools/vendor_tools.py
+++ b/tools/vendor_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from sqlalchemy.ext.asyncio import AsyncSession
 from db.models import Vendor
+from typing import Any
 
 from .reference_data import ReferenceDataManager
 
@@ -20,10 +21,16 @@ async def get_vendor(db: AsyncSession, vendor_id: int) -> Vendor | None:
     return await _manager.get_vendor(db, vendor_id)
 
 
-async def list_vendors(db: AsyncSession, skip: int = 0, limit: int = 10) -> list[Vendor]:
+async def list_vendors(
+    db: AsyncSession,
+    skip: int = 0,
+    limit: int = 10,
+    filters: dict[str, Any] | None = None,
+    sort: list[str] | None = None,
+) -> list[Vendor]:
     warnings.warn(
         "list_vendors is deprecated; use ReferenceDataManager.list_vendors",
         DeprecationWarning,
         stacklevel=2,
     )
-    return await _manager.list_vendors(db, skip=skip, limit=limit)
+    return await _manager.list_vendors(db, skip=skip, limit=limit, filters=filters, sort=sort)


### PR DESCRIPTION
## Summary
- allow filtering and sorting in reference data lookups
- wire new parameters through helper modules and API routes
- support filters & sort for on-call schedule
- accept filter params in MCP tool schemas
- document lookup filtering options
- test asset/vendor/site filters and on-call schedule filters

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c4f2d2fc0832bbebbf7eca7b44664