### PR TITLE
Dispose engine at shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,6 +74,7 @@ async def lifespan(app: FastAPI):
         await conn.run_sync(Base.metadata.create_all)
 
     yield
+    await engine.dispose()
 
 app = FastAPI(title="Truck Stop MCP Helpdesk API", lifespan=lifespan)
 app.add_exception_handler(

--- a/tests/test_engine_disposal.py
+++ b/tests/test_engine_disposal.py
@@ -1,0 +1,20 @@
+import pytest
+import pytest_asyncio
+from asgi_lifespan import LifespanManager
+from unittest.mock import AsyncMock
+
+from main import app
+from db.mssql import engine
+
+# Override the autouse app_lifespan fixture from conftest
+@pytest_asyncio.fixture(autouse=True)
+async def app_lifespan():
+    yield
+
+@pytest.mark.asyncio
+async def test_engine_disposed_on_shutdown(monkeypatch):
+    dispose_mock = AsyncMock()
+    monkeypatch.setattr(engine.__class__, "dispose", dispose_mock)
+    async with LifespanManager(app):
+        pass
+    dispose_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- dispose the SQLAlchemy engine during shutdown
- test that engine disposal is awaited

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c556e55fc832b8830ba561ceb44b7