### PR TITLE
Fix test whitespace and flake8 errors

### DIFF
--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -80,9 +80,6 @@ async def test_get_ticket_attachments_error(client: AsyncClient):
 async def test_escalate_ticket_success(client: AsyncClient):
     tid = await _create_ticket(client)
 
-
-
-
     payload = {
         "ticket_id": tid,
         "severity_id": 1,
@@ -95,9 +92,7 @@ async def test_escalate_ticket_success(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_escalate_ticket_error(client: AsyncClient):
-
     resp = await client.post("/update_ticket", json={})
-
     assert resp.status_code == 422
     assert "path" in resp.json()
 
@@ -144,12 +139,9 @@ async def test_search_tickets_enhanced_success(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-
 async def test_search_tickets_alias_params(client: AsyncClient):
     await _create_ticket(client, subject="Alias bar")
     payload = {"query": "Alias", "user_identifier": "tester@example.com"}
-
- 
 
     resp = await client.post("/search_tickets", json=payload)
     assert resp.status_code == 200
@@ -162,22 +154,15 @@ async def test_search_tickets_unified_user_identifier_alias(client: AsyncClient)
 
     payload = {"user_identifier": "tester@example.com"}
 
-
     resp = await client.post("/search_tickets", json=payload)
     assert resp.status_code == 200
     assert resp.json().get("status") in {"success", "error"}
 
 
 @pytest.mark.asyncio
-
 async def test_search_tickets_unified_error(client: AsyncClient):
     resp = await client.post("/search_tickets", json={"unexpected": 1})
     assert resp.status_code == 422
-
-
-
-
-
 
 
 @pytest.mark.asyncio
@@ -193,14 +178,20 @@ async def test_get_analytics_sla_performance_success(client: AsyncClient):
         )
         await TicketManager().create_ticket(db, t)
         await db.commit()
-    resp = await client.post("/get_analytics", json={"type": "sla_performance", "params": {"days": 30}})
+    resp = await client.post(
+        "/get_analytics",
+        json={"type": "sla_performance", "params": {"days": 30}},
+    )
     assert resp.status_code == 200
     assert resp.json().get("status") in {"success", "error"}
 
 
 @pytest.mark.asyncio
 async def test_get_analytics_sla_performance_error(client: AsyncClient):
-    resp = await client.post("/get_analytics", json={"type": "sla_performance", "params": {"days": "bad"}})
+    resp = await client.post(
+        "/get_analytics",
+        json={"type": "sla_performance", "params": {"days": "bad"}},
+    )
     assert resp.status_code == 200
 
 
@@ -208,7 +199,10 @@ async def test_get_analytics_sla_performance_error(client: AsyncClient):
 async def test_bulk_update_tickets_success(client: AsyncClient):
     tid1 = await _create_ticket(client, "Bulk1")
     tid2 = await _create_ticket(client, "Bulk2")
-    payload = {"ticket_ids": [tid1, tid2], "updates": {"Assigned_Name": "Agent"}}
+    payload = {
+        "ticket_ids": [tid1, tid2],
+        "updates": {"Assigned_Name": "Agent"},
+    }
     resp = await client.post("/bulk_update_tickets", json=payload)
     assert resp.status_code == 200
     assert resp.json().get("status") in {"success", "error"}

--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -110,13 +110,7 @@ async def test_removed_tools_return_404():
 async def test_new_tool_endpoints():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-
-
         resp = await client.post("/get_analytics", json={"type": "status_counts"})
-
         assert resp.status_code == 404
-
-
         resp = await client.post("/list_reference_data", json={"type": "sites"})
         assert resp.status_code == 404
-

--- a/tests/test_enhanced_operations.py
+++ b/tests/test_enhanced_operations.py
@@ -46,5 +46,3 @@ async def test_validate_ticket_update_invalid_field():
         )
         assert not res.is_valid
         assert res.blocking_errors
-
-

--- a/tests/test_enhanced_search.py
+++ b/tests/test_enhanced_search.py
@@ -85,7 +85,11 @@ async def test_enhanced_search_ai_features():
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
             "/search_tickets",
-            json={"text": "email server", "include_relevance_score": True, "include_highlights": True},
+            json={
+                "text": "email server",
+                "include_relevance_score": True,
+                "include_highlights": True,
+            },
         )
         assert resp.status_code == 200
         data = resp.json()


### PR DESCRIPTION
## Summary
- clean up excess blank lines and trailing whitespace
- wrap long test lines
- reformat dynamic tool tests

## Testing
- `flake8`
- `pytest -q` *(fails: 2 failed, 56 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6885862a411c832ba717a6f05051ed51