### PR TITLE
docs: expand create_ticket example

### DIFF
--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -26,7 +26,7 @@ Create a new ticket. Parameters match the `TicketCreate` schema described in [AP
 Example:
 ```bash
 curl -X POST http://localhost:8000/create_ticket \
-  -d '{"Subject": "Printer issue", "Ticket_Contact_Name": "Alice"}'
+  -d '{"Subject": "Printer issue", "Ticket_Body": "Cannot connect to printer", "Ticket_Contact_Name": "Alice", "Ticket_Contact_Email": "alice@example.com"}'
 ```
 
 ## update_ticket


### PR DESCRIPTION
## Summary
- include `Ticket_Body` and `Ticket_Contact_Email` in `create_ticket` example

## Testing
- `python - <<'PY'` (json.loads) 
- `pytest -q` *(fails: 6 failed, 54 passed)*
- `flake8 docs/MCP_TOOLS_GUIDE.md` *(fails: SyntaxError: invalid character '–')*


------
https://chatgpt.com/codex/tasks/task_e_6890f01b2184832ba1e8efbe9c5c4c5a