### PR TITLE
Use DB formatted datetime strings

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, DateTime, Integer, String, Text
+from sqlalchemy import Column, Integer, String, Text
+from src.shared.utils.date_format import FormattedDateTime
 from sqlalchemy.orm import DeclarativeBase
 
 
@@ -17,13 +18,13 @@ class Ticket(Base):
     Asset_ID = Column(Integer)
     Site_ID = Column(Integer)
     Ticket_Category_ID = Column(Integer)
-    Created_Date = Column(DateTime(timezone=False))
+    Created_Date = Column(FormattedDateTime())
     Assigned_Name = Column(String)
     Assigned_Email = Column(String)
     Severity_ID = Column(Integer)
     Assigned_Vendor_ID = Column(Integer)
-    Closed_Date = Column(DateTime(timezone=False))
-    LastModified = Column(DateTime(timezone=False))
+    Closed_Date = Column(FormattedDateTime())
+    LastModified = Column(FormattedDateTime())
     LastModfiedBy = Column(String)
     Resolution = Column(Text)
 
@@ -53,7 +54,7 @@ class TicketAttachment(Base):
     Ticket_ID = Column(Integer)
     Name = Column(String)
     WebURl = Column(String)
-    UploadDateTime = Column(DateTime(timezone=False))
+    UploadDateTime = Column(FormattedDateTime())
 
 
 class TicketMessage(Base):
@@ -63,7 +64,7 @@ class TicketMessage(Base):
     Message = Column(Text)
     SenderUserCode = Column(String)
     SenderUserName = Column(String)
-    DateTimeStamp = Column(DateTime(timezone=False))
+    DateTimeStamp = Column(FormattedDateTime())
 
 
 class Site(Base):
@@ -97,8 +98,8 @@ class OnCallShift(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     user_email = Column(String, nullable=False, index=True)
-    start_time = Column(DateTime(timezone=False), nullable=False)
-    end_time = Column(DateTime(timezone=False), nullable=False)
+    start_time = Column(FormattedDateTime(), nullable=False)
+    end_time = Column(FormattedDateTime(), nullable=False)
 
 
 class ViewBase(DeclarativeBase):
@@ -123,13 +124,13 @@ class VTicketMasterExpanded(ViewBase):
     Ticket_Category_ID = Column(Integer)
     Ticket_Category_Label = Column(String)
 
-    Created_Date = Column(DateTime(timezone=False))
+    Created_Date = Column(FormattedDateTime())
     Assigned_Name = Column(String)
     Assigned_Email = Column(String)
     Severity_ID = Column(Integer)
     Assigned_Vendor_ID = Column(Integer)
-    Closed_Date = Column(DateTime(timezone=False))
-    LastModified = Column(DateTime(timezone=False))
+    Closed_Date = Column(FormattedDateTime())
+    LastModified = Column(FormattedDateTime())
     LastModfiedBy = Column(String)
 
     Assigned_Vendor_Name = Column(String)

--- a/src/core/services/enhanced_context.py
+++ b/src/core/services/enhanced_context.py
@@ -25,6 +25,7 @@ from src.shared.schemas.agent_data import (
 from .user_services import UserManager
 from .analytics_reporting import AnalyticsManager
 from .ticket_management import _OPEN_STATE_IDS, _CLOSED_STATE_IDS
+from src.shared.utils.date_format import format_db_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -360,9 +361,9 @@ class EnhancedContextManager:
         is_overdue = age_hours > sla_threshold_hours and not closed_date
 
         return {
-            "created_timestamp": created.isoformat() if created else None,
-            "last_modified": last_modified.isoformat() if last_modified else None,
-            "closed_timestamp": closed_date.isoformat() if closed_date else None,
+            "created_timestamp": format_db_datetime(created) if created else None,
+            "last_modified": format_db_datetime(last_modified) if last_modified else None,
+            "closed_timestamp": format_db_datetime(closed_date) if closed_date else None,
             "age_minutes": round(age_minutes, 2),
             "age_hours": round(age_hours, 2),
             "age_days": round(age_days, 2),
@@ -373,7 +374,7 @@ class EnhancedContextManager:
             "sla_threshold_hours": sla_threshold_hours,
             "priority_text": self._severity_id_to_text(ticket.Severity_ID),
             "complexity_estimate": self._estimate_ticket_complexity(ticket),
-            "metadata_generated_at": now.isoformat(),
+            "metadata_generated_at": format_db_datetime(now),
         }
 
     # Additional helper methods...
@@ -777,7 +778,7 @@ class EnhancedContextManager:
             "avg_resolution_hours": 0.0,
             "ticket_frequency": "unknown",
             "error": True,
-            "calculation_timestamp": self._get_current_utc().isoformat(),
+            "calculation_timestamp": format_db_datetime(self._get_current_utc()),
         }
 
     async def _calculate_user_ticket_statistics(self, user_email: str) -> Dict[str, Any]:
@@ -837,7 +838,7 @@ class EnhancedContextManager:
                 "closed_tickets": total_tickets - open_tickets,
                 "avg_resolution_hours": round(avg_resolution_hours, 2),
                 "ticket_frequency": "high" if total_tickets > 20 else "normal",
-                "calculation_timestamp": self._get_current_utc().isoformat(),
+                "calculation_timestamp": format_db_datetime(self._get_current_utc()),
                 "error": False,
             }
 

