### PR TITLE
Fix validator cache usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -296,7 +296,7 @@ def build_mcp_endpoint(tool: Tool, schema: Dict[str, Any]):
         validator = Draft7Validator(schema)
 
         if _validator_cache_enabled:
-            _validator_cache[key] = validator
+            _validator_cache.set(key, validator)
 
 
     async def endpoint(request: Request):


### PR DESCRIPTION
## Summary
- call `set` method on validator cache

## Testing
- `flake8`
- `pytest -q` *(fails: PydanticUserError – "Config" and "model_config" cannot be used together)*

------
https://chatgpt.com/codex/tasks/task_e_687d65bc6364832b8a9644ea226b0e7e