### PR TITLE
Implement LRU validator cache

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from datetime import datetime, UTC
 from typing import Any, Dict, List
+from collections import OrderedDict
 
 import jsonschema
 import sentry_sdk
@@ -45,7 +46,31 @@ _correlation_id_var: ContextVar[str] = ContextVar("correlation_id", default="-")
 START_TIME = datetime.now(UTC)
 
 # Cache for JSON schema validators keyed by serialized schema
-_validator_cache: Dict[str, Draft7Validator] = {}
+
+class LRUValidatorCache:
+    """Simple LRU cache for JSON schema validators."""
+
+    def __init__(self, maxsize: int = 50) -> None:
+        self.maxsize = maxsize
+        self._data: "OrderedDict[str, Draft7Validator]" = OrderedDict()
+
+    def get(self, key: str) -> Draft7Validator | None:
+        validator = self._data.get(key)
+        if validator is not None:
+            # Move to end to mark as recently used
+            self._data.move_to_end(key)
+        return validator
+
+    def set(self, key: str, validator: Draft7Validator) -> None:
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = validator
+        if len(self._data) > self.maxsize:
+            # Remove least recently used entry
+            self._data.popitem(last=False)
+
+
+_validator_cache = LRUValidatorCache(maxsize=50)
 
 
 class CorrelationIdFilter(logging.Filter):
@@ -262,7 +287,7 @@ def build_mcp_endpoint(tool: Tool, schema: Dict[str, Any]):
     validator = _validator_cache.get(key)
     if validator is None:
         validator = Draft7Validator(schema)
-        _validator_cache[key] = validator
+        _validator_cache.set(key, validator)
 
     async def endpoint(request: Request):
         try:


### PR DESCRIPTION
## Summary
- implement `LRUValidatorCache` in `main.py`
- replace global dictionary cache with this LRU cache
- use new cache when building MCP endpoints

## Testing
- `pytest -q` *(fails: 12 failed, 18 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687d5c9f4190832b84650dde6bf284c6