### PR TITLE
Fix imports after restructuring

### DIFF
--- a/src/api/v1/analytics.py
+++ b/src/api/v1/analytics.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from schemas.analytics import (
+from src.shared.schemas.analytics import (
     StatusCount,
     SiteOpenCount,
     UserOpenCount,
@@ -13,7 +13,7 @@ from schemas.analytics import (
     TrendCount,
     StaffTicketReport,
 )
-from tools.analytics_reporting import (
+from src.core.services.analytics_reporting import (
     tickets_by_status,
     open_tickets_by_site,
     open_tickets_by_user,

--- a/src/api/v1/auth.py
+++ b/src/api/v1/auth.py
@@ -3,8 +3,8 @@ from typing import Optional
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from schemas.oncall import OnCallShiftOut
-from tools.user_services import UserManager
+from src.shared.schemas.oncall import OnCallShiftOut
+from src.core.services.user_services import UserManager
 
 from .deps import get_db
 

--- a/src/api/v1/deps.py
+++ b/src/api/v1/deps.py
@@ -4,7 +4,7 @@ from typing import Any, AsyncGenerator, Dict, Sequence
 from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.mssql import SessionLocal
+from src.infrastructure.database import SessionLocal
 
 logger = logging.getLogger(__name__)
 

--- a/src/api/v1/tickets.py
+++ b/src/api/v1/tickets.py
@@ -9,8 +9,8 @@ from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.models import VTicketMasterExpanded
-from schemas import (
+from src.core.repositories.models import VTicketMasterExpanded
+from src.shared.schemas import (
     TicketCreate,
     TicketOut,
     TicketUpdate,
@@ -18,10 +18,10 @@ from schemas import (
     TicketSearchOut,
     TicketSearchRequest,
 )
-from schemas.search_params import TicketSearchParams
-from schemas.basic import TicketMessageOut
-from schemas.paginated import PaginatedResponse
-from tools.ticket_management import TicketManager
+from src.shared.schemas.search_params import TicketSearchParams
+from src.shared.schemas.basic import TicketMessageOut
+from src.shared.schemas.paginated import PaginatedResponse
+from src.core.services.ticket_management import TicketManager
 
 from .deps import get_db, extract_filters
 


### PR DESCRIPTION
## Summary
- correct references to moved modules

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: no such table: V_Ticket_Master_Expanded)*

------
https://chatgpt.com/codex/tasks/task_e_687d02cbc2ec832b9fe625edefc73252