### PR TITLE
Handle DB errors when posting messages

### DIFF
--- a/tests/test_ticket_messages.py
+++ b/tests/test_ticket_messages.py
@@ -1,0 +1,23 @@
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from tools.ticket_management import TicketManager
+from db.mssql import SessionLocal
+from errors import DatabaseError
+
+
+@pytest.mark.asyncio
+async def test_post_message_db_error(monkeypatch):
+    manager = TicketManager()
+    async with SessionLocal() as db:
+        async def fail_commit():
+            raise SQLAlchemyError("fail")
+
+        async def dummy_rollback():
+            pass
+
+        monkeypatch.setattr(db, "commit", fail_commit)
+        monkeypatch.setattr(db, "rollback", dummy_rollback)
+
+        with pytest.raises(DatabaseError):
+            await manager.post_message(db, 1, "oops", "u")

--- a/tools/ticket_management.py
+++ b/tools/ticket_management.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, or_, and_, func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
-from fastapi import HTTPException
+from errors import DatabaseError
 
 from db.models import (
     Ticket,
@@ -158,7 +158,9 @@ class TicketManager:
         for key, value in filters.items():
             if hasattr(VTicketMasterExpanded, key):
                 col = getattr(VTicketMasterExpanded, key)
-                stmt = stmt.filter(col.ilike(f"%{value}%") if isinstance(value, str) else col == value)
+                stmt = stmt.filter(
+                    col.ilike(f"%{value}%") if isinstance(value, str) else col == value
+                )  # noqa: E501
         if sort_value == "oldest":
             stmt = stmt.order_by(VTicketMasterExpanded.Created_Date.asc())
         else:
@@ -212,7 +214,9 @@ class TicketManager:
         ticket_ids.update(row[0] for row in result.all())
         if not ticket_ids:
             return []
-        query = select(VTicketMasterExpanded).filter(VTicketMasterExpanded.Ticket_ID.in_(ticket_ids))
+        query = select(VTicketMasterExpanded).filter(
+            VTicketMasterExpanded.Ticket_ID.in_(ticket_ids)
+        )  # noqa: E501
         query = query.order_by(VTicketMasterExpanded.Ticket_ID)
         if status:
             query = query.join(
@@ -323,7 +327,7 @@ class TicketManager:
         except SQLAlchemyError as e:
             await db.rollback()
             logger.exception("Failed to save ticket message for %s", ticket_id)
-            raise HTTPException(status_code=500, detail=f"Failed to save message: {e}")
+            raise DatabaseError("Failed to save message", details=str(e))
         return msg
 
     async def get_attachments(self, db: AsyncSession, ticket_id: int) -> List[TicketAttachment]:
@@ -440,5 +444,11 @@ class TicketTools:
         db_ticket = await TicketManager().create_ticket(self.db, ticket)
         return db_ticket
 
-__all__ = ["TicketManager", "TicketTools", "TicketPriority", "TicketStatus", "TicketSearchResult"]
 
+__all__ = [
+    "TicketManager",
+    "TicketTools",
+    "TicketPriority",
+    "TicketStatus",
+    "TicketSearchResult",
+]


### PR DESCRIPTION
## Summary
- raise `DatabaseError` when `TicketManager.post_message` fails
- adjust imports accordingly
- add regression test for database failure handling

## Testing
- `flake8 tools/ticket_management.py tests/test_ticket_messages.py`
- `mypy tools/ticket_management.py tests/test_ticket_messages.py --config-file mypy.ini` *(fails: multiple errors across repository)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c556dd4dc832bb400daea023adbc5