### PR TITLE
Fix post_message sender fields and external commit handling

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -535,13 +535,13 @@ class TicketManager:
         msg = TicketMessage(
             Ticket_ID=ticket_id,
             Message=message,
-            SenderUserCode="GilAI@heinzcorps.com",
-            SenderUserName="Gil AI",
+            SenderUserCode=sender_code,
+            SenderUserName=sender_name,
             DateTimeStamp=datetime.now(timezone.utc),
         )
         db.add(msg)
         try:
-            await db.commit()
+            await db.flush()
             await db.refresh(msg)
             logger.info("Posted message to ticket %s", ticket_id)
         except SQLAlchemyError as e:

--- a/tests/test_ticket_messages.py
+++ b/tests/test_ticket_messages.py
@@ -10,14 +10,14 @@ from src.shared.exceptions import DatabaseError
 async def test_post_message_db_error(monkeypatch):
     manager = TicketManager()
     async with SessionLocal() as db:
-        async def fail_commit():
+        async def fail_flush(*args, **kwargs):
             raise SQLAlchemyError("fail")
 
         async def dummy_rollback():
             pass
 
-        monkeypatch.setattr(db, "commit", fail_commit)
+        monkeypatch.setattr(db, "flush", fail_flush)
         monkeypatch.setattr(db, "rollback", dummy_rollback)
 
         with pytest.raises(DatabaseError):
-            await manager.post_message(db, 1, "oops", "u")
+            await manager.post_message(db, 1, "oops", "u", "u")


### PR DESCRIPTION
## Summary
- use passed sender information in `TicketManager.post_message`
- flush instead of committing inside `post_message`
- adjust `test_post_message_db_error` accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881571ebbc832bb85fea112c5547a5