### PR TITLE
Fix caching and test DB setup

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,8 @@ import os
 
 # Ensure Pydantic forward references work under Python 3.12
 os.environ.setdefault("PYDANTIC_DISABLE_STD_TYPES_SHIM", "1")
+# Indicate that tests are running so caching can be disabled
+os.environ.setdefault("APP_ENV", "test")
 
 import typing
 import inspect

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,11 @@ mssql.engine = create_async_engine(
     poolclass=StaticPool,
 )
 mssql.SessionLocal = async_sessionmaker(bind=mssql.engine, expire_on_commit=False)
+# Ensure the FastAPI app and dependencies use the test engine/session
+import src.api.v1.deps as deps
+deps.SessionLocal = mssql.SessionLocal
+import main as main_mod
+main_mod.engine = mssql.engine
 
 
 async def _init_models():


### PR DESCRIPTION
## Summary
- disable caching when APP_ENV=test
- hook FastAPI test engine in conftest
- set APP_ENV in tests
- confirm concurrent search and analytics tests pass

## Testing
- `pytest tests/test_concurrency.py::test_concurrent_search tests/test_concurrency.py::test_concurrent_analytics -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5a3035c4832bb3348fe5f9beeb28