### PR TITLE
Update ticket status filters

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -414,28 +414,19 @@ class TicketManager:
         )  # noqa: E501
         query = query.order_by(VTicketMasterExpanded.Ticket_ID)
         if status:
-            query = query.join(
-                TicketStatusModel,
-                VTicketMasterExpanded.Ticket_Status_ID == TicketStatusModel.ID,
-                isouter=True,
-            )
             s = status.lower()
             if s == "open":
                 query = query.filter(
-                    or_(
-                        TicketStatusModel.Label.ilike("%open%"),
-                        TicketStatusModel.Label.ilike("%progress%"),
-                    )
+                    VTicketMasterExpanded.Ticket_Status_ID.in_([1, 2, 4, 5, 6, 8])
                 )
             elif s == "closed":
                 query = query.filter(
-                    or_(
-                        TicketStatusModel.Label.ilike("%closed%"),
-                        TicketStatusModel.Label.ilike("%resolved%"),
-                    )
+                    VTicketMasterExpanded.Ticket_Status_ID.in_([3, 7])
                 )
-            elif s == "progress":
-                query = query.filter(TicketStatusModel.Label.ilike("%progress%"))
+            elif s in {"in_progress", "progress"}:
+                query = query.filter(
+                    VTicketMasterExpanded.Ticket_Status_ID.in_([2, 4, 5, 6, 8])
+                )
         if filters:
             conditions = []
             for key, value in filters.items():
@@ -459,26 +450,20 @@ class TicketManager:
         days: int = 7,
         limit: int = 10,
     ) -> List[VTicketMasterExpanded]:
-        query = select(VTicketMasterExpanded).join(
-            TicketStatusModel,
-            VTicketMasterExpanded.Ticket_Status_ID == TicketStatusModel.ID,
-            isouter=True,
-        )
+        query = select(VTicketMasterExpanded)
         if status:
             s = status.lower()
             if s == "open":
                 query = query.filter(
-                    or_(
-                        TicketStatusModel.Label.ilike("%open%"),
-                        TicketStatusModel.Label.ilike("%progress%"),
-                    )
+                    VTicketMasterExpanded.Ticket_Status_ID.in_([1, 2, 4, 5, 6, 8])
                 )
             elif s == "closed":
                 query = query.filter(
-                    or_(
-                        TicketStatusModel.Label.ilike("%closed%"),
-                        TicketStatusModel.Label.ilike("%resolved%"),
-                    )
+                    VTicketMasterExpanded.Ticket_Status_ID.in_([3, 7])
+                )
+            elif s in {"in_progress", "progress"}:
+                query = query.filter(
+                    VTicketMasterExpanded.Ticket_Status_ID.in_([2, 4, 5, 6, 8])
                 )
         if days is not None and days > 0:
             cutoff = datetime.now(timezone.utc) - timedelta(days=days)


### PR DESCRIPTION
## Summary
- refine ticket status logic in TicketManager
- simplify queries using status IDs

## Testing
- `bash scripts/setup-tests.sh`
- `flake8`
- `pytest -q` *(fails: tests/test_dynamic_tools.py::test_new_tool_endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68858c50ca4c832b872c5dc76898ede6