### PR TITLE
Add semantic filter mapping tests

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -44,6 +44,9 @@ _STATUS_MAP = {
 
 _OPEN_STATE_IDS = [1, 2, 4, 5, 6, 8]
 
+# Closed states currently map to the single "Closed" status
+_CLOSED_STATE_IDS = [3]
+
 _PRIORITY_MAP = {
     "critical": "Critical",
     "high": "High",
@@ -69,6 +72,8 @@ def apply_semantic_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
                 v = value.lower()
                 if v == "open":
                     translated["Ticket_Status_ID"] = _OPEN_STATE_IDS
+                elif v == "closed":
+                    translated["Ticket_Status_ID"] = _CLOSED_STATE_IDS
                 else:
                     translated["Ticket_Status_ID"] = _STATUS_MAP.get(v, value)
             elif isinstance(value, list):
@@ -76,6 +81,8 @@ def apply_semantic_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
                 for item in value:
                     if isinstance(item, str) and item.lower() == "open":
                         ids.extend(_OPEN_STATE_IDS)
+                    elif isinstance(item, str) and item.lower() == "closed":
+                        ids.extend(_CLOSED_STATE_IDS)
                     elif isinstance(item, str):
                         ids.append(_STATUS_MAP.get(item.lower(), item))
                     else:
@@ -113,6 +120,11 @@ def apply_semantic_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
             translated[key] = value
 
     return translated
+
+
+def _apply_semantic_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
+    """Backward-compatible wrapper for :func:`apply_semantic_filters`."""
+    return apply_semantic_filters(filters)
 
 
 class TicketManager:

--- a/tests/test_semantic_filters.py
+++ b/tests/test_semantic_filters.py
@@ -6,7 +6,9 @@ from src.core.repositories.models import Ticket, TicketStatus
 from src.core.services.ticket_management import TicketManager
 from src.core.services.ticket_management import (
     apply_semantic_filters,
+    _apply_semantic_filters,
     _OPEN_STATE_IDS,
+    _CLOSED_STATE_IDS,
 )
 
 
@@ -34,7 +36,7 @@ async def test_open_status_filter_matches_multiple_states():
             await TicketManager().create_ticket(db, t)
         await db.commit()
 
-        filters = apply_semantic_filters({"status": "open"})
+        filters = _apply_semantic_filters({"status": "open"})
         assert filters == {"Ticket_Status_ID": _OPEN_STATE_IDS}
 
         res = await TicketManager().list_tickets(db, filters=filters)
@@ -52,3 +54,22 @@ async def test_priority_filter_maps_to_severity_id():
 
     filters = apply_semantic_filters({"priority": [1, "low"]})
     assert filters == {"Severity_ID": [1, 4]}
+
+
+def test_status_string_mappings():
+    mapping_expectations = {
+        "open": _OPEN_STATE_IDS,
+        "closed": _CLOSED_STATE_IDS,
+        "in_progress": 2,
+        "progress": 2,
+        "pending": 3,
+        "resolved": 4,
+    }
+    for status, expected in mapping_expectations.items():
+        result = _apply_semantic_filters({"status": status})
+        assert result == {"Ticket_Status_ID": expected}
+
+
+def test_open_closed_constants():
+    assert _OPEN_STATE_IDS == [1, 2, 4, 5, 6, 8]
+    assert _CLOSED_STATE_IDS == [3]


### PR DESCRIPTION
## Summary
- expand ticket status mapping tests
- add closed state constants and wrapper function

## Testing
- `pytest -k semantic_filters -q`

------
https://chatgpt.com/codex/tasks/task_e_68858c51f8b8832ba245b254ebc85424