### PR TITLE
Prune unused search endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,9 @@ failed validation.
 
 Additional tools are available:
 
-* `search_tickets` – run a detailed ticket search.
+* `search_tickets` – run a detailed ticket search. The legacy
+  `search_tickets_advanced` route has been removed in favor of this
+  unified interface.
   ```bash
   curl -X POST http://localhost:8000/search_tickets \
     -d '{"text": "printer", "status": 1, "days": 0}'

--- a/docs/API.md
+++ b/docs/API.md
@@ -73,7 +73,8 @@ JSON body matching the tool's schema. See
 - `POST /create_ticket` – Create a ticket. Example: see `TicketCreate` schema
 - `POST /update_ticket` – Update a ticket. Example: `{"ticket_id": 1, "updates": {}}`
 - `POST /add_ticket_message` – Add a message to a ticket.
-- `POST /search_tickets` – Search tickets. Example: `{"text": "printer", "created_after": "2024-01-01"}`
+- `POST /search_tickets` – Search tickets. Example: `{"text": "printer", "created_after": "2024-01-01"}`. The deprecated
+  `/search_tickets_advanced` route was removed.
 - `POST /update_ticket` – Update a ticket or close/assign by modifying fields.
 - `POST /get_tickets_by_user` – Tickets for a user. Example: `{"identifier": "user@example.com"}`
 

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -309,10 +309,11 @@ Example:
 curl -X POST http://localhost:8000/advanced_search \
   -d '{"text_search": "printer", "limit": 10}'
 
-## advanced_search (removed)
+## search_tickets_advanced (removed)
 
-
-Use `search_tickets` with a text string.
+The previous `search_tickets_advanced` endpoint has been removed. Use
+`search_tickets` for unified search or `advanced_search` for complex
+queries.
 
 
 Example:

--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -173,11 +173,6 @@ async def test_search_tickets_unified_error(client: AsyncClient):
     resp = await client.post("/search_tickets", json={"unexpected": 1})
     assert resp.status_code == 422
 
-@pytest.mark.asyncio
-async def test_search_tickets_advanced_error(client: AsyncClient):
-
-    resp = await client.post("/search_tickets_advanced", json={"limit": -1})
-    assert resp.status_code == 404
 
 
 


### PR DESCRIPTION
## Summary
- remove legacy `_search_tickets` and `_search_tickets_advanced` helpers
- drop `test_search_tickets_advanced_error`
- clarify search interface in docs

## Testing
- `pytest tests/test_additional_tools.py::test_search_tickets_unified_error -q`
- `pytest tests/test_enhanced_search.py::test_enhanced_search_direct_parameters -q`
- `pytest -k search_tickets_advanced -q`

------
https://chatgpt.com/codex/tasks/task_e_68857f6c7bb0832baeb98c6e0a5c97a6