### PR TITLE
Update docs for consolidated toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,63 +347,29 @@ key containing the available tools. The verification script fetches this route
 and compares the returned names against a predefined mapping. It exits with a
 non-zero status when any tools are missing or unexpected. The default mapping
 checks for the ``get_ticket`` and ``list_tickets`` endpoints. The route also
-lists new operations such as ``advanced_search``, ``escalate_ticket``,
-``sla_metrics`` and ``bulk_update_tickets``.
+Verify the list of available tools with:
 
 ```bash
 python verify_tools.py http://localhost:8000
 ```
 
-Include this check in deployment pipelines to catch configuration issues early.
-
 ### Tool Reference
 
-The MCP server exposes several JSON-RPC tools. `get_tickets_by_user` returns
-expanded ticket records for a user. It accepts an `identifier`, optional
-`status` and arbitrary `filters`. Detailed descriptions for every tool are
-available in [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md).
+The server exposes eleven core JSON-RPC tools. Each expects a JSON body matching its schema.
 
-```bash
-curl "http://localhost:8000/get_tickets_by_user?identifier=user@example.com&status=open"
-```
+- `get_ticket` – `{"ticket_id": 123}`
+- `list_tickets` – `{"limit": 5}`
+- `create_ticket` – see `TicketCreate` schema
+- `update_ticket` – `{"ticket_id": 1, "updates": {}}`
+- `close_ticket` – `{"ticket_id": 1, "resolution": "Fixed"}`
+- `assign_ticket` – `{"ticket_id": 1, "assignee_email": "tech@example.com"}`
+- `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
+- `search_tickets` – `{"query": "printer"}`
+- `get_tickets_by_user` – `{"identifier": "user@example.com"}`
+- `get_ticket_full_context` – `{"ticket_id": 123}`
+- `get_system_snapshot` – `{}`
 
-Tool endpoints validate request bodies against each tool's `inputSchema` using
-JSON Schema. Payloads missing required fields or with incorrect types return a
-`422 Unprocessable Entity` response.
-
-`get_open_tickets` lists tickets filtered by status and age. Provide a
-number of `days` and optional `status` such as `open` or `closed`.
-
-```bash
-curl -X POST http://localhost:8000/get_open_tickets \
-  -d '{"status": "open", "days": 7, "limit": 5}'
-```
-
-Request bodies are validated against each tool's `inputSchema` using the
-`jsonschema` library. Missing or incorrectly typed fields result in a `422`
-response.
-
-Additional tools are available:
-
-* `advanced_search` – run a detailed ticket search.
-  ```bash
-  curl -X POST http://localhost:8000/advanced_search \
-    -d '{"text_search": "printer", "limit": 10}'
-  ```
-* `escalate_ticket` – escalate a ticket for faster attention.
-  ```bash
-  curl -X POST http://localhost:8000/escalate_ticket \
-    -d '{"ticket_id": 123}'
-  ```
-* `sla_metrics` – retrieve SLA performance metrics.
-  ```bash
-  curl -X POST http://localhost:8000/sla_metrics -d '{}'
-  ```
-* `bulk_update_tickets` – apply updates to many tickets at once.
-  ```bash
-  curl -X POST http://localhost:8000/bulk_update_tickets \
-    -d '{"ticket_ids": [1,2,3], "updates": {"Assigned_Email": "tech@example.com"}}'
-  ```
+See [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md) for detailed descriptions.
 
 ## License
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -74,15 +74,8 @@ JSON body matching the tool's schema. See
 - `POST /add_ticket_message` – Add a message to a ticket.
 - `POST /search_tickets` – Search tickets. Example: `{"query": "printer"}`
 - `POST /get_tickets_by_user` – Tickets for a user. Example: `{"identifier": "user@example.com"}`
-- `POST /get_open_tickets` – List open tickets. Example: `{"days": 30}`
-- `POST /get_analytics` – Analytics reports. Example: `{"type": "site_counts"}`
-- `POST /list_reference_data` – Reference data lookup. Example: `{"type": "sites"}`
 - `POST /get_ticket_full_context` – Full context for a ticket. Example: `{"ticket_id": 123}`
 - `POST /get_system_snapshot` – System snapshot. Example: `{}`
-- `POST /advanced_search` – Advanced ticket search. Example: `{"text_search": "printer"}`
-- `POST /escalate_ticket` – Escalate a ticket. Example: `{"ticket_id": 42}`
-- `POST /sla_metrics` – SLA metrics summary. Example: `{}`
-- `POST /bulk_update_tickets` – Bulk ticket updates. Example: `{"ticket_ids": [1,2], "updates": {}}`
 
 Endpoints under `/mcp-tools` are also exposed as HTTP routes with the same names as the MCP tools. Refer to the OpenAPI schema or `/docs` endpoint when running the application for the full specification.
 

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -2,6 +2,24 @@
 
 This document describes the JSON-RPC tools exposed by the MCP server. Each section lists the purpose of the tool, the parameters expected in the request body and an example invocation.
 
+## get_ticket
+Fetch a ticket by ID.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_ticket \
+  -d '{"ticket_id": 1}'
+```
+
+## list_tickets
+List tickets with optional filters.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/list_tickets \
+  -d '{"limit": 5, "filters": {"status": "open"}}'
+```
+
 ## create_ticket
 Create a new ticket. Parameters match the `TicketCreate` schema described in [API.md](API.md).
 
@@ -25,7 +43,7 @@ curl -X POST http://localhost:8000/update_ticket \
 ```
 
 ## close_ticket
-Close a ticket with a resolution message.
+Close a ticket with a resolution.
 
 Parameters:
 - `ticket_id` – integer ticket ID.
