### PR TITLE
Update ticket message sender parameters

### DIFF
--- a/tools/message_tools.py
+++ b/tools/message_tools.py
@@ -33,4 +33,4 @@ async def post_ticket_message(
         DeprecationWarning,
         stacklevel=2,
     )
-    return await _manager.post_message(db, ticket_id, message, sender_code)
+    return await _manager.post_message(db, ticket_id, message, sender_code, sender_name)

--- a/tools/ticket_management.py
+++ b/tools/ticket_management.py
@@ -306,13 +306,14 @@ class TicketManager:
         db: AsyncSession,
         ticket_id: int,
         message: str,
-        sender: str,
+        sender_code: str,
+        sender_name: str,
     ) -> TicketMessage:
         msg = TicketMessage(
             Ticket_ID=ticket_id,
             Message=message,
-            SenderUserCode=sender,
-            SenderUserName=sender,
+            SenderUserCode=sender_code,
+            SenderUserName=sender_name,
             DateTimeStamp=datetime.now(timezone.utc),
         )
         db.add(msg)


### PR DESCRIPTION
## Summary
- support separate sender code and sender name in `TicketManager.post_message`
- pass both values in deprecated `post_ticket_message`

## Testing
- `flake8`
- `pytest tests/test_ticket_lifecycle.py::test_ticket_full_lifecycle -q`


------
https://chatgpt.com/codex/tasks/task_e_687c556c60e8832bb4b83e200e67fa66