### PR TITLE
Use BaseModel generics for PaginatedResponse

### DIFF
--- a/src/shared/schemas/paginated.py
+++ b/src/shared/schemas/paginated.py
@@ -1,10 +1,10 @@
 from typing import Generic, List, TypeVar
-from pydantic.generics import GenericModel
+from pydantic import BaseModel
 
 T = TypeVar('T')
 
 
-class PaginatedResponse(GenericModel, Generic[T]):
+class PaginatedResponse(BaseModel, Generic[T]):
     items: List[T]
     total: int
     skip: int


### PR DESCRIPTION
## Summary
- switch PaginatedResponse to inherit from `BaseModel`

## Testing
- `pytest -q` *(fails: TicketManager has no attribute '_sanitize_search_input')*

------
https://chatgpt.com/codex/tasks/task_e_687d6c59f8dc832ba90c64a141cc18fa