### PR TITLE
Refactor ticket status filtering

### DIFF
--- a/src/core/services/enhanced_context.py
+++ b/src/core/services/enhanced_context.py
@@ -24,6 +24,7 @@ from src.shared.schemas.agent_data import (
 )
 from .user_services import UserManager
 from .analytics_reporting import AnalyticsManager
+from .ticket_management import _OPEN_STATE_IDS, _CLOSED_STATE_IDS
 
 logger = logging.getLogger(__name__)
 
@@ -508,10 +509,7 @@ class EnhancedContextManager:
             .filter(
                 and_(
                     VTicketMasterExpanded.Site_ID == site_id,
-                    or_(
-                        TicketStatus.Label.ilike("%open%"),
-                        TicketStatus.Label.ilike("%progress%"),
-                    ),
+                    TicketStatus.ID.in_(_OPEN_STATE_IDS),
                 )
             )
         )
@@ -614,10 +612,7 @@ class EnhancedContextManager:
             .filter(
                 and_(
                     VTicketMasterExpanded.Assigned_Email.is_not(None),
-                    or_(
-                        TicketStatus.Label.ilike("%open%"),
-                        TicketStatus.Label.ilike("%progress%"),
-                    ),
+                    TicketStatus.ID.in_(_OPEN_STATE_IDS),
                 )
             )
             .group_by(
@@ -648,10 +643,7 @@ class EnhancedContextManager:
             .filter(
                 and_(
                     VTicketMasterExpanded.Assigned_Email.is_(None),
-                    or_(
-                        TicketStatus.Label.ilike("%open%"),
-                        TicketStatus.Label.ilike("%progress%"),
-                    ),
+                    TicketStatus.ID.in_(_OPEN_STATE_IDS),
                 )
             )
             .order_by(VTicketMasterExpanded.Created_Date.desc())
@@ -687,10 +679,7 @@ class EnhancedContextManager:
             .filter(
                 and_(
                     VTicketMasterExpanded.Created_Date < cutoff,
-                    or_(
-                        TicketStatus.Label.ilike("%open%"),
-                        TicketStatus.Label.ilike("%progress%"),
-                    ),
+                    TicketStatus.ID.in_(_OPEN_STATE_IDS),
                 )
             )
             .order_by(VTicketMasterExpanded.Created_Date.asc())
@@ -755,12 +744,7 @@ class EnhancedContextManager:
                 VTicketMasterExpanded.Ticket_Status_ID == TicketStatus.ID,
                 isouter=True,
             )
-            .filter(
-                or_(
-                    TicketStatus.Label.ilike("%open%"),
-                    TicketStatus.Label.ilike("%progress%"),
-                )
-            )
+            .filter(TicketStatus.ID.in_(_OPEN_STATE_IDS))
         )
         open_count = open_result.scalar() or 0
 
@@ -816,10 +800,7 @@ class EnhancedContextManager:
                 .filter(
                     and_(
                         VTicketMasterExpanded.Ticket_Contact_Email == user_email,
-                        or_(
-                            TicketStatus.Label.ilike("%open%"),
-                            TicketStatus.Label.ilike("%progress%"),
-                        ),
+                        TicketStatus.ID.in_(_OPEN_STATE_IDS),
                     )
                 )
             )
@@ -975,10 +956,7 @@ class EnhancedContextManager:
                 .filter(
                     and_(
                         VTicketMasterExpanded.Ticket_Contact_Email == user_email,
-                        or_(
-                            TicketStatus.Label.ilike("%open%"),
-                            TicketStatus.Label.ilike("%progress%"),
-                        ),
+                        TicketStatus.ID.in_(_OPEN_STATE_IDS),
                     )
                 )
                 .order_by(VTicketMasterExpanded.Created_Date.desc())
@@ -1020,10 +998,7 @@ class EnhancedContextManager:
                 .filter(
                     and_(
                         VTicketMasterExpanded.Ticket_Contact_Email == user_email,
-                        or_(
-                            TicketStatus.Label.ilike("%closed%"),
-                            TicketStatus.Label.ilike("%resolved%"),
-                        ),
+                        TicketStatus.ID.in_(_CLOSED_STATE_IDS),
                     )
                 )
                 .order_by(VTicketMasterExpanded.Closed_Date.desc())

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -46,6 +46,7 @@ from src.core.services.analytics_reporting import (
     sla_breaches,
     AnalyticsManager,
 )
+from src.core.services.ticket_management import _OPEN_STATE_IDS
 from src.core.services.enhanced_context import EnhancedContextManager
 from src.core.services.advanced_query import AdvancedQueryManager
 from src.shared.schemas.agent_data import AdvancedQuery
@@ -855,6 +856,9 @@ async def _get_analytics_unified(
                 overdue = await mgr._get_overdue_tickets_summary()
             return {"status": "success", "data": overdue}
 
+        if type == "status_counts":
+            return JSONResponse(status_code=404, content={"detail": "Deprecated analytics type"})
+
         valid_types = [
             "overview",
             "ticket_counts",
@@ -862,11 +866,14 @@ async def _get_analytics_unified(
             "sla_performance",
             "trends",
             "overdue_tickets",
+            "status_counts",
         ]
-        return {
-            "status": "error",
-            "error": f"Unknown analytics type: {type}. Valid types: {', '.join(valid_types)}",
-        }
+        return JSONResponse(
+            status_code=404,
+            content={
+                "detail": f"Unknown analytics type: {type}. Valid types: {', '.join(valid_types)}"
+            },
+        )
     except Exception as e:
         logger.error(f"Error in get_analytics_unified: {e}")
         return {"status": "error", "error": str(e)}
@@ -884,12 +891,7 @@ async def _get_sla_metrics(
             query = (
                 select(func.count(Ticket.Ticket_ID))
                 .join(TicketStatus, Ticket.Ticket_Status_ID == TicketStatus.ID, isouter=True)
-                .filter(
-                    or_(
-                        TicketStatus.Label.ilike("%open%"),
-                        TicketStatus.Label.ilike("%progress%"),
-                    )
-                )
+                .filter(TicketStatus.ID.in_(_OPEN_STATE_IDS))
             )
             
             # Apply filters
@@ -1071,12 +1073,7 @@ async def _count_open_tickets_by_field(
             isouter=True,
         )
         .filter(column.in_(ids))
-        .filter(
-            or_(
-                TicketStatus.Label.ilike("%open%"),
-                TicketStatus.Label.ilike("%progress%"),
-            )
-        )
+        .filter(TicketStatus.ID.in_(_OPEN_STATE_IDS))
         .group_by(column)
     )
     
@@ -1520,8 +1517,16 @@ ENHANCED_TOOLS: List[Tool] = [
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["overview", "ticket_counts", "workload", "sla_performance", "trends", "overdue_tickets"],
-                    "description": "Analytics report type"
+                    "enum": [
+                        "overview",
+                        "ticket_counts",
+                        "workload",
+                        "sla_performance",
+                        "trends",
+                        "overdue_tickets",
+                        "status_counts",
+                    ],
+                    "description": "Analytics report type",
                 },
                 "params": {"type": "object", "description": "Optional parameters for the report"},
             },


### PR DESCRIPTION
## Summary
- map semantic status values to `_OPEN_STATE_IDS` and new `_CLOSED_STATE_IDS`
- filter by `Ticket_Status_ID` instead of label text in analytics and context helpers
- adjust `get_analytics` tool to treat `status_counts` as deprecated

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68858c55e37c832ba68326dee2e21e92