### PR TITLE
Add unified reference data tool

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -76,7 +76,7 @@ JSON body matching the tool's schema. See
 - `POST /get_tickets_by_user` – Tickets for a user. Example: `{"identifier": "user@example.com"}`
 - `POST /get_open_tickets` – List open tickets. Example: `{"days": 30}`
 - `POST /get_analytics` – Analytics reports. Example: `{"type": "site_counts"}`
-- `POST /list_reference_data` – Reference data lookup. Example: `{"type": "sites"}`
+- `POST /get_reference_data` – Reference data lookup. Example: `{"type": "sites"}`
 - `POST /get_ticket_full_context` – Full context for a ticket. Example: `{"ticket_id": 123}`
 - `POST /get_system_snapshot` – System snapshot. Example: `{}`
 - `POST /advanced_search` – Advanced ticket search. Example: `{"text_search": "printer"}`

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -132,19 +132,21 @@ curl -X POST http://localhost:8000/get_analytics \
   -d '{"type": "site_counts"}'
 ```
 
-## list_reference_data
-Return reference data such as sites, assets or vendors.
+## get_reference_data
+Return reference data such as sites, assets, vendors, categories, priorities, or statuses.
 
 Parameters:
-- `type` – one of `sites`, `assets`, `vendors`, `categories`.
+- `type` – one of `sites`, `assets`, `vendors`, `categories`, `priorities`, `statuses`.
 - `limit` – optional limit (default 10).
+- `skip` – optional offset (default 0).
 - `filters` – optional filter mapping.
 - `sort` – optional list of sort columns.
+- `include_counts` – set to `true` to include open/total ticket counts.
 
 Example:
 ```bash
