### PR TITLE
Fix ticket closure status ID

### DIFF
--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -62,7 +62,7 @@ curl -X POST http://localhost:8000/update_ticket \
 Example – close a ticket:
 ```bash
 curl -X POST http://localhost:8000/update_ticket \
-  -d '{"ticket_id": 5, "updates": {"Ticket_Status_ID": 4, "Resolution": "Replaced toner"}}'
+  -d '{"ticket_id": 5, "updates": {"Ticket_Status_ID": 3, "Resolution": "Replaced toner"}}'
 ```
 
 


### PR DESCRIPTION
## Summary
- change close ticket example to use `Ticket_Status_ID: 3`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882aed0ddc832b90cfd1eb3b96e664