### PR TITLE
Document new MCP tools and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,9 @@ set of tool endpoints. The `/tools` route now returns an object with a `tools`
 key containing the available tools. The verification script fetches this route
 and compares the returned names against a predefined mapping. It exits with a
 non-zero status when any tools are missing or unexpected. The default mapping
-checks for the ``get_ticket`` and ``list_tickets`` endpoints.
+checks for the ``get_ticket`` and ``list_tickets`` endpoints. The route also
+lists new operations such as ``advanced_search``, ``escalate_ticket``,
+``sla_metrics`` and ``bulk_update_tickets``.
 
 ```bash
 python verify_tools.py http://localhost:8000
@@ -379,6 +381,28 @@ curl -X POST http://localhost:8000/tickets_by_timeframe \
 Request bodies are validated against each tool's `inputSchema` using the
 `jsonschema` library. Missing or incorrectly typed fields result in a `422`
 response.
+
+Additional tools are available:
+
+* `advanced_search` – run a detailed ticket search.
+  ```bash
+  curl -X POST http://localhost:8000/advanced_search \
+    -d '{"text_search": "printer", "limit": 10}'
+  ```
+* `escalate_ticket` – escalate a ticket for faster attention.
+  ```bash
+  curl -X POST http://localhost:8000/escalate_ticket \
+    -d '{"ticket_id": 123}'
+  ```
+* `sla_metrics` – retrieve SLA performance metrics.
+  ```bash
+  curl -X POST http://localhost:8000/sla_metrics -d '{}'
+  ```
+* `bulk_update_tickets` – apply updates to many tickets at once.
+  ```bash
+  curl -X POST http://localhost:8000/bulk_update_tickets \
+    -d '{"ticket_ids": [1,2,3], "updates": {"Assigned_Email": "tech@example.com"}}'
+  ```
 
 ## License
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -84,6 +84,10 @@ JSON body matching the tool's schema.
 - `POST /list_categories` – List categories. Example: `{"filters": {}}`
 - `POST /get_ticket_full_context` – Full context for a ticket. Example: `{"ticket_id": 123}`
 - `POST /get_system_snapshot` – System snapshot. Example: `{}`
+- `POST /advanced_search` – Advanced ticket search. Example: `{"text_search": "printer"}`
+- `POST /escalate_ticket` – Escalate a ticket. Example: `{"ticket_id": 42}`
+- `POST /sla_metrics` – SLA metrics summary. Example: `{}`
+- `POST /bulk_update_tickets` – Bulk ticket updates. Example: `{"ticket_ids": [1,2], "updates": {}}`
 
 Endpoints under `/mcp-tools` are also exposed as HTTP routes with the same names as the MCP tools. Refer to the OpenAPI schema or `/docs` endpoint when running the application for the full specification.
 
@@ -139,4 +143,34 @@ Example payloads:
 
 ```json
 {"Ticket_Status_ID": 3}
+```
+
+### TicketExpandedOut
+
+`TicketExpandedOut` extends `TicketOut` with additional labels and timestamps.
+Fields include:
+
+- `status_label` (maps to `Ticket_Status_Label`)
+- `Site_Label`
+- `Site_ID`
+- `Asset_Label`
+- `category_label` (maps to `Ticket_Category_Label`)
+- `Assigned_Vendor_Name`
+- `Priority_Level`
+- `Closed_Date`
+- `LastModified`
+
+Example:
+
+```json
+{
+  "Ticket_ID": 1,
+  "Subject": "Printer not working",
+  "status_label": "Open",
+  "Site_Label": "HQ",
+  "Site_ID": 2,
+  "Priority_Level": "High",
+  "Closed_Date": null,
+  "LastModified": null
+}
 ```


### PR DESCRIPTION
## Summary
- document advanced tools in README and API docs
- update README with example requests
- explain TicketExpandedOut schema details

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee4ad5f9c832bb85e81b4b920ec8f