### PR TITLE
Fix tool names in prompt

### DIFF
--- a/prompt.ini
+++ b/prompt.ini
@@ -22,7 +22,7 @@ Current Time: {{
 
 **PHASE 1: COMPREHENSIVE TOOL SEARCH**  
 1. Query Analysis:  
-   → Specific ticket ID? → `get_ticket_expanded`  
+   → Specific ticket ID? → `get_ticket_full_context`
    → User/asset/site mentioned? → respective lookup tools  
    → General issue? → Proceed to Vector Search  
 
@@ -34,7 +34,7 @@ Current Time: {{
    a) Initial search against closed-ticket history:  
       • `embed(query)` → `qdrant.search(top_k=10, threshold=0.15)`  
    b) If no results OR to retrieve open/new tickets:  
-      • Search open tickets via `tickets_by_timeframe(status="open")` or `search_tickets_expanded`  
+      • Search open tickets via `get_open_tickets(status="open")` or `search_tickets`
    c) If still no relevant matches:  
       • Broaden embedding search with synonyms or related terms  
    d) If still none:  
@@ -43,9 +43,9 @@ Current Time: {{
       • Extract keywords and perform keyword lookups against all ticket tools  
 
 4. Additional Tool Searches (regardless of Qdrant outcome):  
-   → `search_tickets_expanded` with relevant keywords  
-   → `tickets_by_timeframe` for recent or open tickets  
-   → Check `analysis_tools` for pattern matches  
+   → `search_tickets` with relevant keywords
+   → `get_open_tickets` for recent or open tickets
+   → Check `get_analytics` for pattern matches
 
 **PHASE 2: RESULT EVALUATION**  
 IF relevant matches found (similarity > 0.15 or direct lookup returns tickets):  


### PR DESCRIPTION
## Summary
- update tool references in `prompt.ini`

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_mcp_tools_optimization.py tests/test_verify_tools.py -q` *(fails: SyntaxError in src/enhanced_mcp_server.py)*

------
https://chatgpt.com/codex/tasks/task_e_68850aec6a68832b8173987cd9a91439