### PR TITLE
Remove redundant commits in ticket manager

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -47,7 +47,7 @@ class TicketManager:
             ticket_obj = Ticket(**ticket_obj)
         db.add(ticket_obj)
         try:
-            await db.commit()
+            await db.flush()
             await db.refresh(ticket_obj)
             return OperationResult(success=True, data=ticket_obj)
         except SQLAlchemyError as e:
@@ -67,7 +67,7 @@ class TicketManager:
             if hasattr(ticket, key):
                 setattr(ticket, key, value)
         try:
-            await db.commit()
+            await db.flush()
             await db.refresh(ticket)
             logger.info("Updated ticket %s", ticket_id)
             return ticket

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -265,6 +265,7 @@ async def _create_ticket(
             result = await TicketManager().create_ticket(db_session, payload)
             if not result.success:
                 raise Exception(result.error or "create failed")
+            await db_session.commit()
             ticket = await TicketManager().get_ticket(
                 db_session, result.data.Ticket_ID
             )
@@ -282,6 +283,7 @@ async def _update_ticket(ticket_id: int, updates: _Dict[str, Any]) -> _Dict[str,
             updated = await TicketManager().update_ticket(db_session, ticket_id, updates)
             if not updated:
                 return {"status": "error", "error": "Ticket not found"}
+            await db_session.commit()
             ticket = await TicketManager().get_ticket(db_session, ticket_id)
             data = TicketExpandedOut.model_validate(ticket).model_dump()
             return {"status": "success", "data": data}
@@ -306,6 +308,7 @@ async def _close_ticket(
             updated = await TicketManager().update_ticket(db_session, ticket_id, updates)
             if not updated:
                 return {"status": "error", "error": "Ticket not found"}
+            await db_session.commit()
             ticket = await TicketManager().get_ticket(db_session, ticket_id)
             data = TicketExpandedOut.model_validate(ticket).model_dump()
             return {"status": "success", "data": data}
@@ -329,6 +332,7 @@ async def _assign_ticket(
             updated = await TicketManager().update_ticket(db_session, ticket_id, updates)
             if not updated:
                 return {"status": "error", "error": "Ticket not found"}
+            await db_session.commit()
             ticket = await TicketManager().get_ticket(db_session, ticket_id)
             data = TicketExpandedOut.model_validate(ticket).model_dump()
             return {"status": "success", "data": data}

--- a/tests/test_advanced_filters.py
+++ b/tests/test_advanced_filters.py
@@ -26,6 +26,7 @@ async def test_date_range_and_sort():
         )
         await TicketManager().create_ticket(db, t1)
         await TicketManager().create_ticket(db, t2)
+        await db.commit()
 
         filters = AdvancedFilters(
             created_from=datetime(2023, 1, 5, tzinfo=UTC),
@@ -58,6 +59,7 @@ async def test_multi_value_and_bool_filter():
         )
         await TicketManager().create_ticket(db, t1)
         await TicketManager().create_ticket(db, t2)
+        await db.commit()
         filters = AdvancedFilters(site_ids=[1, 2], assigned=False)
         res = await TicketManager().list_tickets(db, filters=filters)
         ids = {t.Ticket_ID for t in res}

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -57,6 +57,7 @@ async def _add_ticket(**kwargs):
         )
 
         await TicketManager().create_ticket(db, ticket)
+        await db.commit()
 
         return ticket
 

--- a/tests/test_analytics_cache_lock.py
+++ b/tests/test_analytics_cache_lock.py
@@ -21,6 +21,7 @@ async def _add_sample_ticket():
             Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(session, t)
+        await session.commit()
 
 
 def _enable_cache(monkeypatch):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -19,6 +19,7 @@ async def _add_sample_ticket():
             Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(session, t)
+        await session.commit()
 
 
 async def _search_worker():

--- a/tests/test_enhanced_operations.py
+++ b/tests/test_enhanced_operations.py
@@ -18,6 +18,7 @@ async def test_validate_ticket_update_success():
             Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, ticket)
+        await db.commit()
         manager = EnhancedOperationsManager(db)
         res = await manager.validate_operation_before_execution(
             "update_ticket", ticket.Ticket_ID, {"Subject": "New"}
@@ -38,6 +39,7 @@ async def test_validate_ticket_update_invalid_field():
             Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, ticket)
+        await db.commit()
         manager = EnhancedOperationsManager(db)
         res = await manager.validate_operation_before_execution(
             "update_ticket", ticket.Ticket_ID, {"BadField": "x"}
@@ -58,6 +60,7 @@ async def test_validate_ticket_assignment_missing_email():
             Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, ticket)
+        await db.commit()
         manager = EnhancedOperationsManager(db)
         res = await manager.validate_operation_before_execution(
             "assign_ticket", ticket.Ticket_ID, {"assignee_name": "A"}

--- a/tests/test_operation_result.py
+++ b/tests/test_operation_result.py
@@ -20,6 +20,7 @@ async def test_create_ticket_returns_operation_result():
             Ticket_Status_ID=1,
         )
         result = await TicketManager().create_ticket(db, ticket)
+        await db.commit()
         assert isinstance(result, OperationResult)
         assert result.success
         assert isinstance(result.data, Ticket)

--- a/tests/test_reference_data_filters.py
+++ b/tests/test_reference_data_filters.py
@@ -56,6 +56,7 @@ async def test_ticket_list_filters_and_sort():
         )
         await TicketManager().create_ticket(db, t1)
         await TicketManager().create_ticket(db, t2)
