### PR TITLE
Include schema validation path in errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,8 @@ curl "http://localhost:8000/get_tickets_by_user?identifier=user@example.com&stat
 
 Tool endpoints validate request bodies against each tool's `inputSchema` using
 JSON Schema. Payloads missing required fields or with incorrect types return a
-`422 Unprocessable Entity` response.
+`422 Unprocessable Entity` response. The error payload also includes a
+`path` field that pinpoints which property failed validation.
 
 `get_open_tickets` lists tickets filtered by status and age. Provide a
 number of `days` and optional `status` such as `open` or `closed`.
@@ -388,7 +389,7 @@ curl -X POST http://localhost:8000/get_open_tickets \
 
 Request bodies are validated against each tool's `inputSchema` using the
 `jsonschema` library. Missing or incorrectly typed fields result in a `422`
-response.
+response. The `path` key in the JSON body indicates which field failed.
 
 Additional tools are available:
 

--- a/main.py
+++ b/main.py
@@ -316,7 +316,10 @@ def build_mcp_endpoint(tool: Tool, schema: Dict[str, Any]):
         except JsonSchemaError as exc:
             return JSONResponse(
                 status_code=422,
-                content={"detail": f"Schema validation error: {exc.message}"}
+                content={
+                    "detail": f"Schema validation error: {exc.message}",
+                    "path": list(exc.path),
+                }
             )
 
         # Filter to only allowed parameters

--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -48,6 +48,7 @@ async def test_get_ticket_messages_success(client: AsyncClient):
 async def test_get_ticket_messages_error(client: AsyncClient):
     resp = await client.post("/get_ticket_messages", json={})
     assert resp.status_code == 422
+    assert "path" in resp.json()
 
 
 @pytest.mark.asyncio
@@ -72,6 +73,7 @@ async def test_get_ticket_attachments_success(client: AsyncClient):
 async def test_get_ticket_attachments_error(client: AsyncClient):
     resp = await client.post("/get_ticket_attachments", json={})
     assert resp.status_code == 422
+    assert "path" in resp.json()
 
 
 @pytest.mark.asyncio
@@ -100,6 +102,7 @@ async def test_escalate_ticket_error(client: AsyncClient):
     resp = await client.post("/update_ticket", json={})
 
     assert resp.status_code == 422
+    assert "path" in resp.json()
 
 
 @pytest.mark.asyncio
@@ -121,6 +124,7 @@ async def test_get_reference_data_priorities_error(client: AsyncClient):
         json={"type": "priorities", "limit": "bad"},
     )
     assert resp.status_code == 422
+    assert "path" in resp.json()
 
 
 @pytest.mark.asyncio
@@ -194,3 +198,4 @@ async def test_bulk_update_tickets_success(client: AsyncClient):
 async def test_bulk_update_tickets_error(client: AsyncClient):
     resp = await client.post("/bulk_update_tickets", json={"ticket_ids": []})
     assert resp.status_code == 422
+    assert "path" in resp.json()

--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -24,9 +24,11 @@ async def test_dynamic_tool_routes():
 
         resp = await client.post("/get_ticket", json={})
         assert resp.status_code == 422
+        assert "path" in resp.json()
 
         resp = await client.post("/get_ticket", json={"ticket_id": "one"})
         assert resp.status_code == 422
+        assert "path" in resp.json()
 
 
 @pytest.mark.asyncio
@@ -35,9 +37,11 @@ async def test_dynamic_tool_validation():
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post("/get_ticket", json={"ticket_id": "bad"})
         assert resp.status_code == 422
+        assert "path" in resp.json()
 
         resp = await client.post("/get_ticket", json={})
         assert resp.status_code == 422
+        assert "path" in resp.json()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- return JSON schema error path in `build_mcp_endpoint`
- document schema error path in README
- update tests expecting 422 errors

## Testing
- `pytest tests/test_dynamic_tools.py tests/test_additional_tools.py -q` *(fails: test_escalate_ticket_success, test_search_tickets_unified_success, test_search_tickets_advanced_error, test_dynamic_create_ticket, test_removed_tools_return_404, test_new_tool_endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_688195c79848832bb4815fc41f3d6224