### PR TITLE
Implement semantic filter & relevance search

### DIFF
--- a/tests/test_search_relevance_new.py
+++ b/tests/test_search_relevance_new.py
@@ -1,0 +1,32 @@
+import pytest
+from datetime import datetime, UTC
+
+from src.infrastructure.database import SessionLocal
+from src.core.repositories.models import Ticket
+from src.core.services.ticket_management import TicketManager
+from src.enhanced_mcp_server import _search_tickets
+
+
+@pytest.mark.asyncio
+async def test_search_results_sorted_by_relevance():
+    async with SessionLocal() as db:
+        t1 = Ticket(
+            Subject="Query Subject",
+            Ticket_Body="body",
+            Created_Date=datetime.now(UTC),
+        )
+        t2 = Ticket(
+            Subject="Other",
+            Ticket_Body="Contains query in body",
+            Created_Date=datetime.now(UTC),
+        )
+        await TicketManager().create_ticket(db, t1)
+        await TicketManager().create_ticket(db, t2)
+        await db.commit()
+
+    res = await _search_tickets("query", limit=5)
+    assert res["status"] == "success"
+    data = res["data"]
+    assert len(data) >= 2
+    assert data[0]["relevance"] >= data[1]["relevance"]
+    assert "highlights" in data[0]

--- a/tests/test_semantic_filters_new.py
+++ b/tests/test_semantic_filters_new.py
@@ -1,0 +1,33 @@
+import pytest
+from datetime import datetime, UTC
+
+from src.infrastructure.database import SessionLocal
+from src.core.repositories.models import Ticket
+from src.core.services.ticket_management import TicketManager
+from src.enhanced_mcp_server import _list_tickets
+
+
+@pytest.mark.asyncio
+async def test_semantic_status_filter():
+    async with SessionLocal() as db:
+        open_t = Ticket(
+            Subject="OpenTicket",
+            Ticket_Body="b",
+            Created_Date=datetime.now(UTC),
+            Ticket_Status_ID=1,
+        )
+        closed_t = Ticket(
+            Subject="ClosedTicket",
+            Ticket_Body="b",
+            Created_Date=datetime.now(UTC),
+            Ticket_Status_ID=4,
+        )
+        await TicketManager().create_ticket(db, open_t)
+        await TicketManager().create_ticket(db, closed_t)
+        await db.commit()
+
+    res = await _list_tickets(limit=10, filters={"status": "open"})
+    assert res["status"] == "success"
+    ids = {t["Ticket_ID"] for t in res["data"]}
+    assert open_t.Ticket_ID in ids
+    assert closed_t.Ticket_ID not in ids


### PR DESCRIPTION
## Summary
- add helper functions to enhanced MCP server for semantic filters & search
- score search results by relevance and highlight matches
- translate human-friendly filters to DB fields
- add tests for new semantic and relevance features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687eea564ae4832b88f072fc924f5b1f