### PR TITLE
Add MCP tool optimization tests

### DIFF
--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -63,3 +63,40 @@ async def test_dynamic_create_ticket():
         assert data.get("status") == "success"
         assert data["data"]["Ticket_Status_ID"] == 2
         assert data["data"]["LastModified"] is not None
+
+
+@pytest.mark.asyncio
+async def test_removed_tools_return_404():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        missing = [
+            "open_by_site",
+            "open_by_assigned_user",
+            "tickets_by_status",
+            "ticket_trend",
+            "waiting_on_user",
+            "sla_breaches",
+            "staff_report",
+            "tickets_by_timeframe",
+            "list_sites",
+            "list_assets",
+            "list_vendors",
+            "list_categories",
+            "by_user",
+        ]
+        for name in missing:
+            resp = await client.post(f"/{name}", json={})
+            assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_new_tool_endpoints():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/get_analytics", json={"type": "status_counts"})
+        assert resp.status_code == 200
+        assert resp.json().get("status") in {"success", "error"}
+
+        resp = await client.post("/list_reference_data", json={"type": "sites"})
+        assert resp.status_code == 200
+        assert resp.json().get("status") in {"success", "error"}

--- a/tests/test_mcp_tools_optimization.py
+++ b/tests/test_mcp_tools_optimization.py
@@ -1,0 +1,31 @@
+import pytest
+
+from src.tool_list import TOOLS
+import src.core.services.analytics_reporting as analytics_reporting
+
+
+@pytest.mark.asyncio
+async def test_tool_count():
+    assert len(TOOLS) >= 14
+
+
+def test_schema_quality():
+    for tool in TOOLS:
+        assert isinstance(tool.inputSchema, dict)
+        if tool.inputSchema:
+            assert tool.inputSchema.get("type") == "object"
+
+
+def test_semantic_filter_support():
+    tools_with_filters = [t for t in TOOLS if "filters" in t.inputSchema.get("properties", {})]
+    for tool in tools_with_filters:
+        assert tool.inputSchema["properties"]["filters"]["type"] == "object"
+
+
+def test_ai_feature_tools_present():
+    names = {t.name for t in TOOLS}
+    assert {"get_ticket_full_context", "get_system_snapshot"}.issubset(names)
+
+
+def test_analytics_cache_performance():
+    assert analytics_reporting._cache_ttl <= 300


### PR DESCRIPTION
## Summary
- update dynamic tool tests with checks for removed and new tools
- add optimization test suite for MCP tool metadata

## Testing
- `pytest tests/test_dynamic_tools.py tests/test_mcp_tools_optimization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687eea530a40832b99e0e4a022cd9883