### PR TITLE
docs: clarify site-specific ticket access requirements

### DIFF
--- a/DEXA_v3.2_Agent_Guide.md
+++ b/DEXA_v3.2_Agent_Guide.md
@@ -26,6 +26,13 @@
 | 6  | Corporate         | 1000    |
 | 7  | Heinz Retail Est. | 2000    |
 
+## 🛡️ Site Access Rules
+
+- Non-admin callers must include a `site_id` when querying or modifying tickets.
+- The system derives the caller's site from the prompt, allowing them to create
+  or update tickets only for that location.
+- Cross-site attempts are rejected unless the caller is an administrator.
+
 ---
 
 ## 🧠 DATA ARCHITECTURE

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ uvicorn main:app --reload
 ## API Documentation
 
 Detailed endpoint descriptions are provided in [docs/API.md](docs/API.md).
+
+## Site Access Requirements
+
+Non-admin callers must supply a `site_id` when querying or modifying tickets through the API or MCP tools. The system derives each user's site from the prompt and rejects attempts to create or update tickets for other locations. Only administrators may omit the `site_id` or work across multiple sites.
 ## Running tests
 
 Install the dependencies from `requirements.txt` and the package itself before

--- a/alembic/versions/a3c896922b31_add_missing_ticket_columns.py
+++ b/alembic/versions/a3c896922b31_add_missing_ticket_columns.py
@@ -44,4 +44,3 @@ def downgrade() -> None:
     op.drop_column('Tickets_Master', 'MetaData')
     op.drop_column('Tickets_Master', 'Watchers')
     op.drop_column('Tickets_Master', 'Most_Recent_Service_Scheduled_ID')
-

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,13 @@
 
 This document lists the available HTTP endpoints provided by the HelpDesk service. Each endpoint includes a brief description and the HTTP method used.
 
+## Site Access Requirements
+
+Non-admin callers must include a `site_id` whenever searching for or modifying
+tickets. The application infers a user's site from the conversation context and
+rejects attempts to create or update tickets for other locations. Only
+administrators may omit the `site_id` or act across multiple sites.
+
 ## Ticket Endpoints
 
 All ticket operations are prefixed with `/ticket` (singular). The old `/tickets`

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -2,6 +2,13 @@
 
 This document describes the JSON-RPC tools exposed by the MCP server. Each section lists the purpose of the tool, the parameters expected in the request body and an example invocation.
 
+## Site Access Requirements
+
+Non-admin callers must include a `site_id` when using any ticket query or
+modification tool. The server infers a user's site from the prompt context and
+rejects attempts to create or update tickets for other sites. Only
+administrators may omit the `site_id` or work across multiple sites.
+
 ## get_ticket
 Fetch a ticket by ID.
 


### PR DESCRIPTION
## Summary
- document required `site_id` for non-admin ticket queries and updates
- explain that users may only manage tickets for their own site
- fix trailing newline in migration to satisfy flake8

## Testing
- `flake8`
- `pytest tests/test_health.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689116f6c4ac832bb6e9bb62c8d80aaa