### PR TITLE
Update tests for ticket version field

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -58,6 +58,8 @@ async def test_create_and_get_ticket(client: AsyncClient):
     resp = await _create_ticket(client)
     assert resp.status_code == 201
     created = resp.json()
+    assert "Version" in created
+    assert created["Version"] == 1
     tid = created["Ticket_ID"]
 
     list_resp = await client.get("/tickets/expanded")
@@ -75,6 +77,7 @@ async def test_create_and_get_ticket(client: AsyncClient):
     ticket_json = get_resp.json()
     assert ticket_json["Subject"] == "API test"
     assert "status_label" in ticket_json
+    assert ticket_json["Version"] == 1
 
 
 @pytest.mark.asyncio
@@ -90,6 +93,7 @@ async def test_update_ticket(client: AsyncClient):
     assert resp.status_code == 201
     ticket = resp.json()
     tid = ticket["Ticket_ID"]
+    assert ticket["Version"] == 1
 
     # LastModified should be None right after creation
     get_resp = await client.get(f"/ticket/{tid}")
@@ -100,11 +104,13 @@ async def test_update_ticket(client: AsyncClient):
     resp = await client.put(f"/ticket/{tid}", json={"Subject": "Updated"})
     assert resp.status_code == 200
     assert resp.json()["Subject"] == "Updated"
+    assert resp.json()["Version"] == 2
 
     get_resp = await client.get(f"/ticket/{tid}")
     assert get_resp.status_code == 200
     assert get_resp.json()["LastModified"] is not None
     assert get_resp.json()["LastModfiedBy"] == "Gil AI"
+    assert get_resp.json()["Version"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -47,6 +47,7 @@ async def test_tickets_expanded_endpoint(client: AsyncClient):
     assert data["total"] == 1
     item = data["items"][0]
     assert item["Ticket_ID"] == tid
+    assert item["Version"] == 1
     assert "Ticket_Status_Label" in item
     assert "Ticket_Category_Label" in item
     assert "Site_Label" in item
@@ -65,6 +66,7 @@ def test_ticket_expanded_schema():
         "Subject": "s",
         "Ticket_Status_Label": "Open",
         "Site_ID": 1,
+        "Version": 1,
     }
     obj = TicketExpandedOut(**data)
     assert obj.Ticket_ID == 1
@@ -72,6 +74,7 @@ def test_ticket_expanded_schema():
     assert obj.Closed_Date is None
     assert obj.LastModified is None
     assert obj.LastModfiedBy is None
+    assert obj.Version == 1
 
 
 @pytest.mark.asyncio
@@ -138,6 +141,7 @@ def test_ticket_expanded_from_orm_blank_assigned_email():
         Ticket_Contact_Name="n",
         Ticket_Contact_Email="c@example.com",
         Assigned_Email="",
+        Version=1,
     )
     obj = TicketExpandedOut.model_validate(ticket)
     assert obj.Assigned_Email is None
@@ -153,6 +157,7 @@ def test_ticket_expanded_from_orm_blank_contact_email():
         Ticket_Body="b",
         Ticket_Contact_Name="n",
         Ticket_Contact_Email="",
+        Version=1,
     )
     obj = TicketExpandedOut.model_validate(ticket)
     assert obj.Ticket_Contact_Email is None


### PR DESCRIPTION
## Summary
- update ticket route tests for new Version column
- verify version data in tickets expanded view tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac04db730832ba3e3249d26aee3f6