### PR TITLE
Allow searching tickets without contact email

### DIFF
--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -114,6 +114,12 @@ class TicketIn(TicketBase):
 class TicketOut(TicketIn):
     Ticket_ID: int
 
+    @field_validator("Ticket_Contact_Email", mode="before")
+    def _clean_contact_email(cls, v):
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
+
     model_config = ConfigDict(
         str_max_length=None,
         from_attributes=True,

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -144,3 +144,15 @@ def test_ticket_expanded_from_orm_blank_assigned_email():
     assert obj.Closed_Date is None
     assert obj.LastModified is None
     assert obj.LastModfiedBy is None
+
+
+def test_ticket_expanded_from_orm_blank_contact_email():
+    ticket = VTicketMasterExpanded(
+        Ticket_ID=1,
+        Subject="s",
+        Ticket_Body="b",
+        Ticket_Contact_Name="n",
+        Ticket_Contact_Email="",
+    )
+    obj = TicketExpandedOut.model_validate(ticket)
+    assert obj.Ticket_Contact_Email is None


### PR DESCRIPTION
## Summary
- clean `Ticket_Contact_Email` when generating ticket output
- add regression test for blank contact email

## Testing
- `pytest tests/test_tickets_expanded.py::test_ticket_expanded_from_orm_blank_contact_email -q`
- `pytest -q` *(partial run; interrupted after ~59 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6886e34b3ab8832b995acfbe8f1d17d1