### PR TITLE
Set LastModified on ticket updates

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -66,6 +66,7 @@ class TicketManager:
         for key, value in updates.items():
             if hasattr(ticket, key):
                 setattr(ticket, key, value)
+        ticket.LastModified = datetime.now(timezone.utc)
         try:
             await db.commit()
             await db.refresh(ticket)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -95,6 +95,10 @@ async def test_update_ticket(client: AsyncClient):
     assert resp.status_code == 200
     assert resp.json()["Subject"] == "Updated"
 
+    get_resp = await client.get(f"/ticket/{tid}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["LastModified"] is not None
+
 
 @pytest.mark.asyncio
 async def test_update_ticket_invalid_field(client: AsyncClient):


### PR DESCRIPTION
## Summary
- update `update_ticket` to stamp LastModified
- ensure `LastModified` returned after updating
- test that LastModified is populated

## Testing
- `pytest tests/test_routes.py::test_update_ticket -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed93457c8832bae9519943ef24c84