### PR TITLE
Fix SQLite engine arguments

### DIFF
--- a/src/infrastructure/database/__init__.py
+++ b/src/infrastructure/database/__init__.py
@@ -5,6 +5,16 @@ from config import DB_CONN_STRING
 
 
 def get_engine_args(conn_string: str) -> dict[str, Any]:
+    """Return engine keyword arguments based on the connection string."""
+    if conn_string.startswith("sqlite"):
+        # SQLite requires a special pool configuration and does not support
+        # traditional connection pooling arguments such as ``pool_size`` or
+        # ``max_overflow``.
+        from sqlalchemy.pool import StaticPool
+
+        return {"poolclass": StaticPool, "connect_args": {"check_same_thread": False}}
+
+    # Arguments common to all other database types
     base_args = {
         "pool_size": 10,
         "max_overflow": 20,
@@ -16,10 +26,6 @@ def get_engine_args(conn_string: str) -> dict[str, Any]:
         if conn_string.startswith("mssql+pyodbc"):
             raise RuntimeError("Use async driver 'mssql+aioodbc'")
         base_args.update({"poolclass": AsyncAdaptedQueuePool, "fast_executemany": True})
-    elif conn_string.startswith("sqlite"):
-        from sqlalchemy.pool import StaticPool
-
-        base_args.update({"poolclass": StaticPool, "connect_args": {"check_same_thread": False}})
 
     return base_args
 


### PR DESCRIPTION
## Summary
- add SQLite-aware logic to `get_engine_args`
- stub out minimal MCP server definitions so tests can import main

## Testing
- `pytest -q tests/test_db_conn.py`

------
https://chatgpt.com/codex/tasks/task_e_687d511ece68832b94ca9fefc5e7b3c2