### PR TITLE
Fix E303 blank line issue in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -341,9 +341,6 @@ def build_mcp_endpoint(tool: Tool, schema: Dict[str, Any]):
 server = create_enhanced_server()
 logger.info("Enhanced MCP server active with %d tools", len(TOOLS))
 
-
-
-
 for tool in EXPOSED_TOOLS:
     schema = tool.inputSchema if isinstance(tool.inputSchema, dict) else {}
     endpoint_func = build_mcp_endpoint(tool, schema)


### PR DESCRIPTION
## Summary
- reduce blank lines after server log entry
- confirm `flake8` passes for `main.py`

## Testing
- `flake8 main.py`


------
https://chatgpt.com/codex/tasks/task_e_6882a01556bc832b96cdad2d2ceb418e