### PR TITLE
Add ticket IDs to SLA breach results

### DIFF
--- a/schemas/analytics.py
+++ b/schemas/analytics.py
@@ -32,3 +32,11 @@ class TrendCount(BaseModel):
 
     date: date
     count: int
+
+
+class SlaBreachesResult(BaseModel):
+    """Count of SLA breaches and affected ticket IDs."""
+
+    breaches: int
+    ticket_ids: list[int]
+

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -187,7 +187,7 @@ ENHANCED_TOOLS: List[Tool] = [
     ),
     Tool(
         name="sla_breaches",
-        description="Count SLA breaches",
+        description="List ticket IDs breaching SLA and return their count",
         inputSchema={
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Summary
- expose ticket IDs in `sla_breaches` analytics responses
- return the new data model from the API and tool definition
- adjust tests for updated structure
- tidy unused import and fix lints

## Testing
- `ruff check api/routes.py schemas/analytics.py src/enhanced_mcp_server.py tools/analysis_tools.py tests/test_analytics.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687032ff1aa8832b8c52ba612bb9bdc2