### PR TITLE
Make datetime columns timezone-aware

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -17,13 +17,13 @@ class Ticket(Base):
     Asset_ID = Column(Integer)
     Site_ID = Column(Integer)
     Ticket_Category_ID = Column(Integer)
-    Created_Date = Column(DateTime(timezone=False))
+    Created_Date = Column(DateTime(timezone=True))
     Assigned_Name = Column(String)
     Assigned_Email = Column(String)
     Severity_ID = Column(Integer)
     Assigned_Vendor_ID = Column(Integer)
-    Closed_Date = Column(DateTime(timezone=False))
-    LastModified = Column(DateTime(timezone=False))
+    Closed_Date = Column(DateTime(timezone=True))
+    LastModified = Column(DateTime(timezone=True))
     LastModfiedBy = Column(String)
     Resolution = Column(Text)
 
@@ -53,7 +53,7 @@ class TicketAttachment(Base):
     Ticket_ID = Column(Integer)
     Name = Column(String)
     WebURl = Column(String)
-    UploadDateTime = Column(DateTime(timezone=False))
+    UploadDateTime = Column(DateTime(timezone=True))
 
 
 class TicketMessage(Base):
@@ -63,7 +63,7 @@ class TicketMessage(Base):
     Message = Column(Text)
     SenderUserCode = Column(String)
     SenderUserName = Column(String)
-    DateTimeStamp = Column(DateTime(timezone=False))
+    DateTimeStamp = Column(DateTime(timezone=True))
 
 
 class Site(Base):
@@ -97,8 +97,8 @@ class OnCallShift(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     user_email = Column(String, nullable=False, index=True)
-    start_time = Column(DateTime(timezone=False), nullable=False)
-    end_time = Column(DateTime(timezone=False), nullable=False)
+    start_time = Column(DateTime(timezone=True), nullable=False)
+    end_time = Column(DateTime(timezone=True), nullable=False)
 
 
 class ViewBase(DeclarativeBase):
@@ -123,13 +123,13 @@ class VTicketMasterExpanded(ViewBase):
     Ticket_Category_ID = Column(Integer)
     Ticket_Category_Label = Column(String)
 
-    Created_Date = Column(DateTime(timezone=False))
+    Created_Date = Column(DateTime(timezone=True))
     Assigned_Name = Column(String)
     Assigned_Email = Column(String)
     Severity_ID = Column(Integer)
     Assigned_Vendor_ID = Column(Integer)
-    Closed_Date = Column(DateTime(timezone=False))
-    LastModified = Column(DateTime(timezone=False))
+    Closed_Date = Column(DateTime(timezone=True))
+    LastModified = Column(DateTime(timezone=True))
     LastModfiedBy = Column(String)
 
     Assigned_Vendor_Name = Column(String)


### PR DESCRIPTION
## Summary
- ensure all DateTime columns use timezone awareness
- keep CRUD operations using `datetime.now(timezone.utc)` for updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68864cf00b60832b9eaf8666ffb063eb