### PR TITLE
Fix duplicate constant

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -57,7 +57,6 @@ _STATUS_MAP = {
 }
 
 _OPEN_STATE_IDS = [1, 2, 4, 5, 6, 8]
-_CLOSED_STATE_IDS = [3]
 
 _PRIORITY_MAP = {
     "critical": "Critical",


### PR DESCRIPTION
## Summary
- remove redundant `_CLOSED_STATE_IDS` constant assignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688832e81efc832bae50788f583a3baa