### PR TITLE
Fix closing ticket update

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -582,6 +582,9 @@ async def _update_ticket(ticket_id: int, updates: Dict[str, Any]) -> Dict[str, A
         async with db.SessionLocal() as db_session:
             # Apply semantic filters to updates
             applied_updates = apply_semantic_filters(updates)
+            status_value = applied_updates.get("Ticket_Status_ID")
+            if isinstance(status_value, list) and len(status_value) == 1:
+                applied_updates["Ticket_Status_ID"] = status_value[0]
             message = applied_updates.pop("message", None)
 
             # Closing logic
@@ -634,6 +637,9 @@ async def _bulk_update_tickets(
         async with db.SessionLocal() as db_session:
             mgr = TicketManager()
             applied_updates = apply_semantic_filters(updates)
+            status_value = applied_updates.get("Ticket_Status_ID")
+            if isinstance(status_value, list) and len(status_value) == 1:
+                applied_updates["Ticket_Status_ID"] = status_value[0]
             applied_updates["LastModified"] = datetime.now(timezone.utc)
             applied_updates["LastModfiedBy"] = "Gil AI"
             

--- a/tests/test_ticket_commits.py
+++ b/tests/test_ticket_commits.py
@@ -80,6 +80,7 @@ async def test_close_ticket_commits_once(monkeypatch):
     await _patched_session(monkeypatch, counter)
     result = await _update_ticket(tid, {"resolution": "done", "status": "closed"})
     assert result["status"] == "success"
+    assert result["data"]["Ticket_Status_ID"] == 3
     assert counter[0] == 1
 
 


### PR DESCRIPTION
## Summary
- fix applying `status` updates when closing tickets
- ensure commit test verifies status id integer

## Testing
- `pytest tests/test_ticket_commits.py::test_close_ticket_commits_once -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e810004c832b89eb8e127b245dfb