### PR TITLE
Update docs for ticket columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,30 @@ Both the `Ticket_Body` and `Resolution` columns are defined using the SQL
 `TEXT` (or `nvarchar(max)`) type so lengthy content can be stored without
 truncation. Ensure any custom migrations preserve this unrestricted text type.
 
+### Tickets_Master columns
+
+The `Tickets_Master` table stores the primary ticket data. Columns include:
+
+- `Ticket_ID`
+- `Subject`
+- `Ticket_Body`
+- `Ticket_Status_ID`
+- `Ticket_Contact_Name`
+- `Ticket_Contact_Email`
+- `Asset_ID`
+- `Site_ID`
+- `Ticket_Category_ID`
+- `Version`
+- `Created_Date`
+- `Assigned_Name`
+- `Assigned_Email`
+- `Severity_ID`
+- `Assigned_Vendor_ID`
+- `Closed_Date`
+- `LastModified`
+- `LastModfiedBy`
+- `Resolution`
+
 ### V_Ticket_Master_Expanded
 
 The API uses the `V_Ticket_Master_Expanded` view to join tickets with
@@ -148,6 +172,7 @@ SELECT t.Ticket_ID,
        s.Label AS Site_Label,
        t.Ticket_Category_ID,
        c.Label AS Ticket_Category_Label,
+       t.Version,
        t.Created_Date,
        t.Assigned_Name,
        t.Assigned_Email,
@@ -156,6 +181,7 @@ SELECT t.Ticket_ID,
        t.Closed_Date,
        t.LastModified,
        t.LastModfiedBy,
+       t.Version,
        v.Name AS Assigned_Vendor_Name,
        t.Resolution,
        p.Level AS Priority_Level

--- a/docs/API.md
+++ b/docs/API.md
@@ -95,6 +95,29 @@ Endpoints under `/mcp-tools` are also exposed as HTTP routes with the same names
 
 ## Ticket Schemas
 
+### Tickets_Master columns
+The underlying `Tickets_Master` table contains the following fields:
+
+- `Ticket_ID`
+- `Subject`
+- `Ticket_Body`
+- `Ticket_Status_ID`
+- `Ticket_Contact_Name`
+- `Ticket_Contact_Email`
+- `Asset_ID`
+- `Site_ID`
+- `Ticket_Category_ID`
+- `Version`
+- `Created_Date`
+- `Assigned_Name`
+- `Assigned_Email`
+- `Severity_ID`
+- `Assigned_Vendor_ID`
+- `Closed_Date`
+- `LastModified`
+- `LastModfiedBy`
+- `Resolution`
+
 ### TicketCreate
 
 Use this schema when creating a ticket. The server automatically populates `Created_Date` so it should be omitted from the payload. All other fields match the database columns and most are optional. If `Ticket_Status_ID` is not supplied it defaults to `1` (Open).

--- a/tests/test_ticket_version.py
+++ b/tests/test_ticket_version.py
@@ -3,16 +3,19 @@ import pytest_asyncio
 from datetime import datetime, UTC
 from httpx import AsyncClient, ASGITransport
 
+
 from main import app
 from src.core.services.ticket_management import TicketManager
 from src.core.repositories.models import Ticket
 from src.infrastructure.database import SessionLocal
+
 
 @pytest_asyncio.fixture
 async def client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
+
 
 @pytest.mark.asyncio
 async def test_version_increments_on_update():
@@ -34,6 +37,7 @@ async def test_version_increments_on_update():
         updated = await TicketManager().get_ticket(db, tid)
         assert getattr(updated, "Version", None) == (orig_version or 0) + 1
 
+
 @pytest.mark.asyncio
 async def test_version_unchanged_when_no_real_update():
     async with SessionLocal() as db:
@@ -54,6 +58,7 @@ async def test_version_unchanged_when_no_real_update():
         await db.commit()
         unchanged = await TicketManager().get_ticket(db, tid)
         assert getattr(unchanged, "Version", None) == orig_version
+
 
 @pytest.mark.asyncio
 async def test_assigned_name_not_email_after_mcp_update(client: AsyncClient):


### PR DESCRIPTION
## Summary
- document all fields on `Tickets_Master`
- revise view snippet to include `Version`
- sync API docs with latest ticket columns

## Testing
- `bash scripts/setup-tests.sh`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac04f1f6c832b9770672d51e1938e