### PR TITLE
Support open status list in semantic filters

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -186,6 +186,10 @@ _STATUS_MAP = {
     "pending": 3,
 }
 
+# IDs that represent an "open" style status in the database. When filtering on
+# ``status=open`` these should all be matched.
+_OPEN_STATE_IDS = [1, 2, 4, 5, 6, 8]
+
 _PRIORITY_MAP = {
     "critical": "Critical",
     "high": "High",
@@ -270,7 +274,21 @@ def _apply_semantic_filters(filters: dict[str, Any]) -> dict[str, Any]:
         
         if k in {"status", "ticket_status"}:
             if isinstance(value, str):
-                translated["Ticket_Status_ID"] = _STATUS_MAP.get(value.lower(), value)
+                v = value.lower()
+                if v == "open":
+                    translated["Ticket_Status_ID"] = _OPEN_STATE_IDS
+                else:
+                    translated["Ticket_Status_ID"] = _STATUS_MAP.get(v, value)
+            elif isinstance(value, list):
+                ids: list[Any] = []
+                for item in value:
+                    if isinstance(item, str) and item.lower() == "open":
+                        ids.extend(_OPEN_STATE_IDS)
+                    elif isinstance(item, str):
+                        ids.append(_STATUS_MAP.get(item.lower(), item))
+                    else:
+                        ids.append(item)
+                translated["Ticket_Status_ID"] = ids
             else:
                 translated["Ticket_Status_ID"] = value
                 

--- a/tests/test_semantic_filters.py
+++ b/tests/test_semantic_filters.py
@@ -1,0 +1,39 @@
+import pytest
+from datetime import datetime, UTC
+
+from src.infrastructure.database import SessionLocal
+from src.core.repositories.models import Ticket, TicketStatus
+from src.core.services.ticket_management import TicketManager
+from src.enhanced_mcp_server import _apply_semantic_filters, _OPEN_STATE_IDS
+
+
+@pytest.mark.asyncio
+async def test_open_status_filter_matches_multiple_states():
+    async with SessionLocal() as db:
+        now = datetime.now(UTC)
+        statuses = [
+            (1, "Open"),
+            (2, "In Progress"),
+            (3, "Closed"),
+            (4, "Waiting"),
+        ]
+        for sid, label in statuses:
+            if not await db.get(TicketStatus, sid):
+                db.add(TicketStatus(ID=sid, Label=label))
+        await db.commit()
+
+        t1 = Ticket(Subject="A", Ticket_Body="b", Created_Date=now, Ticket_Status_ID=1)
+        t2 = Ticket(Subject="B", Ticket_Body="b", Created_Date=now, Ticket_Status_ID=2)
+        t3 = Ticket(Subject="C", Ticket_Body="b", Created_Date=now, Ticket_Status_ID=3)
+        t4 = Ticket(Subject="D", Ticket_Body="b", Created_Date=now, Ticket_Status_ID=4)
+
+        for t in (t1, t2, t3, t4):
+            await TicketManager().create_ticket(db, t)
+        await db.commit()
+
+        filters = _apply_semantic_filters({"status": "open"})
+        assert filters == {"Ticket_Status_ID": _OPEN_STATE_IDS}
+
+        res = await TicketManager().list_tickets(db, filters=filters)
+        ids = {t.Ticket_ID for t in res}
+        assert ids == {t1.Ticket_ID, t2.Ticket_ID, t4.Ticket_ID}


### PR DESCRIPTION
## Summary
- add `_OPEN_STATE_IDS` constant
- extend `_apply_semantic_filters` to map `status: open` to multiple IDs
- test open status mapping

## Testing
- `pytest -q tests/test_semantic_filters.py`

------
https://chatgpt.com/codex/tasks/task_e_687ffc67dfd4832b9263311c5d190e59