-curl -X POST http://localhost:8000/list_reference_data \
-  -d '{"type": "sites", "limit": 5}'
+curl -X POST http://localhost:8000/get_reference_data \
+  -d '{"type": "sites", "include_counts": true}'
 ```
 
 ## get_ticket_full_context

--- a/main.py
+++ b/main.py
@@ -329,7 +329,7 @@ def build_mcp_endpoint(tool: Tool, schema: Dict[str, Any]):
 server = create_enhanced_server()
 logger.info("Enhanced MCP server active with %d tools", len(TOOLS))
 
-EXCLUDED_TOOLS = {"get_open_tickets", "get_analytics", "list_reference_data"}
+EXCLUDED_TOOLS = {"get_open_tickets", "get_analytics"}
 EXPOSED_TOOLS = [t for t in TOOLS if t.name not in EXCLUDED_TOOLS]
 
 for tool in EXPOSED_TOOLS:

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -925,52 +925,107 @@ async def _get_sla_metrics(
         return {"status": "error", "error": str(e)}
 
 
-async def _list_reference_data(
+async def _get_reference_data_unified(
     type: str,
     limit: int = 10,
+    skip: int = 0,
     filters: Dict[str, Any] | None = None,
     sort: list[str] | None = None,
+    include_counts: bool = False,
 ) -> Dict[str, Any]:
-    """Return reference data such as sites, assets, vendors, or categories."""
+    """Return reference data records with optional ticket counts."""
     try:
         async with db.SessionLocal() as db_session:
             mgr = ReferenceDataManager()
-            
+
+            records: list[Any]
+            field = None
             if type == "sites":
-                records = await mgr.list_sites(
-                    db_session, limit=limit, filters=filters, sort=sort
-                )
+                records = await mgr.list_sites(db_session, skip=skip, limit=limit, filters=filters, sort=sort)
+                field = "Site_ID"
+                ids = [r.ID for r in records]
             elif type == "assets":
-                records = await mgr.list_assets(
-                    db_session, limit=limit, filters=filters, sort=sort
-                )
+                records = await mgr.list_assets(db_session, skip=skip, limit=limit, filters=filters, sort=sort)
+                field = "Asset_ID"
+                ids = [r.ID for r in records]
             elif type == "vendors":
-                records = await mgr.list_vendors(
-                    db_session, limit=limit, filters=filters, sort=sort
-                )
+                records = await mgr.list_vendors(db_session, skip=skip, limit=limit, filters=filters, sort=sort)
+                field = "Assigned_Vendor_ID"
+                ids = [r.ID for r in records]
             elif type == "categories":
-                records = await mgr.list_categories(
-                    db_session, filters=filters, sort=sort
-                )
+                records = await mgr.list_categories(db_session, filters=filters, sort=sort)
+                total_count = len(records)
+                if skip:
+                    records = records[skip:]
+                if limit:
+                    records = records[:limit]
+                field = "Ticket_Category_ID"
+                ids = [r.ID for r in records]
+            elif type == "priorities":
+                result = await db_session.execute(select(Priority).order_by(Priority.ID))
+                records = result.scalars().all()
+                total_count = len(records)
+                if skip:
+                    records = records[skip:]
+                if limit:
+                    records = records[:limit]
+                field = "Priority_Level"
+                ids = [r.Level for r in records]
+            elif type == "statuses":
+                result = await db_session.execute(select(TicketStatus).order_by(TicketStatus.ID))
+                records = result.scalars().all()
+                total_count = len(records)
+                if skip:
+                    records = records[skip:]
+                if limit:
+                    records = records[:limit]
+                field = "Ticket_Status_ID"
+                ids = [r.ID for r in records]
             else:
                 return {"status": "error", "error": f"Unknown reference data type: {type}"}
-                
-            # Convert to dictionaries and clean up
+
+            if include_counts and field:
+                open_counts = await _count_open_tickets_by_field(db_session, field, ids)
+                total_counts = await _count_total_tickets_by_field(db_session, field, ids)
+            else:
+                open_counts = {}
+                total_counts = {}
+
             data = []
             for r in records:
                 item = r.__dict__.copy()
-                # Remove SQLAlchemy internal attributes
-                item.pop('_sa_instance_state', None)
+                item.pop("_sa_instance_state", None)
+                if type == "priorities":
+                    item = {
+                        "id": r.ID,
+                        "level": r.Level,
+                        "semantic_name": _PRIORITY_MAP.get(r.Level.lower(), r.Level) if r.Level else None,
+                    }
+                    key = r.Level
+                else:
+                    key = r.ID
+
+                if include_counts:
+                    item["open_tickets"] = open_counts.get(key, 0)
+                    item["total_tickets"] = total_counts.get(key, 0)
+                    item["closed_tickets"] = item["total_tickets"] - item["open_tickets"]
+
                 data.append(item)
-                
-            return {
+
+            result_obj = {
                 "status": "success",
                 "data": data,
                 "type": type,
-                "count": len(data)
+                "count": len(data),
+                "skip": skip,
+                "limit": limit,
             }
+            if type in {"categories", "priorities", "statuses"}:
+                result_obj["total_count"] = locals().get("total_count", len(records))
+
+            return result_obj
     except Exception as e:
-        logger.error(f"Error in list_reference_data: {e}")
+        logger.error(f"Error in get_reference_data: {e}")
         return {"status": "error", "error": str(e)}
 
 
@@ -1029,224 +1084,6 @@ async def _count_total_tickets_by_field(
     return {row[0]: row[1] for row in result.all()}
 
 
-async def _list_sites_enhanced(
-    limit: int = 10,
-    skip: int = 0,
-    filters: Dict[str, Any] | None = None,
-    sort: list[str] | None = None,
-) -> Dict[str, Any]:
-    """List sites with ticket counts."""
-    try:
-        async with db.SessionLocal() as db_session:
-            mgr = ReferenceDataManager()
-            sites = await mgr.list_sites(
-                db_session,
-                skip=skip,
-                limit=limit,
-                filters=filters,
-                sort=sort,
-            )
-            
-            # Get ticket counts
-            ids = [s.ID for s in sites]
-            open_counts = await _count_open_tickets_by_field(db_session, "Site_ID", ids)
-            total_counts = await _count_total_tickets_by_field(db_session, "Site_ID", ids)
-            
-            # Build enhanced data
-            data = []
-            for s in sites:
-                item = s.__dict__.copy()
-                item.pop('_sa_instance_state', None)
-                item["open_tickets"] = open_counts.get(s.ID, 0)
-                item["total_tickets"] = total_counts.get(s.ID, 0)
-                item["closed_tickets"] = item["total_tickets"] - item["open_tickets"]
-                data.append(item)
-                
-            return {
-                "status": "success",
-                "data": data,
-                "count": len(data),
-                "skip": skip,
-                "limit": limit
-            }
-    except Exception as e:
-        logger.error(f"Error in list_sites_enhanced: {e}")
-        return {"status": "error", "error": str(e)}
-
-
-async def _list_assets_enhanced(
-    limit: int = 10,
-    skip: int = 0,
-    filters: Dict[str, Any] | None = None,
-    sort: list[str] | None = None,
-) -> Dict[str, Any]:
-    """List assets with ticket counts."""
-    try:
-        async with db.SessionLocal() as db_session:
-            mgr = ReferenceDataManager()
-            assets = await mgr.list_assets(
-                db_session,
-                skip=skip,
-                limit=limit,
-                filters=filters,
-                sort=sort,
-            )
-            
-            # Get ticket counts
-            ids = [a.ID for a in assets]
-            open_counts = await _count_open_tickets_by_field(db_session, "Asset_ID", ids)
-            total_counts = await _count_total_tickets_by_field(db_session, "Asset_ID", ids)
-            
-            # Build enhanced data
-            data = []
-            for a in assets:
-                item = a.__dict__.copy()
-                item.pop('_sa_instance_state', None)
-                item["open_tickets"] = open_counts.get(a.ID, 0)
-                item["total_tickets"] = total_counts.get(a.ID, 0)
-                item["closed_tickets"] = item["total_tickets"] - item["open_tickets"]
-                data.append(item)
-                
-            return {
-                "status": "success",
-                "data": data,
-                "count": len(data),
-                "skip": skip,
-                "limit": limit
-            }
-    except Exception as e:
-        logger.error(f"Error in list_assets_enhanced: {e}")
-        return {"status": "error", "error": str(e)}
-
-
-async def _list_vendors_enhanced(
-    limit: int = 10,
-    skip: int = 0,
-    filters: Dict[str, Any] | None = None,
-    sort: list[str] | None = None,
-) -> Dict[str, Any]:
-    """List vendors with ticket counts."""
-    try:
-        async with db.SessionLocal() as db_session:
-            mgr = ReferenceDataManager()
-            vendors = await mgr.list_vendors(
-                db_session,
-                skip=skip,
-                limit=limit,
-                filters=filters,
-                sort=sort,
-            )
-            
-            # Get ticket counts
-            ids = [v.ID for v in vendors]
-            open_counts = await _count_open_tickets_by_field(db_session, "Assigned_Vendor_ID", ids)
-            total_counts = await _count_total_tickets_by_field(db_session, "Assigned_Vendor_ID", ids)
-            
-            # Build enhanced data
-            data = []
-            for v in vendors:
-                item = v.__dict__.copy()
-                item.pop('_sa_instance_state', None)
-                item["open_tickets"] = open_counts.get(v.ID, 0)
-                item["total_tickets"] = total_counts.get(v.ID, 0)
-                item["closed_tickets"] = item["total_tickets"] - item["open_tickets"]
-                data.append(item)
-                
-            return {
-                "status": "success",
-                "data": data,
-                "count": len(data),
-                "skip": skip,
-                "limit": limit
-            }
-    except Exception as e:
-        logger.error(f"Error in list_vendors_enhanced: {e}")
-        return {"status": "error", "error": str(e)}
-
-
-async def _list_categories_enhanced(
-    limit: int = 10,
-    skip: int = 0,
-    filters: Dict[str, Any] | None = None,
-    sort: list[str] | None = None,
-) -> Dict[str, Any]:
-    """List categories with ticket counts."""
-    try:
-        async with db.SessionLocal() as db_session:
-            mgr = ReferenceDataManager()
-            cats = await mgr.list_categories(
-                db_session,
-                filters=filters,
-                sort=sort,
-            )
-            
-            # Apply pagination to categories
-            total_count = len(cats)
-            if skip:
-                cats = cats[skip:]
-            if limit:
-                cats = cats[:limit]
-            
-            # Get ticket counts
-            ids = [c.ID for c in cats]
-            open_counts = await _count_open_tickets_by_field(
-                db_session,
-                "Ticket_Category_ID",
-                ids,
-            )
-            total_counts = await _count_total_tickets_by_field(
-                db_session,
-                "Ticket_Category_ID",
-                ids,
-            )
-            
-            # Build enhanced data
-            data = []
-            for c in cats:
-                item = c.__dict__.copy()
-                item.pop('_sa_instance_state', None)
-                item["open_tickets"] = open_counts.get(c.ID, 0)
-                item["total_tickets"] = total_counts.get(c.ID, 0)
-                item["closed_tickets"] = item["total_tickets"] - item["open_tickets"]
-                data.append(item)
-                
-            return {
-                "status": "success",
-                "data": data,
-                "count": len(data),
-                "total_count": total_count,
-                "skip": skip,
-                "limit": limit
-            }
-    except Exception as e:
-        logger.error(f"Error in list_categories_enhanced: {e}")
-        return {"status": "error", "error": str(e)}
-
-
-async def _list_priorities() -> Dict[str, Any]:
-    """Return available priority levels ordered by ID."""
-    try:
-        async with db.SessionLocal() as db_session:
-            result = await db_session.execute(select(Priority).order_by(Priority.ID))
-            records = result.scalars().all()
-            
-            data = [
-                {
-                    "id": p.ID,
-                    "level": p.Level,
-                    "semantic_name": _PRIORITY_MAP.get(p.Level.lower(), p.Level) if p.Level else None
-                }
-                for p in records
-            ]
-            
-            return {
-                "status": "success",
-                "data": data,
-                "count": len(data)
-            }
-    except Exception as e:
-        logger.error(f"Error in list_priorities: {e}")
-        return {"status": "error", "error": str(e)}
 
 
 async def _ticket_full_context(ticket_id: int) -> Dict[str, Any]:
@@ -1661,37 +1498,36 @@ ENHANCED_TOOLS: List[Tool] = [
         _implementation=_get_sla_metrics,
     ),
     Tool(
-        name="list_reference_data",
-        description="List reference data (sites, assets, vendors, categories)",
+        name="get_reference_data",
+        description="Retrieve reference data with optional ticket counts",
         inputSchema={
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["sites", "assets", "vendors", "categories"],
-                    "description": "Type of reference data"
+                    "enum": [
+                        "sites",
+                        "assets",
+                        "vendors",
+                        "categories",
+                        "priorities",
+                        "statuses",
+                    ],
+                    "description": "Type of reference data",
                 },
                 "limit": {"type": "integer", "default": 10},
+                "skip": {"type": "integer", "default": 0},
                 "filters": {"type": "object"},
                 "sort": {"type": "array", "items": {"type": "string"}},
+                "include_counts": {"type": "boolean", "default": False},
             },
             "required": ["type"],
             "examples": [
-                {"type": "sites", "limit": 10},
-                {"type": "categories", "sort": ["Label"]}
+                {"type": "sites", "include_counts": True},
+                {"type": "priorities"},
             ],
         },
-        _implementation=_list_reference_data,
-    ),
-    Tool(
-        name="list_priorities",
-        description="List available priority levels",
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "examples": [{}],
-        },
-        _implementation=_list_priorities,
+        _implementation=_get_reference_data_unified,
     ),
     Tool(
         name="get_ticket_full_context",
@@ -1768,84 +1604,6 @@ ENHANCED_TOOLS: List[Tool] = [
     ),
 ]
 
-# Enhanced reference data tools with ticket counts
-ENHANCED_REFERENCE_TOOLS: List[Tool] = [
-    Tool(
-        name="list_sites_enhanced",
-        description="List sites with open/total ticket counts",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "limit": {"type": "integer", "default": 10},
-                "skip": {"type": "integer", "default": 0},
-                "filters": {"type": "object"},
-                "sort": {"type": "array", "items": {"type": "string"}},
-            },
-            "examples": [
-                {"limit": 20},
-                {"limit": 10, "sort": ["Label"]}
-            ],
-        },
-        _implementation=_list_sites_enhanced,
-    ),
-    Tool(
-        name="list_assets_enhanced",
-        description="List assets with open/total ticket counts",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "limit": {"type": "integer", "default": 10},
-                "skip": {"type": "integer", "default": 0},
-                "filters": {"type": "object"},
-                "sort": {"type": "array", "items": {"type": "string"}},
-            },
-            "examples": [
-                {"limit": 20},
-                {"limit": 10, "filters": {"Site_ID": 1}}
-            ],
-        },
-        _implementation=_list_assets_enhanced,
-    ),
-    Tool(
-        name="list_vendors_enhanced",
-        description="List vendors with open/total ticket counts",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "limit": {"type": "integer", "default": 10},
-                "skip": {"type": "integer", "default": 0},
-                "filters": {"type": "object"},
-                "sort": {"type": "array", "items": {"type": "string"}},
-            },
-            "examples": [
-                {"limit": 20},
-                {"limit": 10, "sort": ["Label"]}
-            ],
-        },
-        _implementation=_list_vendors_enhanced,
-    ),
-    Tool(
-        name="list_categories_enhanced",
-        description="List categories with open/total ticket counts",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "limit": {"type": "integer", "default": 10},
-                "skip": {"type": "integer", "default": 0},
-                "filters": {"type": "object"},
-                "sort": {"type": "array", "items": {"type": "string"}},
-            },
-            "examples": [
-                {"limit": 20},
-                {"limit": 10, "sort": ["Name"]}
-            ],
-        },
-        _implementation=_list_categories_enhanced,
-    ),
-]
-
-# Combine all tools
-ENHANCED_TOOLS.extend(ENHANCED_REFERENCE_TOOLS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -77,32 +77,40 @@ async def test_get_ticket_attachments_error(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_escalate_ticket_success(client: AsyncClient):
     tid = await _create_ticket(client)
-    resp = await client.post("/escalate_ticket", json={"ticket_id": tid})
+    payload = {
+        "ticket_id": tid,
+        "severity_id": 1,
+        "assignee_email": "tech@example.com",
+    }
+    resp = await client.post("/escalate_ticket", json=payload)
     assert resp.status_code == 200
     assert resp.json().get("status") in {"success", "error"}
 
 
 @pytest.mark.asyncio
 async def test_escalate_ticket_error(client: AsyncClient):
-    resp = await client.post("/escalate_ticket", json={})
+    resp = await client.post("/escalate_ticket", json={"ticket_id": 1})
     assert resp.status_code == 422
 
 
 @pytest.mark.asyncio
-async def test_list_priorities_success(client: AsyncClient):
+async def test_get_reference_data_priorities_success(client: AsyncClient):
     async with SessionLocal() as db:
         p1 = Priority(Level="Low")
         p2 = Priority(Level="High")
         db.add_all([p1, p2])
         await db.commit()
-    resp = await client.post("/list_priorities", json={})
+    resp = await client.post("/get_reference_data", json={"type": "priorities"})
     assert resp.status_code == 200
     assert resp.json().get("status") in {"success", "error"}
 
 
 @pytest.mark.asyncio
-async def test_list_priorities_error(client: AsyncClient):
-    resp = await client.post("/list_priorities", json={"limit": "bad"})
+async def test_get_reference_data_priorities_error(client: AsyncClient):
+    resp = await client.post(
+        "/get_reference_data",
+        json={"type": "priorities", "limit": "bad"},
+    )
     assert resp.status_code == 422
 
 

--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -97,6 +97,6 @@ async def test_new_tool_endpoints():
         assert resp.status_code == 200
         assert resp.json().get("status") in {"success", "error"}
 
-        resp = await client.post("/list_reference_data", json={"type": "sites"})
+        resp = await client.post("/get_reference_data", json={"type": "sites"})
         assert resp.status_code == 200
         assert resp.json().get("status") in {"success", "error"}


### PR DESCRIPTION
## Summary
- add `_get_reference_data_unified` and expose via `get_reference_data`
- remove old reference-data tools
- update docs to reference the new unified tool
- adjust test cases to call `get_reference_data`

## Testing
- `pytest -q` *(fails: tests/test_additional_tools.py::test_search_tickets_advanced_error, tests/test_dynamic_tools.py::test_new_tool_endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_687f93cf0bf0832ba171ad7b3d6d346f