### PR TITLE
Fix tool names in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ set of tool endpoints. The `/tools` route now returns an object with a `tools`
 key containing the available tools. The verification script fetches this route
 and compares the returned names against a predefined mapping. It exits with a
 non-zero status when any tools are missing or unexpected. The default mapping
-checks for the ``g_ticket`` and ``l_tkts`` endpoints.
+checks for the ``get_ticket`` and ``list_tickets`` endpoints.
 
 ```bash
 python verify_tools.py http://localhost:8000

--- a/docs/API.md
+++ b/docs/API.md
@@ -64,8 +64,8 @@ This document lists the available HTTP endpoints provided by the HelpDesk servic
 The following POST endpoints are generated from the MCP tools. Each expects a
 JSON body matching the tool's schema.
 
-- `POST /g_ticket` – Get a ticket by ID. Example: `{"ticket_id": 123}`
-- `POST /l_tkts` – List recent tickets. Example: `{"limit": 5}`
+- `POST /get_ticket` – Get a ticket by ID. Example: `{"ticket_id": 123}`
+- `POST /list_tickets` – List recent tickets. Example: `{"limit": 5}`
 - `POST /tickets_by_user` – List tickets for a user. Example: `{"identifier": "user@example.com"}`
 - `POST /by_user` – Alias of `tickets_by_user`.
 - `POST /open_by_site` – Open tickets by site. Example: `{}`


### PR DESCRIPTION
## Summary
- update tool references in README and docs/API
- mention that verify_tools.py now checks for `get_ticket` and `list_tickets`

## Testing
- `bash scripts/setup-tests.sh`
- `flake8` *(fails: F401, E302, E303, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d88d8ce68832b9aa5767aa686d09d