+        await db.commit()
 
         res = await TicketManager().list_tickets(db, filters={"Subject": "F2"})
         assert len(res) == 1 and res[0].Subject == "F2"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -38,6 +38,7 @@ async def test_search_tickets():
         )
 
         await TicketManager().create_ticket(db, t)
+        await db.commit()
         params = TicketSearchParams()
         results = await TicketManager().search_tickets(db, "Network", params=params)
         assert results and results[0]["Subject"] == "Network issue"
@@ -56,6 +57,7 @@ async def test_search_endpoint_skips_invalid_ticket():
             Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, bad)
+        await db.commit()
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -85,6 +87,7 @@ async def test_search_filters_escape_special_chars():
         await TicketManager().create_ticket(db, t1)
         await TicketManager().create_ticket(db, t2)
         await TicketManager().create_ticket(db, t3)
+        await db.commit()
 
         params = TicketSearchParams(Subject="100% guaranteed")
         res = await TicketManager().search_tickets(db, "", params=params)

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -30,6 +30,7 @@ async def test_search_skips_oversized_ticket_body():
         )
         await TicketManager().create_ticket(db, valid)
         await TicketManager().create_ticket(db, invalid)
+        await db.commit()
         valid_id = valid.Ticket_ID
 
     transport = ASGITransport(app=app)
@@ -67,6 +68,7 @@ async def test_search_filters_and_sort():
         )
         await TicketManager().create_ticket(db, first)
         await TicketManager().create_ticket(db, second)
+        await db.commit()
         first_id = first.Ticket_ID
         second_id = second.Ticket_ID
 
@@ -97,6 +99,7 @@ async def test_search_accepts_json():
             Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, t)
+        await db.commit()
         tid = t.Ticket_ID
 
     transport = ASGITransport(app=app)

--- a/tests/test_ticket_search_endpoint.py
+++ b/tests/test_ticket_search_endpoint.py
@@ -20,6 +20,7 @@ async def test_ticket_search_route_returns_results():
             Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, t)
+        await db.commit()
         tid = t.Ticket_ID
 
     transport = ASGITransport(app=app)
@@ -42,6 +43,7 @@ async def test_ticket_search_route_accepts_json():
             Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, t)
+        await db.commit()
         tid = t.Ticket_ID
 
     transport = ASGITransport(app=app)

--- a/tests/test_tickets_by_user.py
+++ b/tests/test_tickets_by_user.py
@@ -53,6 +53,7 @@ async def test_get_tickets_by_user_function():
             Created_Date=now,
         )
         await TicketManager().create_ticket(db, t4)
+        await db.commit()
         msg = TicketMessage(
             Ticket_ID=t3.Ticket_ID,
             Message="hi",
@@ -89,6 +90,7 @@ async def test_tickets_by_user_endpoint():
                 Created_Date=now,
             )
             await TicketManager().create_ticket(db, t)
+            await db.commit()
         resp = await ac.get("/tickets/by_user", params={"identifier": "endpoint@example.com"})
         assert resp.status_code == 200
         data = resp.json()
@@ -110,6 +112,7 @@ async def test_tickets_by_user_tool():
             Created_Date=now,
         )
         await TicketManager().create_ticket(db, t)
+        await db.commit()
 
     server = create_enhanced_server()
     tool = next(x for x in server._tools if x.name == "tickets_by_user")
@@ -146,6 +149,7 @@ async def test_status_and_filtering():
             )
             await TicketManager().create_ticket(db, open_t)
             await TicketManager().create_ticket(db, closed_t)
+            await db.commit()
 
         resp = await ac.get(
             "/tickets/by_user",


### PR DESCRIPTION
## Summary
- handle committing in API database dependency
- cleanup enhanced MCP server to commit explicitly
- adjust tests to commit directly when using TicketManager

## Testing
- `bash scripts/setup-tests.sh`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed93f1fa8832b924637304a43962d