### PR TITLE
Add modified_by parameter for ticket updates

### DIFF
--- a/src/api/v1/tickets.py
+++ b/src/api/v1/tickets.py
@@ -265,7 +265,10 @@ async def update_ticket_endpoint(
     db: AsyncSession = Depends(get_db_with_commit),
 ) -> TicketOut:
     updated = await TicketManager().update_ticket(
-        db, ticket_id, updates.model_dump(exclude_unset=True)
+        db,
+        ticket_id,
+        updates.model_dump(exclude_unset=True),
+        modified_by="Gil AI",
     )
     if not updated:
         logger.warning("Ticket %s not found", ticket_id)
@@ -285,7 +288,9 @@ async def update_ticket_json(
     updates: TicketUpdate = Body(...),
     db: AsyncSession = Depends(get_db_with_commit),
 ) -> TicketExpandedOut:
-    updated = await TicketManager().update_ticket(db, ticket_id, updates)
+    updated = await TicketManager().update_ticket(
+        db, ticket_id, updates, modified_by="Gil AI"
+    )
     if not updated:
         logger.warning("Ticket %s not found", ticket_id)
         raise HTTPException(status_code=404, detail="Ticket not found")

--- a/src/core/services/enhanced_operations.py
+++ b/src/core/services/enhanced_operations.py
@@ -355,7 +355,12 @@ class EnhancedOperationsManager:
     async def _execute_ticket_update(self, ticket_id: int, parameters: Dict[str, Any]) -> Dict[str, Any]:
         """Execute ticket update."""
         update_data = TicketUpdate(**parameters)
-        updated_ticket = await self.ticket_manager.update_ticket(self.db, ticket_id, update_data)
+        updated_ticket = await self.ticket_manager.update_ticket(
+            self.db,
+            ticket_id,
+            update_data,
+            modified_by="Gil AI",
+        )
         return {"updated_ticket_id": ticket_id, "success": True}
 
     async def _execute_ticket_assignment(self, ticket_id: int, parameters: Dict[str, Any]) -> Dict[str, Any]:
@@ -368,7 +373,12 @@ class EnhancedOperationsManager:
             Assigned_Name=assignee_name
         )
 
-        updated_ticket = await self.ticket_manager.update_ticket(self.db, ticket_id, update_data)
+        updated_ticket = await self.ticket_manager.update_ticket(
+            self.db,
+            ticket_id,
+            update_data,
+            modified_by="Gil AI",
+        )
         return {"assigned_to": assignee_email, "success": True}
 
     async def _execute_ticket_closure(self, ticket_id: int, parameters: Dict[str, Any]) -> Dict[str, Any]:
@@ -381,7 +391,12 @@ class EnhancedOperationsManager:
             Resolution=resolution
         )
 
-        updated_ticket = await self.ticket_manager.update_ticket(self.db, ticket_id, update_data)
+        updated_ticket = await self.ticket_manager.update_ticket(
+            self.db,
+            ticket_id,
+            update_data,
+            modified_by="Gil AI",
+        )
         return {"closed": True, "resolution": resolution}
 
     # Helper methods

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -174,7 +174,12 @@ class TicketManager:
             return OperationResult(success=False, error=f"Failed to create ticket: {e}")
 
     async def update_ticket(
-        self, db: AsyncSession, ticket_id: int, updates: BaseModel | Dict[str, Any]
+        self,
+        db: AsyncSession,
+        ticket_id: int,
+        updates: BaseModel | Dict[str, Any],
+        *,
+        modified_by: str = "Gil AI",
     ) -> Ticket | None:
         if isinstance(updates, BaseModel):
             updates = updates.model_dump(exclude_unset=True)
@@ -186,7 +191,7 @@ class TicketManager:
                 setattr(ticket, key, value)
         # Record when the ticket was last modified
         ticket.LastModified = datetime.now(timezone.utc)
-        ticket.LastModfiedBy = "Gil AI"
+        ticket.LastModfiedBy = modified_by
         try:
             await db.flush()
             await db.refresh(ticket)

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -605,7 +605,12 @@ async def _update_ticket(ticket_id: int, updates: Dict[str, Any]) -> Dict[str, A
                 applied_updates["Assigned_Name"] = applied_updates.get("Assigned_Email")
 
             try:
-                updated = await TicketManager().update_ticket(db_session, ticket_id, applied_updates)
+                updated = await TicketManager().update_ticket(
+                    db_session,
+                    ticket_id,
+                    applied_updates,
+                    modified_by="Gil AI",
+                )
                 if not updated:
                     return {"status": "error", "error": f"Ticket {ticket_id} not found"}
 
@@ -658,7 +663,12 @@ async def _bulk_update_tickets(
             try:
                 for tid in ticket_ids:
                     try:
-                        result = await mgr.update_ticket(db_session, tid, applied_updates)
+                        result = await mgr.update_ticket(
+                            db_session,
+                            tid,
+                            applied_updates,
+                            modified_by="Gil AI",
+                        )
                         if result:
                             ticket = await mgr.get_ticket(db_session, tid)
                             updated.append(_format_ticket_by_level(ticket))


### PR DESCRIPTION
## Summary
- add `modified_by` optional argument to `update_ticket`
- propagate modifier to API and internal ticket update helpers
- use the modifier in enhanced operations

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888330168d4832bb68111d5594db327