### PR TITLE
Fix pydantic settings initialization

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 import logging
 
+logger = logging.getLogger(__name__)
+
 from dotenv import load_dotenv
 from pydantic import ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -50,9 +52,6 @@ class Settings(BaseSettings):
                 return "UTC"
             return v
 
-    class Config:
-        case_sensitive = False
-        env_file = ".env"
 
     @field_validator("API_BASE_URL")
     @classmethod


### PR DESCRIPTION
## Summary
- drop legacy `Config` inner class from `Settings`
- define module logger for timezone validator

## Testing
- `pytest tests/test_db_conn.py::test_pyodbc_conn_string_not_allowed -q`

------
https://chatgpt.com/codex/tasks/task_e_687d68b53afc832bb1bdc73cdebf4b98