### PR TITLE
Update search_tickets tool schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Additional tools are available:
 * `search_tickets` – run a detailed ticket search.
   ```bash
   curl -X POST http://localhost:8000/search_tickets \
-    -d '{"text": "printer", "created_after": "2024-01-01T00:00:00Z"}'
+    -d '{"text": "printer", "status": 1, "days": 0}'
   ```
 
 * `update_ticket` – modify an existing ticket, including escalation.
@@ -436,7 +436,7 @@ The server exposes nine core JSON-RPC tools. Each expects a JSON body matching i
 - `update_ticket` – `{"ticket_id": 1, "updates": {}}`
 - `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
 
-- `search_tickets` – `{"text": "printer", "created_before": "2024-01-31"}`
+- `search_tickets` – `{"text": "printer", "status": 1, "days": 0}`
 
 - `get_tickets_by_user` – `{"identifier": "user@example.com"}`
 - `get_ticket_full_context` – `{"ticket_id": 123}` (no user history or nested related tickets)

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -93,13 +93,13 @@ Comprehensive ticket search with AI-optimized features and semantic filtering. S
 - `user_identifier` – Alias for `user` parameter (backward compatibility)
 
 #### Time Filtering
-- `days` – Limit to tickets created in the last N days (default: 30, 0 = all time)
-- `created_after` – Only tickets created on or after this ISO datetime
-- `created_before` – Only tickets created on or before this ISO datetime
+- `days` – Limit to tickets created in the last N days (default: 30, `0` returns all tickets). Ignored if `created_after` or `created_before` are provided
+- `created_after` – Only tickets created on or after this ISO datetime (ISO-8601)
+- `created_before` – Only tickets created on or before this ISO datetime (ISO-8601)
 
 #### Semantic Filters (AI-Friendly)
-- `status` – Ticket status: `"open"`, `"closed"`, `"in_progress"`, `"resolved"`, `"waiting"`
-- `priority` – Priority level: `"critical"`, `"high"`, `"medium"`, `"low"`
+- `status` – Ticket status (friendly name or numeric ID). Friendly names include: `"open"`, `"closed"`, `"in_progress"`, `"resolved"`, `"waiting"`
+- `priority` – Priority level (friendly name or ID). Names include: `"critical"`, `"high"`, `"medium"`, `"low"`
 - `site_id` – Filter by site ID (1=Vermillion, 2=Steele, 3=Summit, etc.)
 - `assigned_to` – Filter by assignee email address
 - `unassigned_only` – If true, only return unassigned tickets (default: false)
@@ -117,7 +117,7 @@ Comprehensive ticket search with AI-optimized features and semantic filtering. S
 #### Basic Text Search
 ```bash
 curl -X POST http://localhost:8000/search_tickets \
-  -d '{"text": "printer error", "status": "open", "limit": 5}'
+  -d '{"text": "printer error", "status": 1, "limit": 5}'
 ```
 
 #### User-Specific Search
@@ -129,7 +129,7 @@ curl -X POST http://localhost:8000/search_tickets \
 #### Site and Priority Filtering
 ```bash
 curl -X POST http://localhost:8000/search_tickets \
-  -d '{"site_id": 1, "priority": "high", "days": 7}'
+  -d '{"site_id": 1, "priority": 2, "days": 7}'
 ```
 
 #### Unassigned Ticket Triage
@@ -143,6 +143,7 @@ curl -X POST http://localhost:8000/search_tickets \
 curl -X POST http://localhost:8000/search_tickets \
   -d '{
     "text": "network outage",
+    "days": 0,
     "created_after": "2024-01-01T00:00:00Z",
     "created_before": "2024-12-31T23:59:59Z"
   }'

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -1581,31 +1581,36 @@ ENHANCED_TOOLS: List[Tool] = [
             # Time-based filtering
             "days": {
                 "type": "integer", 
-                "description": "Limit to tickets created in the last N days (0 = all time)",
+                "description": "Limit to tickets created in the last N days (0 = all tickets). Ignored when 'created_after' or 'created_before' are provided",
                 "default": 30,
                 "minimum": 0
             },
             "created_after": {
                 "type": "string", 
                 "format": "date-time",
+                "pattern": "^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$",
                 "description": "Only tickets created on or after this ISO date (overrides 'days')"
             },
             "created_before": {
-                "type": "string", 
-                "format": "date-time", 
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$",
                 "description": "Only tickets created on or before this ISO date"
             },
-            
             # Direct semantic filters (commonly used)
             "status": {
-                "type": "string",
-                "enum": ["open", "closed", "in_progress", "resolved", "waiting"],
-                "description": "Ticket status - 'open' includes multiple open states (Open, In Progress, Waiting, etc.)"
+                "oneOf": [
+                    {"type": "string", "enum": ["open", "closed", "in_progress", "resolved", "waiting"]},
+                    {"type": "integer"}
+                ],
+                "description": "Ticket status (friendly name or numeric ID). 'open' includes multiple open states"
             },
             "priority": {
-                "type": "string",
-                "enum": ["critical", "high", "medium", "low"],
-                "description": "Priority level (maps to Severity_ID: critical=1, high=2, medium=3, low=4)"
+                "oneOf": [
+                    {"type": "string", "enum": ["critical", "high", "medium", "low"]},
+                    {"type": "integer"}
+                ],
+                "description": "Priority level (friendly name or Severity_ID)"
             },
             "site_id": {
                 "type": "integer",


### PR DESCRIPTION
## Summary
- document numeric IDs for `status` and `priority`
- clarify that `days=0` returns all tickets and is ignored with a date range
- add ISO-8601 regex patterns for date fields
- refresh examples in docs and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688546a20838832b9c790ced4b783262