### PR TITLE
Set default days for enhanced search

### DIFF
--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -93,7 +93,7 @@ Comprehensive ticket search with AI-optimized features and semantic filtering. S
 - `user_identifier` – Alias for `user` parameter (backward compatibility)
 
 #### Time Filtering
-- `days` – Limit to tickets created in the last N days (default: 30, `0` returns all tickets). Ignored if `created_after` or `created_before` are provided
+- `days` – Limit to tickets created in the last N days. Defaults to 30 when omitted or `null` (use `0` to return all tickets). Ignored if `created_after` or `created_before` are provided
 - `created_after` – Only tickets created on or after this ISO datetime (ISO-8601)
 - `created_before` – Only tickets created on or before this ISO datetime (ISO-8601)
 

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -399,6 +399,8 @@ async def _search_tickets_enhanced(
             text = query
         if user is None and user_identifier is not None:
             user = user_identifier
+        if days is None and created_after is None and created_before is None:
+            days = 30
 
         if created_after and not _ISO_DT_PATTERN.match(created_after):
             return JSONResponse(


### PR DESCRIPTION
## Summary
- default `days` to 30 in `_search_tickets_enhanced` when no date range specified
- clarify `days` behavior in MCP tools guide

## Testing
- `pytest tests/test_enhanced_search.py::test_enhanced_search_date_filtering -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867afdc3e8832ba231504a0f3a3a84