### PR TITLE
Clarify search_tickets output

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,15 @@ Additional tools are available:
     -d '{"text": "printer", "created_after": "2024-01-01T00:00:00Z"}'
   ```
 
+  The response may include a `relevance_score` and a `highlights` object when a
+  text query is provided. `highlights` contains the subject and body with
+  matching terms wrapped in `<em>` tags. Each ticket also includes a `metadata`
+  object with fields like `age_days`, `is_overdue`, and `complexity_estimate`.
+  A ticket is considered overdue once it has been open for more than 24 hours.
+  Complexity is estimated as `"high"` if the body exceeds 500 characters or the
+  subject exceeds 100 characters, `"medium"` for bodies over 200 characters or
+  subjects over 50 characters, otherwise `"low"`.
+
 * `update_ticket` – modify an existing ticket, including escalation.
   ```bash
   curl -X POST http://localhost:8000/update_ticket \

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -112,6 +112,21 @@ Comprehensive ticket search with AI-optimized features and semantic filtering. S
 - `include_relevance_score` – Include relevance scoring for text searches (default: true)
 - `include_highlights` – Include search term highlighting (default: true)
 
+### Response Fields
+
+When a text query is used the response includes extra context:
+
+- `relevance_score` – numeric ranking based on how well the query matches the
+  ticket subject, body and category.
+- `highlights` – object with `subject` and `body` snippets where matched terms
+  are wrapped in `<em>` tags. Only returned when `include_highlights` is true.
+- `metadata` – additional ticket info:
+  - `age_days` – age of the ticket in days.
+  - `is_overdue` – `true` if the ticket has been open for more than 24 hours.
+  - `complexity_estimate` – `"high"` when the body exceeds 500 characters or the
+    subject exceeds 100 characters, `"medium"` for bodies over 200 characters or
+    subjects over 50 characters, otherwise `"low"`.
+
 ### Examples
 
 #### Basic Text Search


### PR DESCRIPTION
## Summary
- document search response fields in README and MCP_TOOLS_GUIDE

## Testing
- `pytest -q` *(fails: ImportError: email-validator is not installed, run `pip install pydantic[email]`)*

------
https://chatgpt.com/codex/tasks/task_e_688546a58880832bb1de405c1e105a93