### PR TITLE
Fix tool references and improve validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -329,7 +329,7 @@ logger.info("Enhanced MCP server active with %d tools", len(TOOLS))
 
 
 
-EXCLUDED_TOOLS = {"get_open_tickets"}
+EXCLUDED_TOOLS = set()
 
 
 EXPOSED_TOOLS = [t for t in TOOLS if t.name not in EXCLUDED_TOOLS]

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -172,7 +172,8 @@ class TicketManager:
         sanitized = self._sanitize_search_input(query)
         if not sanitized:
             return []
-        like = f"%{sanitized}%"
+        escaped = self._escape_like_pattern(sanitized)
+        like = f"%{escaped}%"
         stmt = select(VTicketMasterExpanded).filter(
             and_(
                 or_(
@@ -345,7 +346,7 @@ class TicketManager:
             Message=message,
             SenderUserCode='GilAI@heinzcorps.com',
             SenderUserName='Gil AI',
-            DateTimeStamp=datetime.now(),
+            DateTimeStamp=datetime.now(timezone.utc),
         )
         db.add(msg)
         try:


### PR DESCRIPTION
## Summary
- remove unused reference tool definitions and simplify tool list
- adjust excluded tools to none
- fix missing timezone, validation, and schema issues
- standardize analytics error message and reference data counts
- harden search inputs against SQL wildcards

## Testing
- `pytest -q` *(fails: 5 failed, 47 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687fd83abdfc832b8b9db2714a50d522