### PR TITLE
Raise ValueError for unsupported MSSQL driver

### DIFF
--- a/src/infrastructure/database/__init__.py
+++ b/src/infrastructure/database/__init__.py
@@ -24,7 +24,9 @@ def get_engine_args(conn_string: str) -> dict[str, Any]:
 
     if conn_string.startswith("mssql"):
         if conn_string.startswith("mssql+pyodbc"):
-            raise RuntimeError("Use async driver 'mssql+aioodbc'")
+            # ``create_async_engine`` does not work with synchronous drivers.
+            # Raise a ``ValueError`` so configuration issues surface early.
+            raise ValueError("Use async driver 'mssql+aioodbc'")
         base_args.update({"poolclass": AsyncAdaptedQueuePool, "fast_executemany": True})
 
     return base_args

--- a/tests/test_db_conn.py
+++ b/tests/test_db_conn.py
@@ -8,5 +8,5 @@ def test_pyodbc_conn_string_not_allowed(monkeypatch):
     conn = "mssql+pyodbc://user:pass@localhost/db"
     monkeypatch.setenv("DB_CONN_STRING", conn)
     monkeypatch.setattr("config.DB_CONN_STRING", conn, raising=False)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         importlib.reload(mssql)


### PR DESCRIPTION
## Summary
- raise `ValueError` for `mssql+pyodbc` connection strings
- update unit test expectation

## Testing
- `pytest tests/test_db_conn.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687d6c4a2c0c832b8275431034ef83fb