### PR TITLE
Update closed ticket logic

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -587,8 +587,8 @@ async def _update_ticket(ticket_id: int, updates: Dict[str, Any]) -> Dict[str, A
                 applied_updates["Ticket_Status_ID"] = status_value[0]
             message = applied_updates.pop("message", None)
 
-            # Closing logic
-            if applied_updates.get("Ticket_Status_ID") == 4 and "Closed_Date" not in applied_updates:
+            # Closing logic - status ID 3 represents a closed ticket
+            if applied_updates.get("Ticket_Status_ID") == 3 and "Closed_Date" not in applied_updates:
                 applied_updates["Closed_Date"] = datetime.now(timezone.utc)
 
             # Assignment defaults

--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -12,5 +12,3 @@ def test_parse_search_datetime_db_format():
     expected = dt.replace(microsecond=(dt.microsecond // 1000) * 1000)
 
     assert parsed == expected
-
-

--- a/tests/test_ticket_commits.py
+++ b/tests/test_ticket_commits.py
@@ -102,3 +102,22 @@ async def test_assign_ticket_commits_once(monkeypatch):
     result = await _update_ticket(tid, {"assignee_email": "tech@example.com"})
     assert result["status"] == "success"
     assert counter[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_close_ticket_sets_closed_date():
+    async with db.SessionLocal() as setup:
+        ticket = {
+            "Subject": "D",
+            "Ticket_Body": "b",
+            "Ticket_Contact_Name": "u",
+            "Ticket_Contact_Email": "u@example.com",
+        }
+        res = await TicketManager().create_ticket(setup, ticket)
+        await setup.commit()
+        tid = res.data.Ticket_ID
+
+    result = await _update_ticket(tid, {"status": "closed"})
+    assert result["status"] == "success"
+    assert result["data"]["Ticket_Status_ID"] == 3
+    assert result["data"]["Closed_Date"] is not None


### PR DESCRIPTION
## Summary
- mark tickets as closed when status id 3 is used
- ensure update automatically sets `Closed_Date`
- cover closed date behavior in unit tests

## Testing
- `flake8`
- `mypy .` *(fails: Found 100 errors)*
- `pytest tests/test_ticket_commits.py::test_close_ticket_sets_closed_date -q`

------
https://chatgpt.com/codex/tasks/task_e_688815774760832ba14b8ab65e0147ea