### PR TITLE
Handle ambiguous status in update_ticket

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -583,8 +583,14 @@ async def _update_ticket(ticket_id: int, updates: Dict[str, Any]) -> Dict[str, A
             # Apply semantic filters to updates
             applied_updates = apply_semantic_filters(updates)
             status_value = applied_updates.get("Ticket_Status_ID")
-            if isinstance(status_value, list) and len(status_value) == 1:
-                applied_updates["Ticket_Status_ID"] = status_value[0]
+            if isinstance(status_value, list):
+                if len(status_value) == 1:
+                    applied_updates["Ticket_Status_ID"] = status_value[0]
+                else:
+                    return {
+                        "status": "error",
+                        "error": "Ambiguous status values are not allowed",
+                    }
             message = applied_updates.pop("message", None)
 
             # Closing logic - Status 3 is Closed, not Status 4

--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -223,3 +223,14 @@ async def test_bulk_update_tickets_error(client: AsyncClient):
     data = resp.json()
     assert "path" in data
     assert "payload" in data
+
+
+@pytest.mark.asyncio
+async def test_update_ticket_open_status_error(client: AsyncClient):
+    tid = await _create_ticket(client, "Ambiguous")
+    payload = {"ticket_id": tid, "updates": {"status": "open"}}
+    resp = await client.post("/update_ticket", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "error"
+    assert "ambiguous" in data["error"].lower()


### PR DESCRIPTION
## Summary
- validate `Ticket_Status_ID` in `_update_ticket` to ensure only one status value is applied
- check for this error condition via new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882aedd570832b8918a79a755c9c82