### PR TITLE
Add MCP tools guide and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,23 +358,24 @@ Include this check in deployment pipelines to catch configuration issues early.
 
 ### Tool Reference
 
-The MCP server exposes several JSON-RPC tools. `tickets_by_user` returns
+The MCP server exposes several JSON-RPC tools. `get_tickets_by_user` returns
 expanded ticket records for a user. It accepts an `identifier`, optional
-`status` and arbitrary `filters`.
+`status` and arbitrary `filters`. Detailed descriptions for every tool are
+available in [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md).
 
 ```bash
-curl "http://localhost:8000/tickets/by_user?identifier=user@example.com&status=open"
+curl "http://localhost:8000/get_tickets_by_user?identifier=user@example.com&status=open"
 ```
 
 Tool endpoints validate request bodies against each tool's `inputSchema` using
 JSON Schema. Payloads missing required fields or with incorrect types return a
 `422 Unprocessable Entity` response.
 
-`tickets_by_timeframe` lists tickets filtered by status and age. Provide a
+`get_open_tickets` lists tickets filtered by status and age. Provide a
 number of `days` and optional `status` such as `open` or `closed`.
 
 ```bash
-curl -X POST http://localhost:8000/tickets_by_timeframe \
+curl -X POST http://localhost:8000/get_open_tickets \
   -d '{"status": "open", "days": 7, "limit": 5}'
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -62,26 +62,21 @@ This document lists the available HTTP endpoints provided by the HelpDesk servic
 ### MCP Tool Routes
 
 The following POST endpoints are generated from the MCP tools. Each expects a
-JSON body matching the tool's schema.
+JSON body matching the tool's schema. See
+[MCP_TOOLS_GUIDE.md](MCP_TOOLS_GUIDE.md) for a full description of each tool.
 
 - `POST /get_ticket` – Get a ticket by ID. Example: `{"ticket_id": 123}`
 - `POST /list_tickets` – List recent tickets. Example: `{"limit": 5}`
-- `POST /tickets_by_user` – List tickets for a user. Example: `{"identifier": "user@example.com"}`
-- `POST /by_user` – Alias of `tickets_by_user`.
-- `POST /open_by_site` – Open tickets by site. Example: `{}`
-- `POST /open_by_assigned_user` – Open tickets by technician. Example: `{"filters": {}}`
-- `POST /tickets_by_status` – Ticket counts by status. Example: `{}`
-- `POST /ticket_trend` – Ticket trend information. Example: `{"days": 7}`
-- `POST /waiting_on_user` – Tickets waiting on user. Example: `{}`
-- `POST /sla_breaches` – Count SLA breaches. Example: `{"days": 2}`
-- `POST /staff_report` – Technician ticket report. Example: `{"assigned_email": "tech@example.com"}`
-- `POST /get_open_tickets` – List open tickets. Example: `{"days": 30, "limit": 20, "skip": 0, "sort": ["Priority_Level"]}`
-- `POST /tickets_by_timeframe` – Tickets filtered by status and age. Example: `{"days": 7}`
+- `POST /create_ticket` – Create a ticket. Example: see `TicketCreate` schema
+- `POST /update_ticket` – Update a ticket. Example: `{"ticket_id": 1, "updates": {}}`
+- `POST /close_ticket` – Close a ticket with a resolution.
+- `POST /assign_ticket` – Assign a technician.
+- `POST /add_ticket_message` – Add a message to a ticket.
 - `POST /search_tickets` – Search tickets. Example: `{"query": "printer"}`
-- `POST /list_sites` – List sites. Example: `{"limit": 10, "filters": {}, "sort": ["Label"]}`
-- `POST /list_assets` – List assets. Example: `{"limit": 10, "filters": {}, "sort": ["Label"]}`
-- `POST /list_vendors` – List vendors. Example: `{"limit": 10, "filters": {}, "sort": ["Name"]}`
-- `POST /list_categories` – List categories. Example: `{"filters": {}}`
+- `POST /get_tickets_by_user` – Tickets for a user. Example: `{"identifier": "user@example.com"}`
+- `POST /get_open_tickets` – List open tickets. Example: `{"days": 30}`
+- `POST /get_analytics` – Analytics reports. Example: `{"type": "site_counts"}`
+- `POST /list_reference_data` – Reference data lookup. Example: `{"type": "sites"}`
 - `POST /get_ticket_full_context` – Full context for a ticket. Example: `{"ticket_id": 123}`
 - `POST /get_system_snapshot` – System snapshot. Example: `{}`
 - `POST /advanced_search` – Advanced ticket search. Example: `{"text_search": "printer"}`

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -1,0 +1,218 @@
+# MCP Tools Guide
+
+This document describes the JSON-RPC tools exposed by the MCP server. Each section lists the purpose of the tool, the parameters expected in the request body and an example invocation.
+
+## create_ticket
+Create a new ticket. Parameters match the `TicketCreate` schema described in [API.md](API.md).
+
+Example:
+```bash
+curl -X POST http://localhost:8000/create_ticket \
+  -d '{"Subject": "Printer issue", "Ticket_Contact_Name": "Alice"}'
+```
+
+## update_ticket
+Update an existing ticket by ID.
+
+Parameters:
+- `ticket_id` – integer ID of the ticket.
+- `updates` – object of fields to modify.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/update_ticket \
+  -d '{"ticket_id": 5, "updates": {"Assigned_Email": "tech@example.com"}}'
+```
+
+## close_ticket
+Close a ticket with a resolution message.
+
+Parameters:
+- `ticket_id` – integer ticket ID.
+- `resolution` – resolution text.
+- `status_id` – optional status (defaults to 4).
+
+Example:
+```bash
+curl -X POST http://localhost:8000/close_ticket \
+  -d '{"ticket_id": 5, "resolution": "Replaced toner"}'
+```
+
+## assign_ticket
+Assign a ticket to a technician.
+
+Parameters:
+- `ticket_id` – integer ID.
+- `assignee_email` – technician email.
+- `assignee_name` – optional technician name.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/assign_ticket \
+  -d '{"ticket_id": 5, "assignee_email": "tech@example.com"}'
+```
+
+## add_ticket_message
+Append a message to a ticket thread.
+
+Parameters:
+- `ticket_id` – integer ticket ID.
+- `message` – text body.
+- `sender_name` – name of the poster.
+- `sender_code` – optional code for the sender.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/add_ticket_message \
+  -d '{"ticket_id": 5, "message": "Checking the printer", "sender_name": "Alice"}'
+```
+
+## search_tickets
+Keyword search across tickets.
+
+Parameters:
+- `query` – text query.
+- `limit` – optional result limit (default 10).
+
+Example:
+```bash
+curl -X POST http://localhost:8000/search_tickets \
+  -d '{"query": "printer"}'
+```
+
+## get_tickets_by_user
+Retrieve tickets associated with a user.
+
+Parameters:
+- `identifier` – email or other user identifier.
+- `skip` – optional offset (default 0).
+- `limit` – optional maximum number (default 100).
+- `status` – optional status filter.
+- `filters` – optional additional filters.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_tickets_by_user \
+  -d '{"identifier": "user@example.com", "status": "open"}'
+```
+
+## get_open_tickets
+List open tickets with optional filters.
+
+Parameters:
+- `days` – look back period (default 3650).
+- `limit` – result limit (default 10).
+- `skip` – result offset (default 0).
+- `filters` – optional filter mapping.
+- `sort` – optional list of columns to sort by.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_open_tickets \
+  -d '{"days": 30, "limit": 20, "sort": ["Priority_Level"]}'
+```
+
+## get_analytics
+Return analytics information. The `type` field selects the report.
+
+Allowed types include:
+- `status_counts`
+- `site_counts`
+- `technician_workload`
+- `sla_breaches`
+- `trends`
+
+Parameters:
+- `type` – report type.
+- `params` – optional additional parameters for the chosen report.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_analytics \
+  -d '{"type": "site_counts"}'
+```
+
+## list_reference_data
+Return reference data such as sites, assets or vendors.
+
+Parameters:
+- `type` – one of `sites`, `assets`, `vendors`, `categories`.
+- `limit` – optional limit (default 10).
+- `filters` – optional filter mapping.
+- `sort` – optional list of sort columns.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/list_reference_data \
+  -d '{"type": "sites", "limit": 5}'
+```
+
+## get_ticket_full_context
+Return a ticket along with related labels and history.
+
+Parameters:
+- `ticket_id` – integer ID.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_ticket_full_context \
+  -d '{"ticket_id": 5}'
+```
+
+## get_system_snapshot
+Return a snapshot of overall system metrics.
+
+Parameters: none.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_system_snapshot -d '{}'
+```
+
+## advanced_search
+Perform a detailed ticket search using advanced criteria.
+
+Parameters:
+- `text_search` – search string.
+- `limit` – optional result limit.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/advanced_search \
+  -d '{"text_search": "printer", "limit": 10}'
+```
+
+## escalate_ticket
+Escalate a ticket for faster attention.
+
+Parameters:
+- `ticket_id` – integer ID of the ticket to escalate.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/escalate_ticket \
+  -d '{"ticket_id": 123}'
+```
+
+## sla_metrics
+Retrieve SLA performance metrics for the helpdesk.
+
+Parameters: none.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/sla_metrics -d '{}'
+```
+
+## bulk_update_tickets
+Apply updates to multiple tickets.
+
+Parameters:
+- `ticket_ids` – list of ticket IDs.
+- `updates` – fields to apply to each ticket.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/bulk_update_tickets \
+  -d '{"ticket_ids": [1,2,3], "updates": {"Assigned_Email": "tech@example.com"}}'
+```


### PR DESCRIPTION
## Summary
- document new MCP tools in `docs/MCP_TOOLS_GUIDE.md`
- reference the guide from README and update tool names
- update API docs with new tool endpoints

## Testing
- `flake8` *(fails: F401, E302, E303, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eea52595c832b9d41e19d1d01efa5