### PR TITLE
Normalize datetime strings to millisecond precision

### DIFF
--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -9,8 +9,8 @@ def test_parse_search_datetime_db_format():
     text = format_db_datetime(dt)
     parsed = parse_search_datetime(text)
 
+    expected = dt.replace(microsecond=(dt.microsecond // 1000) * 1000)
 
-
-    assert parsed == dt
+    assert parsed == expected
 
 


### PR DESCRIPTION
## Summary
- drop microseconds beyond milliseconds in format_db_datetime
- allow parse_db_datetime to handle 3 or 6 digit precision
- update test to expect millisecond precision

## Testing
- `pytest tests/test_date_format.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d5369cb0832b82c5eb51c0ad2b37