### PR TITLE
Handle unknown environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ This project exposes a FastAPI application for the Truck Stop MCP Helpdesk.
   update the values for your environment. `config.py` automatically loads `.env` and then looks for
   `config_env.py` to provide Python-level overrides when needed.
 
+  Unknown environment variables are ignored. They can be present in `.env` or the shell without
+  causing validation errors.
+
 3. **Ticket text length**
 
    Ticket bodies and resolutions may exceed 2000 characters. These fields are

--- a/config.py
+++ b/config.py
@@ -60,6 +60,7 @@ class Settings(BaseSettings):
         case_sensitive=False,
         env_file=".env",
         validate_assignment=True,
+        extra="ignore",
     )
 
 


### PR DESCRIPTION
## Summary
- ignore unexpected environment variables in `Settings`
- note that extra env vars are ignored

## Testing
- `bash scripts/setup-tests.sh`
- `flake8`
- `pytest -q` *(fails: 4 failed, 48 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688282934e20832bb099e569665b2593