### PR TITLE
Validate update ticket payloads

### DIFF
--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -223,3 +223,21 @@ async def test_bulk_update_tickets_error(client: AsyncClient):
     data = resp.json()
     assert "path" in data
     assert "payload" in data
+
+
+@pytest.mark.asyncio
+async def test_update_ticket_validation_error(client: AsyncClient):
+    tid = await _create_ticket(client, "Validate")
+    payload = {"ticket_id": tid, "updates": {"bad": 1}}
+    resp = await client.post("/update_ticket", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_tickets_validation_error(client: AsyncClient):
+    tid = await _create_ticket(client, "BulkBad")
+    payload = {"ticket_ids": [tid], "updates": {"bad": 1}}
+    resp = await client.post("/bulk_update_tickets", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"

--- a/tests/test_ticket_commits.py
+++ b/tests/test_ticket_commits.py
@@ -78,7 +78,7 @@ async def test_close_ticket_commits_once(monkeypatch):
 
     counter = [0]
     await _patched_session(monkeypatch, counter)
-    result = await _update_ticket(tid, {"resolution": "done", "status": "closed"})
+    result = await _update_ticket(tid, {"Resolution": "done", "status": "closed"})
     assert result["status"] == "success"
     assert result["data"]["Ticket_Status_ID"] == 3
     assert counter[0] == 1
@@ -99,6 +99,23 @@ async def test_assign_ticket_commits_once(monkeypatch):
 
     counter = [0]
     await _patched_session(monkeypatch, counter)
-    result = await _update_ticket(tid, {"assignee_email": "tech@example.com"})
+    result = await _update_ticket(tid, {"Assigned_Email": "tech@example.com"})
     assert result["status"] == "success"
     assert counter[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_update_ticket_invalid_payload(monkeypatch):
+    async with db.SessionLocal() as setup:
+        ticket = {
+            "Subject": "I",
+            "Ticket_Body": "b",
+            "Ticket_Contact_Name": "u",
+            "Ticket_Contact_Email": "u@example.com",
+        }
+        res = await TicketManager().create_ticket(setup, ticket)
+        await setup.commit()
+        tid = res.data.Ticket_ID
+
+    result = await _update_ticket(tid, {"bad_field": 1})
+    assert result["status"] == "error"


### PR DESCRIPTION
## Summary
- validate incoming ticket update data in `_update_ticket` and `_bulk_update_tickets`
- return error responses when validation fails
- adjust ticket commit tests for new validation
- add tests for invalid update payloads via MCP tool endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881577e740832b8660b8cf4f5a688a