### PR TITLE
Unify ticket search

### DIFF
--- a/src/api/v1/tickets.py
+++ b/src/api/v1/tickets.py
@@ -70,13 +70,20 @@ async def search_tickets(
 ) -> List[TicketSearchOut]:
     """Search tickets with optional date filtering."""
     logger.info("Searching tickets for '%s' (limit=%d)", q, limit)
-    results = await TicketManager().search_tickets(db, q, limit=limit, params=params)
+    records, _ = await TicketManager().search_tickets(db, q, limit=limit, params=params)
     validated: List[TicketSearchOut] = []
-    for r in results:
+    for r in records:
+        data = {
+            "Ticket_ID": r.Ticket_ID,
+            "Subject": r.Subject,
+            "body_preview": (r.Ticket_Body or "")[:200],
+            "status_label": r.Ticket_Status_Label,
+            "priority_level": r.Priority_Level,
+        }
         try:
-            validated.append(TicketSearchOut.model_validate(r))
+            validated.append(TicketSearchOut.model_validate(data))
         except ValidationError as exc:
-            logger.error("Invalid search result %s: %s", r.get("Ticket_ID", "?"), exc)
+            logger.error("Invalid search result %s: %s", getattr(r, "Ticket_ID", "?"), exc)
     return validated
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -38,9 +38,9 @@ async def test_search_tickets():
         await TicketManager().create_ticket(db, t)
         await db.commit()
         params = TicketSearchParams()
-        results = await TicketManager().search_tickets(db, "Network", params=params)
-        assert results and results[0]["Subject"] == "Network issue"
-        assert "body_preview" in results[0]
+        records, _ = await TicketManager().search_tickets(db, "Network", params=params)
+        assert records and records[0].Subject == "Network issue"
+        assert hasattr(records[0], "Ticket_ID")
 
 
 @pytest.mark.asyncio
@@ -90,16 +90,16 @@ async def test_search_filters_escape_special_chars():
         await db.commit()
 
         params = TicketSearchParams(Subject="100% guaranteed")
-        res = await TicketManager().search_tickets(db, "", params=params)
-        assert any(r["Ticket_ID"] == t1.Ticket_ID for r in res)
+        res, _ = await TicketManager().search_tickets(db, "", params=params)
+        assert any(r.Ticket_ID == t1.Ticket_ID for r in res)
 
         params = TicketSearchParams(Subject="path\\to\\file")
-        res = await TicketManager().search_tickets(db, "", params=params)
-        assert any(r["Ticket_ID"] == t2.Ticket_ID for r in res)
+        res, _ = await TicketManager().search_tickets(db, "", params=params)
+        assert any(r.Ticket_ID == t2.Ticket_ID for r in res)
 
         params = TicketSearchParams(Subject="under_score_test")
-        res = await TicketManager().search_tickets(db, "", params=params)
-        assert any(r["Ticket_ID"] == t3.Ticket_ID for r in res)
+        res, _ = await TicketManager().search_tickets(db, "", params=params)
+        assert any(r.Ticket_ID == t3.Ticket_ID for r in res)
 
 
 @pytest.mark.asyncio
@@ -122,11 +122,11 @@ async def test_search_created_date_filters():
         await db.commit()
 
         params = TicketSearchParams(created_after=datetime(2023, 1, 5, tzinfo=UTC))
-        res = await TicketManager().search_tickets(db, "DateFilter", params=params)
-        ids = {r["Ticket_ID"] for r in res}
+        res, _ = await TicketManager().search_tickets(db, "DateFilter", params=params)
+        ids = {r.Ticket_ID for r in res}
         assert ids == {new.Ticket_ID}
 
         params = TicketSearchParams(created_before=datetime(2023, 1, 5, tzinfo=UTC))
-        res = await TicketManager().search_tickets(db, "DateFilter", params=params)
-        ids = {r["Ticket_ID"] for r in res}
+        res, _ = await TicketManager().search_tickets(db, "DateFilter", params=params)
+        ids = {r.Ticket_ID for r in res}
         assert ids == {old.Ticket_ID}

--- a/tests/test_semantic_filters.py
+++ b/tests/test_semantic_filters.py
@@ -4,8 +4,8 @@ from datetime import datetime, UTC
 from src.infrastructure.database import SessionLocal
 from src.core.repositories.models import Ticket, TicketStatus
 from src.core.services.ticket_management import TicketManager
-from src.enhanced_mcp_server import (
-    _apply_semantic_filters,
+from src.core.services.ticket_management import (
+    apply_semantic_filters,
     _OPEN_STATE_IDS,
 )
 
@@ -34,7 +34,7 @@ async def test_open_status_filter_matches_multiple_states():
             await TicketManager().create_ticket(db, t)
         await db.commit()
 
-        filters = _apply_semantic_filters({"status": "open"})
+        filters = apply_semantic_filters({"status": "open"})
         assert filters == {"Ticket_Status_ID": _OPEN_STATE_IDS}
 
         res = await TicketManager().list_tickets(db, filters=filters)
@@ -44,11 +44,11 @@ async def test_open_status_filter_matches_multiple_states():
 
 @pytest.mark.asyncio
 async def test_priority_filter_maps_to_severity_id():
-    filters = _apply_semantic_filters({"priority": "high"})
+    filters = apply_semantic_filters({"priority": "high"})
     assert filters == {"Severity_ID": 2}
 
-    filters = _apply_semantic_filters({"priority": 3})
+    filters = apply_semantic_filters({"priority": 3})
     assert filters == {"Severity_ID": 3}
 
-    filters = _apply_semantic_filters({"priority": [1, "low"]})
+    filters = apply_semantic_filters({"priority": [1, "low"]})
     assert filters == {"Severity_ID": [1, 4]}


### PR DESCRIPTION
## Summary
- centralize semantic filter helpers and search logic in `TicketManager`
- simplify API search endpoint to use unified method
- call unified search from RPC tool
- update relevant tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_688586285258832b9747d4b737e2b673