### PR TITLE
Fix logging configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,6 @@ from src.shared.exceptions import DatabaseError, ErrorResponse, NotFoundError, V
 from limiter import limiter
 from src.mcp_server import Tool, create_enhanced_server
 from src.tool_list import TOOLS
-logging.basicConfig(level=logging.INFO)
 logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
 
 # Configure logger for this module


### PR DESCRIPTION
## Summary
- remove the duplicate top-level `basicConfig` call
- keep logger setup inside lifespan

## Testing
- `pytest tests/test_health.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68867de3a278832b891bb2381a1be855