### PR TITLE
Validate ticket updates

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -587,6 +587,9 @@ async def _update_ticket(ticket_id: int, updates: Dict[str, Any]) -> Dict[str, A
                 applied_updates["Ticket_Status_ID"] = status_value[0]
             message = applied_updates.pop("message", None)
 
+            if not applied_updates:
+                return {"status": "error", "error": "No updates provided"}
+
             # Closing logic - Status 3 is Closed, not Status 4
             if applied_updates.get("Ticket_Status_ID") == 3 and "Closed_Date" not in applied_updates:
                 applied_updates["Closed_Date"] = datetime.now(timezone.utc)

--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr, Field, ConfigDict, field_validator
+from pydantic import BaseModel, EmailStr, Field, ConfigDict, field_validator, model_validator
 from typing import Annotated
 from typing import Optional
 from datetime import datetime
@@ -78,6 +78,12 @@ class TicketUpdate(BaseModel):
     Severity_ID: Optional[int] = None
     Assigned_Vendor_ID: Optional[int] = None
     Resolution: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _ensure_fields_present(cls, values: "TicketUpdate") -> "TicketUpdate":
+        if not values.model_fields_set:
+            raise ValueError("At least one field must be supplied")
+        return values
 
     model_config = ConfigDict(
         extra="forbid",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -157,6 +157,16 @@ async def test_update_ticket_invalid_field(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_update_ticket_empty_payload(client: AsyncClient):
+    resp = await _create_ticket(client)
+    assert resp.status_code == 201
+    tid = resp.json()["Ticket_ID"]
+
+    resp = await client.put(f"/ticket/{tid}", json={})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_asset_vendor_site_routes(client: AsyncClient):
     asset = await _add_asset()
     vendor = await _add_vendor()

--- a/tests/test_ticket_commits.py
+++ b/tests/test_ticket_commits.py
@@ -128,3 +128,21 @@ async def test_assign_ticket_semantic_fields(monkeypatch):
     data = result["data"]
     assert data["Assigned_Email"] == "tech@example.com"
     assert data["Assigned_Name"] == "Tech"
+
+
+@pytest.mark.asyncio
+async def test_update_ticket_empty_updates(monkeypatch):
+    async with db.SessionLocal() as setup:
+        ticket = {
+            "Subject": "E1",
+            "Ticket_Body": "b",
+            "Ticket_Contact_Name": "u",
+            "Ticket_Contact_Email": "u@example.com",
+        }
+        res = await TicketManager().create_ticket(setup, ticket)
+        await setup.commit()
+        tid = res.data.Ticket_ID
+
+    result = await _update_ticket(tid, {})
+    assert result["status"] == "error"
+    assert "No updates" in result["error"]


### PR DESCRIPTION
## Summary
- enforce that TicketUpdate has at least one field
- refuse empty update payloads in `_update_ticket`
- test empty update payload via REST endpoint
- test empty updates when using the helper

## Testing
- `pytest tests/test_routes.py::test_update_ticket_empty_payload -q`
- `pytest tests/test_ticket_commits.py::test_update_ticket_empty_updates -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882aeea7f4832bbc71679ac27f6d2f