### PR TITLE
Fix duplicate Version column

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -28,7 +28,6 @@ class Ticket(Base):
     Closed_Date = Column(FormattedDateTime())
     LastModified = Column(FormattedDateTime())
     LastModfiedBy = Column(String)
-    Version = Column(Integer, default=0)
     Resolution = Column(Text)
 
 
@@ -140,7 +139,6 @@ class VTicketMasterExpanded(ViewBase):
     LastModified = Column(FormattedDateTime())
 
     LastModfiedBy = Column(String)
-    Version = Column(Integer)
 
     Assigned_Vendor_Name = Column(String)
     Resolution = Column(Text)

--- a/src/core/repositories/sql.py
+++ b/src/core/repositories/sql.py
@@ -22,7 +22,6 @@ SELECT t.Ticket_ID,
        t.Closed_Date,
        t.LastModified,
        t.LastModfiedBy,
-       t.Version,
        v.Name AS Assigned_Vendor_Name,
        t.Resolution,
        p.Level AS Priority_Level


### PR DESCRIPTION
## Summary
- keep a single Version column on Ticket
- drop redundant Version field from expanded view
- remove extra column reference in SQL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688abe7932e8832badb9857aba4fabed