### PR TITLE
Refactor ticket status lists to constants

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -446,15 +446,17 @@ class TicketManager:
             s = status.lower()
             if s == "open":
                 query = query.filter(
-                    VTicketMasterExpanded.Ticket_Status_ID.in_([1, 2, 4, 5, 6, 8])
+                    VTicketMasterExpanded.Ticket_Status_ID.in_(_OPEN_STATE_IDS)
                 )
             elif s == "closed":
                 query = query.filter(
-                    VTicketMasterExpanded.Ticket_Status_ID.in_([3, 7])
+                    VTicketMasterExpanded.Ticket_Status_ID.in_(_CLOSED_STATE_IDS)
                 )
             elif s in {"in_progress", "progress"}:
                 query = query.filter(
-                    VTicketMasterExpanded.Ticket_Status_ID.in_([2, 4, 5, 6, 8])
+                    VTicketMasterExpanded.Ticket_Status_ID.in_(
+                        _STATUS_MAP["in_progress"]
+                    )
                 )
         if filters:
             conditions = []
@@ -484,15 +486,17 @@ class TicketManager:
             s = status.lower()
             if s == "open":
                 query = query.filter(
-                    VTicketMasterExpanded.Ticket_Status_ID.in_([1, 2, 4, 5, 6, 8])
+                    VTicketMasterExpanded.Ticket_Status_ID.in_(_OPEN_STATE_IDS)
                 )
             elif s == "closed":
                 query = query.filter(
-                    VTicketMasterExpanded.Ticket_Status_ID.in_([3, 7])
+                    VTicketMasterExpanded.Ticket_Status_ID.in_(_CLOSED_STATE_IDS)
                 )
             elif s in {"in_progress", "progress"}:
                 query = query.filter(
-                    VTicketMasterExpanded.Ticket_Status_ID.in_([2, 4, 5, 6, 8])
+                    VTicketMasterExpanded.Ticket_Status_ID.in_(
+                        _STATUS_MAP["in_progress"]
+                    )
                 )
         if days is not None and days > 0:
             cutoff = datetime.now(timezone.utc) - timedelta(days=days)


### PR DESCRIPTION
## Summary
- use `_OPEN_STATE_IDS`, `_CLOSED_STATE_IDS`, and `_STATUS_MAP["in_progress"]` instead of hard-coded status ID lists

## Testing
- `bash scripts/setup-tests.sh`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68863d4933c8832b8516ea21e14fe87b