### PR TITLE
Fix update ticket not found messaging

### DIFF
--- a/src/api/v1/tickets.py
+++ b/src/api/v1/tickets.py
@@ -264,10 +264,12 @@ async def update_ticket_endpoint(
     updates: TicketUpdate,
     db: AsyncSession = Depends(get_db_with_commit),
 ) -> TicketOut:
-    updated = await TicketManager().update_ticket(db, ticket_id, updates.model_dump(exclude_unset=True))
+    updated = await TicketManager().update_ticket(
+        db, ticket_id, updates.model_dump(exclude_unset=True)
+    )
     if not updated:
-        logger.warning("Ticket %s not found or no changes applied", ticket_id)
-        raise HTTPException(status_code=404, detail="Ticket not found or no changes")
+        logger.warning("Ticket %s not found", ticket_id)
+        raise HTTPException(status_code=404, detail="Ticket not found")
     return TicketOut.model_validate(updated)
 
 
@@ -285,8 +287,8 @@ async def update_ticket_json(
 ) -> TicketExpandedOut:
     updated = await TicketManager().update_ticket(db, ticket_id, updates)
     if not updated:
-        logger.warning("Ticket %s not found or no changes applied", ticket_id)
-        raise HTTPException(status_code=404, detail="Ticket not found or no changes")
+        logger.warning("Ticket %s not found", ticket_id)
+        raise HTTPException(status_code=404, detail="Ticket not found")
     ticket = await TicketManager().get_ticket(db, ticket_id)
     return TicketExpandedOut.model_validate(ticket)
 


### PR DESCRIPTION
## Summary
- clarify log message when ticket updates fail because the ticket doesn't exist

## Testing
- `pytest tests/test_routes.py::test_get_ticket_not_found -q`


------
https://chatgpt.com/codex/tasks/task_e_68882af079e4832b8685b7e324244f77