### PR TITLE
Normalize datetime inputs across services

### DIFF
--- a/src/core/services/enhanced_context.py
+++ b/src/core/services/enhanced_context.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import datetime, timezone, timedelta
+from .system_utilities import parse_search_datetime
 from typing import List, Dict, Any, Optional
 
 from sqlalchemy import select, func, and_, or_
@@ -669,6 +670,7 @@ class EnhancedContextManager:
     async def _get_overdue_tickets_summary(self) -> List[Dict[str, Any]]:
         """Get summary of overdue tickets."""
         cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+        cutoff = parse_search_datetime(cutoff)
 
         result = await self.db.execute(
             select(VTicketMasterExpanded)
@@ -707,6 +709,7 @@ class EnhancedContextManager:
     async def _get_recent_system_activity(self) -> List[Dict[str, Any]]:
         """Get recent system activity."""
         recent_cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+        recent_cutoff = parse_search_datetime(recent_cutoff)
 
         result = await self.db.execute(
             select(VTicketMasterExpanded)
@@ -730,6 +733,7 @@ class EnhancedContextManager:
     async def _calculate_system_health(self) -> Dict[str, Any]:
         """Calculate overall system health metrics."""
         last_24h = datetime.now(timezone.utc) - timedelta(hours=24)
+        last_24h = parse_search_datetime(last_24h)
 
         # Get recent ticket count
         recent_result = await self.db.execute(

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -353,17 +353,16 @@ class TicketManager:
                     stmt = stmt.filter(col == value)
 
         if created_after:
-            if isinstance(created_after, str):
-                created_after = parse_search_datetime(created_after)
-            stmt = stmt.filter(VTicketMasterExpanded.Created_Date >= created_after)
+            created_after_dt = parse_search_datetime(created_after)
+            stmt = stmt.filter(VTicketMasterExpanded.Created_Date >= created_after_dt)
         elif days is not None and days >= 0:
             cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+            cutoff = parse_search_datetime(cutoff)
             stmt = stmt.filter(VTicketMasterExpanded.Created_Date >= cutoff)
 
         if created_before:
-            if isinstance(created_before, str):
-                created_before = parse_search_datetime(created_before)
-            stmt = stmt.filter(VTicketMasterExpanded.Created_Date <= created_before)
+            created_before_dt = parse_search_datetime(created_before)
+            stmt = stmt.filter(VTicketMasterExpanded.Created_Date <= created_before_dt)
 
         order_list: list[Any] = []
         if sort:
@@ -504,6 +503,7 @@ class TicketManager:
 
         if days is not None and days > 0:
             cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+            cutoff = parse_search_datetime(cutoff)
             query = query.filter(VTicketMasterExpanded.Created_Date >= cutoff)
         query = query.order_by(VTicketMasterExpanded.Created_Date.desc())
         if limit:

--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -9,5 +9,11 @@ def test_parse_search_datetime_db_format():
     text = format_db_datetime(dt)
     parsed = parse_search_datetime(text)
 
-    assert parsed == dt
+    assert parsed == dt.replace(microsecond=123000)
+
+
+def test_parse_search_datetime_datetime_input():
+    dt = datetime(2024, 2, 3, 4, 5, 6, 987654, tzinfo=UTC)
+    parsed = parse_search_datetime(dt)
+    assert parsed.microsecond == 987000
 


### PR DESCRIPTION
## Summary
- allow `parse_search_datetime` to accept `datetime` values and normalize to milliseconds
- normalize datetimes in ticket search helpers and analytics queries
- ensure search filters always parse datetimes
- truncate datetimes when using days cutoff
- add tests for datetime normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68869b38de6c832b82d55b176534e255