### PR TITLE
Remove history from ticket context

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ The server exposes eleven core JSON-RPC tools. Each expects a JSON body matching
 - `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
 - `search_tickets` – `{"query": "printer"}`
 - `get_tickets_by_user` – `{"identifier": "user@example.com"}`
-- `get_ticket_full_context` – `{"ticket_id": 123}`
+- `get_ticket_full_context` – `{"ticket_id": 123}` (no user history or nested related tickets)
 - `get_system_snapshot` – `{}`
 
 See [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md) for detailed descriptions.

--- a/docs/API.md
+++ b/docs/API.md
@@ -78,7 +78,7 @@ JSON body matching the tool's schema. See
 - `POST /get_analytics` – Analytics reports. Example: `{"type": "site_counts"}`
 - `POST /get_reference_data` – Reference data lookup. Example: `{"type": "sites"}`
 
-- `POST /get_ticket_full_context` – Full context for a ticket. Example: `{"ticket_id": 123}`
+- `POST /get_ticket_full_context` – Full context for a ticket without user history or nested related tickets. Example: `{"ticket_id": 123}`
 - `POST /get_system_snapshot` – System snapshot. Example: `{}`
 
 - `POST /advanced_search` – Advanced ticket search. Example: `{"text_search": "printer"}`

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -170,7 +170,8 @@ curl -X POST http://localhost:8000/get_reference_data \
 
 
 ## get_ticket_full_context
-Return a ticket along with related labels and history.
+Return a ticket along with messages and metadata.
+User history and nested related tickets are omitted.
 
 Parameters:
 - `ticket_id` – integer ID.

--- a/src/core/services/enhanced_context.py
+++ b/src/core/services/enhanced_context.py
@@ -80,7 +80,9 @@ class EnhancedContextManager:
     async def get_ticket_full_context(
         self,
         ticket_id: int,
-        include_deep_history: bool = True
+        include_deep_history: bool = True,
+        include_user_history: bool = False,
+        include_related_tickets: bool = True,
     ) -> TicketFullContext:
         """Get comprehensive ticket context for agent analysis."""
 
@@ -98,10 +100,12 @@ class EnhancedContextManager:
         # Get all related data in parallel
         messages = await self._get_ticket_messages(ticket_id)
         attachments = await self._get_ticket_attachments(ticket_id)
-        user_history = await self._get_user_ticket_history(
-            ticket.Ticket_Contact_Email,
-            limit=50 if include_deep_history else 10
-        )
+        user_history = None
+        if include_user_history:
+            user_history = await self._get_user_ticket_history(
+                ticket.Ticket_Contact_Email,
+                limit=50 if include_deep_history else 10,
+            )
         user_profile = await self.user_manager.get_user_by_email(ticket.Ticket_Contact_Email)
 
         # Asset and site context
@@ -114,7 +118,9 @@ class EnhancedContextManager:
             site_context = await self._get_site_complete_info(ticket.Site_ID)
 
         # Related tickets
-        related_tickets = await self._find_related_tickets(ticket)
+        related_tickets = None
+        if include_related_tickets:
+            related_tickets = await self._find_related_tickets(ticket)
 
         # Timeline events
         timeline_events = await self._get_ticket_timeline(ticket_id)

--- a/src/core/services/enhanced_operations.py
+++ b/src/core/services/enhanced_operations.py
@@ -388,7 +388,12 @@ class EnhancedOperationsManager:
     async def _capture_ticket_state(self, ticket_id: int) -> Dict[str, Any]:
         """Capture current ticket state for comparison."""
         try:
-            context = await self.context_manager.get_ticket_full_context(ticket_id, include_deep_history=False)
+            context = await self.context_manager.get_ticket_full_context(
+                ticket_id,
+                include_deep_history=False,
+                include_user_history=False,
+                include_related_tickets=False,
+            )
             return {
                 "ticket": context.ticket,
                 "message_count": len(context.messages),

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -1163,7 +1163,11 @@ async def _ticket_full_context(ticket_id: int) -> Dict[str, Any]:
     try:
         async with db.SessionLocal() as db_session:
             mgr = EnhancedContextManager(db_session)
-            context = await mgr.get_ticket_full_context(ticket_id)
+            context = await mgr.get_ticket_full_context(
+                ticket_id,
+                include_user_history=False,
+                include_related_tickets=False,
+            )
             
             return {
                 "status": "success",

--- a/src/shared/schemas/agent_data.py
+++ b/src/shared/schemas/agent_data.py
@@ -14,7 +14,7 @@ class TicketFullContext(BaseModel):
     attachments: List[Dict[str, Any]]  # All attachment metadata
 
     # User context
-    user_history: List[Dict[str, Any]]  # User's past tickets
+    user_history: Optional[List[Dict[str, Any]]] = None  # User's past tickets
     user_profile: Dict[str, Any]  # User info from Graph API
 
     # Asset and site context
@@ -22,7 +22,7 @@ class TicketFullContext(BaseModel):
     site_context: Optional[Dict[str, Any]]  # Site info and current state
 
     # Relationship data
-    related_tickets: List[Dict[str, Any]]  # Same user/asset/site tickets
+    related_tickets: Optional[List[Dict[str, Any]]] = None  # Same user/asset/site tickets
 
     # Timeline and metadata
     timeline_events: List[Dict[str, Any]]  # All status changes


### PR DESCRIPTION
## Summary
- make user_history and related_tickets optional
- exclude user_history and related_tickets when returning a ticket's full context
- document that the API omits user_history and nested related tickets

## Testing
- `pytest -q` *(fails: 5 failed, 47 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687ff0b1e508832bb37ba6b4c862c72c