@@ -96,57 +114,6 @@ curl -X POST http://localhost:8000/get_tickets_by_user \
   -d '{"identifier": "user@example.com", "status": "open"}'
 ```
 
-## get_open_tickets
-List open tickets with optional filters.
-
-Parameters:
-- `days` – look back period (default 3650).
-- `limit` – result limit (default 10).
-- `skip` – result offset (default 0).
-- `filters` – optional filter mapping.
-- `sort` – optional list of columns to sort by.
-
-Example:
-```bash
-curl -X POST http://localhost:8000/get_open_tickets \
-  -d '{"days": 30, "limit": 20, "sort": ["Priority_Level"]}'
-```
-
-## get_analytics
-Return analytics information. The `type` field selects the report.
-
-Allowed types include:
-- `status_counts`
-- `site_counts`
-- `technician_workload`
-- `sla_breaches`
-- `trends`
-
-Parameters:
-- `type` – report type.
-- `params` – optional additional parameters for the chosen report.
-
-Example:
-```bash
-curl -X POST http://localhost:8000/get_analytics \
-  -d '{"type": "site_counts"}'
-```
-
-## list_reference_data
-Return reference data such as sites, assets or vendors.
-
-Parameters:
-- `type` – one of `sites`, `assets`, `vendors`, `categories`.
-- `limit` – optional limit (default 10).
-- `filters` – optional filter mapping.
-- `sort` – optional list of sort columns.
-
-Example:
-```bash
-curl -X POST http://localhost:8000/list_reference_data \
-  -d '{"type": "sites", "limit": 5}'
-```
-
 ## get_ticket_full_context
 Return a ticket along with related labels and history.
 
@@ -167,52 +134,4 @@ Parameters: none.
 Example:
 ```bash
 curl -X POST http://localhost:8000/get_system_snapshot -d '{}'
-```
-
-## advanced_search
-Perform a detailed ticket search using advanced criteria.
-
-Parameters:
-- `text_search` – search string.
-- `limit` – optional result limit.
-
-Example:
-```bash
-curl -X POST http://localhost:8000/advanced_search \
-  -d '{"text_search": "printer", "limit": 10}'
-```
-
-## escalate_ticket
-Escalate a ticket for faster attention.
-
-Parameters:
-- `ticket_id` – integer ID of the ticket to escalate.
-
-Example:
-```bash
-curl -X POST http://localhost:8000/escalate_ticket \
-  -d '{"ticket_id": 123}'
-```
-
-## sla_metrics
-Retrieve SLA performance metrics for the helpdesk.
-
-Parameters: none.
-
-Example:
-```bash
-curl -X POST http://localhost:8000/sla_metrics -d '{}'
-```
-
-## bulk_update_tickets
-Apply updates to multiple tickets.
-
-Parameters:
-- `ticket_ids` – list of ticket IDs.
-- `updates` – fields to apply to each ticket.
-
-Example:
-```bash
-curl -X POST http://localhost:8000/bulk_update_tickets \
-  -d '{"ticket_ids": [1,2,3], "updates": {"Assigned_Email": "tech@example.com"}}'
 ```

--- a/prompt.ini
+++ b/prompt.ini
@@ -143,18 +143,19 @@ Based on general IT best practices:
 
 ━━━━━━━━ TOOL REFERENCE ━━━━━━━━  
 
-🔍 **Vector Search** (Qdrant Closed History)  
-- ALWAYS use first for historical context  
-- Then query open-ticket tools  
+Use these JSON-RPC tools before falling back to general knowledge.
 
-📋 **Direct Lookups**  
-- `get_ticket_expanded`, `search_tickets_expanded`  
-- `tickets_by_timeframe(status="open")`, `tickets_by_timeframe(status="recent")`  
-
-🏢 **Entity Lookups**  
-- `site_tools`, `asset_tools`, `vendor_tools`, `category_tools`
-- `user_tools`: `resolve_user_display_name`
-- `open_by_assigned_user` to count open tickets for a technician; pass `Assigned_Email` or `Assigned_Name` as needed.
+1. `get_ticket` – fetch a ticket by ID. Example: `{"ticket_id": 42}`
+2. `list_tickets` – list tickets with optional filters. Example: `{"limit": 5, "filters": {"status": "open"}}`
+3. `create_ticket` – create a new ticket. Example: `{"Subject": "Issue", "Ticket_Contact_Name": "Alice", "Ticket_Contact_Email": "a@example.com"}`
+4. `update_ticket` – modify a ticket. Example: `{"ticket_id": 1, "updates": {"status": "closed"}}`
+5. `close_ticket` – close a ticket with resolution. Example: `{"ticket_id": 1, "resolution": "Done"}`
+6. `assign_ticket` – assign a technician. Example: `{"ticket_id": 1, "assignee_email": "tech@example.com"}`
+7. `add_ticket_message` – post a follow-up message. Example: `{"ticket_id": 1, "message": "Investigating", "sender_name": "Support"}`
+8. `search_tickets` – keyword search. Example: `{"query": "printer"}`
+9. `get_tickets_by_user` – tickets for a user. Example: `{"identifier": "user@example.com"}`
+10. `get_ticket_full_context` – ticket with history. Example: `{"ticket_id": 42}`
+11. `get_system_snapshot` – system overview. Example: `{}`
 
 ━━━━━━━━ QUALITY INDICATORS ━━━━━━━━  
 


### PR DESCRIPTION
## Summary
- document the 11 consolidated MCP tools
- remove references to deprecated endpoints
- sync README and prompt with simplified tool list

## Testing
- `flake8`
- `pytest -q` *(fails: 3 failed, 50 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f93d1ee70832bad0e1cff72a73b8a