### PR TITLE
Fix logging setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,8 +34,7 @@ import uuid
 import asyncio
 from typing import List, Dict, Any
 
-# Configure root logger so messages are output when running with uvicorn
-logging.basicConfig(level=logging.INFO)
+# Configure logger for this module
 logger = logging.getLogger(__name__)
 
 # Correlation ID context variable for log records


### PR DESCRIPTION
## Summary
- remove redundant root logger configuration in `main.py`
- keep logging setup inside `lifespan`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c556d974c832bba80f5000a91256d