### PR TITLE
Refactor TicketExpandedOut schema aliases

### DIFF
--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -128,14 +128,13 @@ class TicketExpandedOut(TicketOut):
     """Ticket output schema that includes related labels."""
 
     status_label: Optional[str] = Field(None, alias="Ticket_Status_Label")
-    Site_Label: Optional[str] = None
-    Site_ID: Optional[int] = None
-    Asset_Label: Optional[str] = None
+    site_label: Optional[str] = Field(None, alias="Site_Label")
+    asset_label: Optional[str] = Field(None, alias="Asset_Label")
     category_label: Optional[str] = Field(None, alias="Ticket_Category_Label")
-
-    Assigned_Vendor_Name: Optional[str] = None
-    Priority_Level: Optional[str] = None
+    vendor_name: Optional[str] = Field(None, alias="Assigned_Vendor_Name")
+    priority_level: Optional[str] = Field(None, alias="Priority_Level")
+    Site_ID: Optional[int] = None
     Closed_Date: Optional[datetime] = None
     LastModified: Optional[datetime] = None
 
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True, str_max_length=None)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)


### PR DESCRIPTION
## Summary
- update aliases for TicketExpandedOut schema to use consistent snake_case

## Testing
- `bash scripts/setup-tests.sh`
- `flake8` *(fails: E302, F401, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee4b0a0a8832b87da4837f78fe55d