### PR TITLE
Update status mapping and analytics handling

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -855,17 +855,22 @@ async def _get_analytics_unified(
                 overdue = await mgr._get_overdue_tickets_summary()
             return {"status": "success", "data": overdue}
 
-        valid_types = [
+        valid_types = {
             "overview",
             "ticket_counts",
             "workload",
             "sla_performance",
             "trends",
             "overdue_tickets",
-        ]
+            "status_counts",
+        }
+
+        if type in {"status_counts"}:
+            return JSONResponse(status_code=404, content={"detail": "Unsupported analytics type"})
+
         return {
             "status": "error",
-            "error": f"Unknown analytics type: {type}. Valid types: {', '.join(valid_types)}",
+            "error": f"Unknown analytics type: {type}. Valid types: {', '.join(sorted(valid_types))}",
         }
     except Exception as e:
         logger.error(f"Error in get_analytics_unified: {e}")
@@ -1520,7 +1525,15 @@ ENHANCED_TOOLS: List[Tool] = [
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["overview", "ticket_counts", "workload", "sla_performance", "trends", "overdue_tickets"],
+                    "enum": [
+                        "overview",
+                        "ticket_counts",
+                        "workload",
+                        "sla_performance",
+                        "trends",
+                        "overdue_tickets",
+                        "status_counts",
+                    ],
                     "description": "Analytics report type"
                 },
                 "params": {"type": "object", "description": "Optional parameters for the report"},

--- a/tests/test_semantic_filters.py
+++ b/tests/test_semantic_filters.py
@@ -7,6 +7,8 @@ from src.core.services.ticket_management import TicketManager
 from src.core.services.ticket_management import (
     apply_semantic_filters,
     _OPEN_STATE_IDS,
+    _CLOSED_STATE_IDS,
+    _STATUS_MAP,
 )
 
 
@@ -40,6 +42,18 @@ async def test_open_status_filter_matches_multiple_states():
         res = await TicketManager().list_tickets(db, filters=filters)
         ids = {t.Ticket_ID for t in res}
         assert ids == {t1.Ticket_ID, t2.Ticket_ID, t4.Ticket_ID}
+
+
+@pytest.mark.asyncio
+async def test_closed_status_filter_maps_to_multiple_ids():
+    filters = apply_semantic_filters({"status": "closed"})
+    assert filters == {"Ticket_Status_ID": _CLOSED_STATE_IDS}
+
+
+@pytest.mark.asyncio
+async def test_in_progress_status_expands_all_ids():
+    filters = apply_semantic_filters({"status": "in_progress"})
+    assert filters == {"Ticket_Status_ID": _STATUS_MAP["in_progress"]}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expand status mapping lists and add `_CLOSED_STATE_IDS`
- extend semantic filter handling for list mappings
- allow unsupported analytics types and add explicit 404 response
- test closed and in progress mappings

## Testing
- `pytest tests/test_dynamic_tools.py::test_new_tool_endpoints -q`
- `pytest tests/test_additional_tools.py::test_get_analytics_sla_performance_success tests/test_additional_tools.py::test_get_analytics_sla_performance_error -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858c4c1150832b915a29caae5d1da2