### PR TITLE
Update tool tests for active routes

### DIFF
--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -95,11 +95,7 @@ async def test_removed_tools_return_404():
             "list_vendors",
             "list_categories",
             "by_user",
-            "get_system_snapshot",
-            "get_ticket_stats",
-            "get_workload_analytics",
             "get_sla_metrics",
-            "sla_metrics",
         ]
         for name in missing:
             resp = await client.post(f"/{name}", json={})
@@ -110,13 +106,15 @@ async def test_removed_tools_return_404():
 async def test_new_tool_endpoints():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/get_analytics",
+            json={"type": "overview"},
+        )
+        assert resp.status_code == 200
 
-
-        resp = await client.post("/get_analytics", json={"type": "status_counts"})
-
-        assert resp.status_code == 404
-
-
-        resp = await client.post("/list_reference_data", json={"type": "sites"})
-        assert resp.status_code == 404
+        resp = await client.post(
+            "/get_reference_data",
+            json={"type": "priorities"},
+        )
+        assert resp.status_code == 200
 


### PR DESCRIPTION
## Summary
- adjust removed tool endpoint expectations
- verify new analytics and reference data tool routes

## Testing
- `pytest -k dynamic_tools -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885862ba4a0832bab6f5301b9dc173b