### PR TITLE
Fix duplicate lines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,10 +378,6 @@ JSON Schema. Payloads missing required fields or with incorrect types return a
 `422 Unprocessable Entity` response. The error payload also includes a
 `path` field that pinpoints which property failed validation.
 
-`422 Unprocessable Entity` response. The response also includes a `path`
-field indicating which property failed validation.
-
-
 `get_open_tickets` lists tickets filtered by status and age. Provide a
 number of `days` and optional `status` such as `open` or `closed`.
 


### PR DESCRIPTION
## Summary
- remove redundant explanation lines in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866f148c74832b906684cf6f2ccba1