### PR TITLE
Rename LastModifiedBy column

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -24,7 +24,7 @@ class Ticket(Base):
     Assigned_Vendor_ID = Column(Integer)
     Closed_Date = Column(DateTime(timezone=False))
     LastModified = Column(DateTime(timezone=False))
-    LastModifiedBy = Column(String)
+    LastModfiedBy = Column(String)
     Resolution = Column(Text)
 
 
@@ -130,7 +130,7 @@ class VTicketMasterExpanded(ViewBase):
     Assigned_Vendor_ID = Column(Integer)
     Closed_Date = Column(DateTime(timezone=False))
     LastModified = Column(DateTime(timezone=False))
-    LastModifiedBy = Column(String)
+    LastModfiedBy = Column(String)
 
     Assigned_Vendor_Name = Column(String)
     Resolution = Column(Text)

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -68,7 +68,7 @@ class TicketManager:
                 setattr(ticket, key, value)
         # Record when the ticket was last modified
         ticket.LastModified = datetime.now(timezone.utc)
-        ticket.LastModifiedBy = "Gil AI"
+        ticket.LastModfiedBy = "Gil AI"
         try:
             await db.flush()
             await db.refresh(ticket)

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -659,7 +659,7 @@ async def _update_ticket(ticket_id: int, updates: Dict[str, Any]) -> Dict[str, A
                 applied_updates["Assigned_Name"] = applied_updates.get("Assigned_Email")
 
             applied_updates["LastModified"] = datetime.now(timezone.utc)
-            applied_updates["LastModifiedBy"] = "Gil AI"
+            applied_updates["LastModfiedBy"] = "Gil AI"
 
             updated = await TicketManager().update_ticket(db_session, ticket_id, applied_updates)
             if not updated:
@@ -701,7 +701,7 @@ async def _bulk_update_tickets(
             mgr = TicketManager()
             applied_updates = _apply_semantic_filters(updates)
             applied_updates["LastModified"] = datetime.now(timezone.utc)
-            applied_updates["LastModifiedBy"] = "Gil AI"
+            applied_updates["LastModfiedBy"] = "Gil AI"
             
             updated: list[Dict[str, Any]] = []
             failed: list[Dict[str, Any]] = []

--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -144,6 +144,6 @@ class TicketExpandedOut(TicketOut):
     Site_ID: Optional[int] = None
     Closed_Date: Optional[datetime] = None
     LastModified: Optional[datetime] = None
-    LastModifiedBy: Optional[str] = None
+    LastModfiedBy: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)


### PR DESCRIPTION
## Summary
- rename `LastModifiedBy` column to `LastModfiedBy` in ORM models
- update ticket update logic to use `LastModfiedBy`
- rename schema field accordingly
- adjust enhanced server update keys

## Testing
- `pytest tests/test_routes.py::test_create_and_get_ticket -q -o log_level=CRITICAL` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6880f269eaa4832b8e65f76e44c0b77d