### PR TITLE
Update timestamp examples to ISO format

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ LEFT JOIN Priority_Levels p ON p.ID = t.Severity_ID;
   dynamic query parameters to filter by any column in
   `V_Ticket_Master_Expanded` and a `sort` parameter for ordering.
 - `GET /ticket/search` - search tickets by subject or body. Query parameters:
-  `q` (required), `limit` (default `10`), optional `created_after`/`created_before`
+`q` (required), `limit` (default `10`), optional `created_after`/`created_before` (ISO-8601 datetimes with timezone)
   and other `V_Ticket_Master_Expanded` columns for filtering, plus
   `sort=oldest|newest` to control ordering. The legacy `/tickets/search` path
   remains available.
@@ -196,7 +196,7 @@ LEFT JOIN Priority_Levels p ON p.ID = t.Severity_ID;
 #### Searching for tickets
 
 Use `/ticket/search` for keyword queries. Provide `q` for the search text and
-optionally specify `limit`, `created_after`, `created_before` or any
+optionally specify `limit`, `created_after`, `created_before` (ISO-8601 datetimes with timezone) or any
 `V_Ticket_Master_Expanded` column to filter results. Sorting by
 `Created_Date` is controlled with `sort=oldest|newest`. A POST variant accepts a
 `TicketSearchRequest` JSON body containing the same fields.
@@ -204,7 +204,7 @@ optionally specify `limit`, `created_after`, `created_before` or any
 Example:
 
 ```bash
-curl "http://localhost:8000/ticket/search?q=printer&limit=5&created_after=2024-01-01"
+curl "http://localhost:8000/ticket/search?q=printer&limit=5&created_after=2024-01-01T00:00:00Z"
 ```
 
 ### Analytics Endpoints

--- a/aiagentprompt.txt
+++ b/aiagentprompt.txt
@@ -63,7 +63,7 @@ Use `search_tickets` for all queries:
   `search_tickets(priority="high", unassigned_only=true)`
 
 - Creation date range:  
-  `search_tickets(created_after="2024-01-01", created_before="2024-01-31")`
+  `search_tickets(created_after="2024-01-01T00:00:00Z", created_before="2024-01-31T00:00:00Z")`
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -73,7 +73,7 @@ JSON body matching the tool's schema. See
 - `POST /create_ticket` – Create a ticket. Example: see `TicketCreate` schema
 - `POST /update_ticket` – Update a ticket. Example: `{"ticket_id": 1, "updates": {}}`
 - `POST /add_ticket_message` – Add a message to a ticket.
-- `POST /search_tickets` – Search tickets. Example: `{"text": "printer", "created_after": "2024-01-01"}`. The deprecated
+- `POST /search_tickets` – Search tickets. Example: `{"text": "printer", "created_after": "2024-01-01T00:00:00Z"}`. The deprecated
   `/search_tickets_advanced` route was removed.
 - `POST /update_ticket` – Update a ticket or close/assign by modifying fields.
 - `POST /get_tickets_by_user` – Tickets for a user. Example: `{"identifier": "user@example.com"}`

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -94,8 +94,8 @@ Comprehensive ticket search with AI-optimized features and semantic filtering. S
 
 #### Time Filtering
 - `days` – Limit to tickets created in the last N days (default: 30, `0` returns all tickets). Ignored if `created_after` or `created_before` are provided
-- `created_after` – Only tickets created on or after this ISO datetime (ISO-8601)
-- `created_before` – Only tickets created on or before this ISO datetime (ISO-8601)
+- `created_after` – Only tickets created on or after this ISO-8601 datetime with timezone
+- `created_before` – Only tickets created on or before this ISO-8601 datetime with timezone
 
 #### Semantic Filters (AI-Friendly)
 - `status` – Ticket status filter. Allowed values: `"open"`, `"in_progress"`, `"resolved"`, `"closed"`
@@ -293,8 +293,8 @@ Run a detailed ticket search with advanced options.
 Parameters:
 - `text_search` – optional text to search for.
 - `search_fields` – list of fields to scan (default `["Subject", "Ticket_Body"]`).
-- `created_after` – only tickets created on or after this timestamp.
-- `created_before` – only tickets created on or before this timestamp.
+- `created_after` – only tickets created on or after this ISO-8601 timestamp with timezone.
+- `created_before` – only tickets created on or before this ISO-8601 timestamp with timezone.
 - `status_filter` – list of statuses to include.
 - `priority_filter` – list of priority IDs.
 - `assigned_to` – restrict to these assignee emails or names.

--- a/prompt.ini
+++ b/prompt.ini
@@ -150,7 +150,7 @@ Use these JSON-RPC tools before falling back to general knowledge.
 3. `create_ticket` – create a new ticket. Example: `{"Subject": "Issue", "Ticket_Contact_Name": "Alice", "Ticket_Contact_Email": "a@example.com"}`
 4. `update_ticket` – modify a ticket. Example: `{"ticket_id": 1, "updates": {"status": "closed"}}`
 5. `add_ticket_message` – post a follow-up message. Example: `{"ticket_id": 1, "message": "Investigating", "sender_name": "Support"}`
-6. `search_tickets` – keyword search. Example: `{"query": "printer", "created_after": "2024-01-01"}`
+6. `search_tickets` – keyword search. Example: `{"query": "printer", "created_after": "2024-01-01T00:00:00Z"}`
 7. `get_tickets_by_user` – tickets for a user. Example: `{"identifier": "user@example.com"}`
 8. `get_ticket_full_context` – ticket with history. Example: `{"ticket_id": 42}`
 9. `get_system_snapshot` – system overview. Example: `{}`


### PR DESCRIPTION
## Summary
- document API search filter examples using ISO-8601 timestamps with timezone
- clarify created_after/created_before parameter descriptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867de2bf94832baf9b5838971a2d76