### PR TITLE
Refactor email validation

### DIFF
--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -1,6 +1,5 @@
-from pydantic import BaseModel, EmailStr, Field, field_validator, ConfigDict
+from pydantic import BaseModel, EmailStr, Field, ConfigDict
 from typing import Annotated
-from email_validator import validate_email, EmailNotValidError
 from typing import Optional
 from datetime import datetime
 
@@ -21,17 +20,6 @@ class TicketBase(BaseModel):
     Resolution: Optional[Annotated[str, Field()]] = None
 
     model_config = ConfigDict(str_max_length=None)
-
-    @field_validator("Ticket_Contact_Email", "Assigned_Email", mode="before")
-    def validate_emails(cls, v):
-        if v is None:
-            return None
-        if isinstance(v, str) and (v == "" or v.lower() == "null"):
-            return None
-        try:
-            return validate_email(v, check_deliverability=False).normalized
-        except EmailNotValidError as e:
-            raise ValueError(str(e))
 
 
 class TicketCreate(TicketBase):
@@ -111,17 +99,6 @@ class TicketIn(BaseModel):
     Priority_ID: Optional[int] = None
     Assigned_Vendor_ID: Optional[int] = None
     Resolution: Optional[Annotated[str, Field()]] = None
-
-    @field_validator("Ticket_Contact_Email", "Assigned_Email", mode="before")
-    def validate_emails(cls, v):
-        if v is None:
-            return None
-        if isinstance(v, str) and (v == "" or v.lower() == "null"):
-            return None
-        try:
-            return validate_email(v, check_deliverability=False).normalized
-        except EmailNotValidError as e:
-            raise ValueError(str(e))
 
     model_config = ConfigDict(extra="forbid", str_max_length=None)
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,6 +13,37 @@ def test_invalid_email():
         )
 
 
+def test_blank_email_invalid():
+    with pytest.raises(ValidationError):
+        TicketCreate(
+            Subject="Test",
+            Ticket_Body="Body",
+            Ticket_Contact_Name="Name",
+            Ticket_Contact_Email="",
+        )
+
+
+def test_null_string_email_invalid():
+    with pytest.raises(ValidationError):
+        TicketCreate(
+            Subject="Test",
+            Ticket_Body="Body",
+            Ticket_Contact_Name="Name",
+            Ticket_Contact_Email="null",
+        )
+
+
+def test_invalid_assigned_email():
+    with pytest.raises(ValidationError):
+        TicketCreate(
+            Subject="Test",
+            Ticket_Body="Body",
+            Ticket_Contact_Name="Name",
+            Ticket_Contact_Email="test@example.com",
+            Assigned_Email="invalid",
+        )
+
+
 def test_subject_too_long():
     with pytest.raises(ValidationError):
         TicketCreate(


### PR DESCRIPTION
## Summary
- drop custom email checks from ticket schemas
- rely on `EmailStr` validation
- test invalid email scenarios

## Testing
- `pytest tests/test_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6c504668832b8f818035fb219469