### PR TITLE
Add SLA breach analytics endpoint

### DIFF
--- a/schemas/analytics.py
+++ b/schemas/analytics.py
@@ -32,3 +32,15 @@ class TrendCount(BaseModel):
 
     date: date
     count: int
+
+
+class LateTicketDetail(BaseModel):
+    """Detailed information about tickets that have breached the SLA."""
+
+    ticket_id: int
+    priority: Optional[int] = None
+    age_days: int
+    owner: Optional[str] = None
+    status_id: Optional[int] = None
+    sla_deadline: date
+

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -198,6 +198,18 @@ ENHANCED_TOOLS: List[Tool] = [
         _implementation=_db_wrapper(analysis_tools.sla_breaches),
     ),
     Tool(
+        name="list_sla_breaches",
+        description="List tickets that have breached the SLA",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "sla_days": {"type": "integer"},
+            },
+            "required": [],
+        },
+        _implementation=_db_wrapper(analysis_tools.list_sla_breaches),
+    ),
+    Tool(
         name="ticket_trend",
         description="Ticket trend",
         inputSchema={"type": "object", "properties": {"days": {"type": "integer"}}, "required": []},


### PR DESCRIPTION
## Summary
- add `LateTicketDetail` schema
- expose helper `list_sla_breaches` in analysis tools
- expose `/analytics/late_tickets` endpoint
- register new tool for MCP server
- test analytics SLA breach listing

## Testing
- `pytest tests/test_analytics.py::test_list_late_tickets -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68705e803998832b9dbe0f8d54b73450