### PR TITLE
Improve ambiguous status update message

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -587,9 +587,15 @@ async def _update_ticket(ticket_id: int, updates: Dict[str, Any]) -> Dict[str, A
                 if len(status_value) == 1:
                     applied_updates["Ticket_Status_ID"] = status_value[0]
                 else:
+                    provided = (
+                        updates.get("status")
+                        or updates.get("ticket_status")
+                        or updates.get("Ticket_Status_ID")
+                    )
+                    opts = ", ".join(str(v) for v in status_value)
                     return {
                         "status": "error",
-                        "error": "Ambiguous status values are not allowed",
+                        "error": f"Ambiguous status value '{provided}'. Valid options: {opts}",
                     }
             message = applied_updates.pop("message", None)
 

--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -233,4 +233,7 @@ async def test_update_ticket_open_status_error(client: AsyncClient):
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "error"
-    assert "ambiguous" in data["error"].lower()
+    err = data["error"].lower()
+    assert "ambiguous" in err
+    assert "open" in err
+    assert "valid options" in err


### PR DESCRIPTION
## Summary
- clarify ambiguous status error message in `_update_ticket`
- test new error message wording

## Testing
- `pytest tests/test_additional_tools.py::test_update_ticket_open_status_error -q`

------
https://chatgpt.com/codex/tasks/task_e_688832ed0a04832b8fe61fd2d8e219e7