### PR TITLE
Validate search date parameters

### DIFF
--- a/tests/test_enhanced_search.py
+++ b/tests/test_enhanced_search.py
@@ -163,3 +163,13 @@ async def test_enhanced_search_date_filtering():
         ids = [t["Ticket_ID"] for t in data["data"]]
         assert old_ticket.Ticket_ID in ids
         assert new_ticket.Ticket_ID not in ids
+
+
+@pytest.mark.asyncio
+async def test_enhanced_search_invalid_dates():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/search_tickets", json={"created_after": "bad"})
+        assert resp.status_code == 422
+        resp = await client.post("/search_tickets", json={"created_before": "bad"})
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- validate `created_after` and `created_before` inputs
- test invalid date handling

## Testing
- `LOG_LEVEL=WARNING pytest -q > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_688546a631d8832b8301b8d398a83170