--- a/src/core/services/system_utilities.py
+++ b/src/core/services/system_utilities.py
@@ -11,6 +11,7 @@ import sys
 from dataclasses import dataclass
 from typing import Generic, Optional, TypeVar
 from datetime import datetime
+from src.shared.utils.date_format import parse_db_datetime
 
 import httpx
 
@@ -35,6 +36,11 @@ def parse_search_datetime(date_str: str | None) -> datetime | None:
     """Safely parse datetime with proper error handling."""
     if not date_str:
         return None
+    try:
+        # First attempt database-specific format
+        return parse_db_datetime(date_str)
+    except ValueError:
+        pass
     try:
         if date_str.endswith("Z"):
             date_str = date_str[:-1] + "+00:00"

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -27,6 +27,7 @@ from src.core.repositories.models import (
 )
 
 from .system_utilities import OperationResult, parse_search_datetime
+from src.shared.utils.date_format import format_db_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -641,7 +642,9 @@ class TicketTools:
                     priority=ticket.Priority_Level or "Medium",
                     assigned_to=ticket.Assigned_Name,
                     created_date=(
-                        ticket.Created_Date.isoformat() if ticket.Created_Date else ""
+                        format_db_datetime(ticket.Created_Date)
+                        if ticket.Created_Date
+                        else ""
                     ),
                     relevance_score=1.0,
                 )

--- a/src/shared/utils/date_format.py
+++ b/src/shared/utils/date_format.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+DB_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
+
+
+def format_db_datetime(dt: datetime) -> str:
+    """Return ``dt`` formatted for database storage."""
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt.strftime(DB_DATETIME_FORMAT)
+
+
+def parse_db_datetime(text: str) -> datetime:
+    """Parse a database datetime string into an aware ``datetime``."""
+    dt = datetime.strptime(text, DB_DATETIME_FORMAT)
+    return dt.replace(tzinfo=timezone.utc)
+
+
+try:
+    from sqlalchemy.types import TypeDecorator, String
+except Exception:  # pragma: no cover - SQLAlchemy not available
+    TypeDecorator = object
+    String = object
+
+
+class FormattedDateTime(TypeDecorator):
+    """Store ``datetime`` values using :data:`DB_DATETIME_FORMAT`."""
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):  # type: ignore[override]
+        if value is None:
+            return value
+        if isinstance(value, datetime):
+            return format_db_datetime(value)
+        if isinstance(value, str):
+            return value
+        raise TypeError(f"Unsupported type for FormattedDateTime: {type(value)}")
+
+    def process_result_value(self, value, dialect):  # type: ignore[override]
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            return parse_db_datetime(value)
+        raise TypeError(f"Unexpected DB value type: {type(value)}")
+

--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -1,0 +1,12 @@
+from datetime import datetime, UTC
+
+from src.core.services.system_utilities import parse_search_datetime
+from src.shared.utils.date_format import format_db_datetime
+
+
+def test_parse_search_datetime_db_format():
+    dt = datetime(2023, 1, 2, 3, 4, 5, 123456, tzinfo=UTC)
+    text = format_db_datetime(dt)
+    parsed = parse_search_datetime(text)
+    assert parsed == dt
+


### PR DESCRIPTION
## Summary
- add new DB date utility with `FormattedDateTime` SQLAlchemy type
- switch model datetime columns to `FormattedDateTime`
- output database timestamps using `format_db_datetime`
- parse search datetimes using DB format if present
- test parsing of DB formatted timestamps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68864ceee8a8832bb47bc87a3a086b94