### PR TITLE
Handle milliseconds precision in ticket search

### DIFF
--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -8,5 +8,5 @@ def test_parse_search_datetime_db_format():
     dt = datetime(2023, 1, 2, 3, 4, 5, 123456, tzinfo=UTC)
     text = format_db_datetime(dt)
     parsed = parse_search_datetime(text)
-    assert parsed == dt
+    assert parsed == dt.replace(microsecond=123000)
 


### PR DESCRIPTION
## Summary
- normalize microsecond precision in `parse_search_datetime`
- adjust datetime parsing test
- validate search with string timestamps

## Testing
- `pytest tests/test_date_format.py::test_parse_search_datetime_db_format -q`
- `pytest tests/test_search.py::test_search_created_after_string_precision tests/test_search.py::test_search_created_after_invalid_string -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867de640ec832bb6b92792d911b34f