### PR TITLE
Update docs for text/user params

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Additional tools are available:
 * `search_tickets` – run a detailed ticket search.
   ```bash
   curl -X POST http://localhost:8000/search_tickets \
-    -d '{"query": "printer", "created_after": "2024-01-01T00:00:00Z"}'
+    -d '{"text": "printer", "created_after": "2024-01-01T00:00:00Z"}'
   ```
 
 * `update_ticket` – modify an existing ticket, including escalation.
@@ -435,7 +435,7 @@ The server exposes nine core JSON-RPC tools. Each expects a JSON body matching i
 - `create_ticket` – see `TicketCreate` schema
 - `update_ticket` – `{"ticket_id": 1, "updates": {}}`
 - `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
-- `search_tickets` – `{"query": "printer", "created_before": "2024-01-31"}`
+- `search_tickets` – `{"text": "printer", "created_before": "2024-01-31"}`
 - `get_tickets_by_user` – `{"identifier": "user@example.com"}`
 - `get_ticket_full_context` – `{"ticket_id": 123}` (no user history or nested related tickets)
 - `get_system_snapshot` – `{}`

--- a/aiagentprompt.txt
+++ b/aiagentprompt.txt
@@ -43,8 +43,8 @@ Step 1: Identify Search Strategy
 Always start with search_tickets - it's your universal search tool:
 
 Ticket ID mentioned? → get_ticket(ticket_id, include_full_context=true)
-User mentioned? → search_tickets(user_identifier="email@example.com")
-General issue? → search_tickets(query="search terms")
+User mentioned? → search_tickets(user="email@example.com")
+General issue? → search_tickets(text="search terms")
 Status-specific? → search_tickets(status="open", days_back=7)
 Priority issues? → search_tickets(priority="high", unassigned_only=true)
 Filter by creation date? → search_tickets(created_after="2024-01-01", created_before="2024-01-31")
@@ -72,8 +72,8 @@ bulk_update_tickets(ticket_ids=[...], updates={...}) - for multiple tickets
 🔍 Search & Retrieval (2 tools)
 1. search_tickets - Universal search tool
 pythonsearch_tickets(
-    query="text to search",           # Search in subject/body
-    user_identifier="user@email.com", # Find user's tickets
+    text="text to search",           # Search in subject/body
+    user="user@email.com", # Find user's tickets
     status="open",                    # open, closed, in_progress, all
     days_back=7,                      # Last N days
     priority="high",                  # critical, high, medium, low
@@ -203,10 +203,10 @@ Since no existing tickets match:
 SEARCH STRATEGY EXAMPLES
 Example 1: User Reports Email Issues
 python# First, search for similar issues
-results = search_tickets(query="email", status="open", days_back=7)
+results = search_tickets(text="email", status="open", days_back=7)
 
 # If specific to user, also check their history
-user_tickets = search_tickets(user_identifier="user@company.com", limit=5)
+user_tickets = search_tickets(user="user@company.com", limit=5)
 
 # Check system-wide email issues
 analytics = get_analytics(report_type="ticket_counts")

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -85,7 +85,7 @@ curl -X POST http://localhost:8000/add_ticket_message \
 Keyword search across tickets.
 
 Parameters:
-- `query` – text query.
+- `text` – text query.
 - `limit` – optional result limit (default 10).
 - `created_after` – only tickets created on or after this ISO date.
 - `created_before` – only tickets created on or before this ISO date.
@@ -93,7 +93,7 @@ Parameters:
 Example:
 ```bash
 curl -X POST http://localhost:8000/search_tickets \
-  -d '{"query": "printer", "created_after": "2024-01-01"}'
+  -d '{"text": "printer", "created_after": "2024-01-01"}'
 ```
 
 ## get_tickets_by_user
@@ -191,12 +191,12 @@ curl -X POST http://localhost:8000/get_system_snapshot -d '{}'
 
 
 ## advanced_search (removed)
-Use `search_tickets` with a query string.
+Use `search_tickets` with a text string.
 
 Example:
 ```bash
 curl -X POST http://localhost:8000/search_tickets \
-  -d '{"query": "printer", "limit": 10}'
+  -d '{"text": "printer", "limit": 10}'
 ```
 
 ## escalate_ticket (removed)


### PR DESCRIPTION
## Summary
- update docs to refer to `text` and `user` parameters
- keep examples consistent with schema

## Testing
- `bash scripts/setup-tests.sh`
- `flake8`
- `pytest -q` *(fails: 4 failed, 48 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6882d8f5846c832ba0c4534d327180ed