### PR TITLE
Add filters and sort options for reference data listing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -77,10 +77,10 @@ JSON body matching the tool's schema.
 - `POST /staff_report` – Technician ticket report. Example: `{"assigned_email": "tech@example.com"}`
 - `POST /tickets_by_timeframe` – Tickets filtered by status and age. Example: `{"days": 7}`
 - `POST /search_tickets` – Search tickets. Example: `{"query": "printer"}`
-- `POST /list_sites` – List sites. Example: `{"limit": 10}`
-- `POST /list_assets` – List assets. Example: `{"limit": 10}`
-- `POST /list_vendors` – List vendors. Example: `{"limit": 10}`
-- `POST /list_categories` – List categories. Example: `{}`
+- `POST /list_sites` – List sites. Example: `{"limit": 10, "filters": {}, "sort": ["Label"]}`
+- `POST /list_assets` – List assets. Example: `{"limit": 10, "filters": {}, "sort": ["Label"]}`
+- `POST /list_vendors` – List vendors. Example: `{"limit": 10, "filters": {}, "sort": ["Name"]}`
+- `POST /list_categories` – List categories. Example: `{"filters": {}}`
 - `POST /get_ticket_full_context` – Full context for a ticket. Example: `{"ticket_id": 123}`
 - `POST /get_system_snapshot` – System snapshot. Example: `{}`
 

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -423,19 +423,32 @@ async def _get_analytics(type: str, params: _Dict[str, Any] | None = None) -> _D
         return {"status": "error", "error": str(e)}
 
 
-async def _list_reference_data(type: str, limit: int = 10) -> _Dict[str, Any]:
+async def _list_reference_data(
+    type: str,
+    limit: int = 10,
+    filters: _Dict[str, Any] | None = None,
+    sort: list[str] | None = None,
+) -> _Dict[str, Any]:
     """Return reference data such as sites or assets."""
     try:
         async with db.SessionLocal() as db_session:
             mgr = ReferenceDataManager()
             if type == "sites":
-                records = await mgr.list_sites(db_session, limit=limit)
+                records = await mgr.list_sites(
+                    db_session, limit=limit, filters=filters or None, sort=sort
+                )
             elif type == "assets":
-                records = await mgr.list_assets(db_session, limit=limit)
+                records = await mgr.list_assets(
+                    db_session, limit=limit, filters=filters or None, sort=sort
+                )
             elif type == "vendors":
-                records = await mgr.list_vendors(db_session, limit=limit)
+                records = await mgr.list_vendors(
+                    db_session, limit=limit, filters=filters or None, sort=sort
+                )
             elif type == "categories":
-                records = await mgr.list_categories(db_session)
+                records = await mgr.list_categories(
+                    db_session, filters=filters or None, sort=sort
+                )
             else:
                 raise ValueError("unknown reference data type")
             data = [r.__dict__ for r in records]
@@ -624,6 +637,8 @@ ENHANCED_TOOLS: List[Tool] = [
             "properties": {
                 "type": {"type": "string"},
                 "limit": {"type": "integer", "default": 10},
+                "filters": {"type": "object"},
+                "sort": {"type": "array", "items": {"type": "string"}},
             },
             "required": ["type"],
         },


### PR DESCRIPTION
## Summary
- support optional `filters` and `sort` parameters in `_list_reference_data`
- expose the new options via the `list_reference_data` tool
- document the parameters in `API.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d88dbd194832bb75de6f3fa2a7f29