### PR TITLE
Support assignee_email/name semantic filters

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -127,8 +127,11 @@ def apply_semantic_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
                 else:
                     translated["Severity_ID"] = value
 
-        elif k == "assignee":
+        elif k in {"assignee", "assignee_email"}:
             translated["Assigned_Email"] = value
+
+        elif k == "assignee_name":
+            translated["Assigned_Name"] = value
 
         elif k == "category":
             translated["Ticket_Category_ID"] = value

--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -12,5 +12,3 @@ def test_parse_search_datetime_db_format():
     expected = dt.replace(microsecond=(dt.microsecond // 1000) * 1000)
 
     assert parsed == expected
-
-


### PR DESCRIPTION
## Summary
- map `assignee_email` and `assignee_name` into their DB columns
- ensure flake8 passes
- verify search and update flows translate assignee fields

## Testing
- `flake8`
- `pytest tests/test_semantic_filters.py::test_assignee_email_and_name_filters tests/test_ticket_commits.py::test_assign_ticket_semantic_fields -q`

------
https://chatgpt.com/codex/tasks/task_e_68881571506c832ba3367987ecc933ae