### PR TITLE
Limit ticket actions to user's site in prompts

### DIFF
--- a/aiagentprompt.txt
+++ b/aiagentprompt.txt
@@ -8,9 +8,10 @@
 ## 🚨 CRITICAL RULES  
 - **NEVER fabricate** ticket numbers, details, or resolutions.  
 - **ALWAYS use tools first** — no exceptions.  
-- **ONLY cite real data** from tool responses.  
-- **If no results are found**, explicitly state so.  
+- **ONLY cite real data** from tool responses.
+- **If no results are found**, explicitly state so.
 - **NOTE:** The column named `Priority` in conversations maps to `Severity_ID` in the SQL database (`ticket_master`).
+- The user's site is defined in this prompt; only create or update tickets for that site unless the user has admin privileges.
 
 ---
 

--- a/prompt.ini
+++ b/prompt.ini
@@ -12,11 +12,12 @@ Current Time: {{
 3️⃣ TRANSPARENCY: Always cite whether using tool data or general knowledge  
 
 ━━━━━━━━ CORE PRINCIPLES ━━━━━━━━  
-- Evidence-based – Prioritize historical ticket data  
-- Intelligent fallback – Use IT expertise when no matches found  
-- Transparent sourcing – Clearly indicate data vs knowledge  
-- Comprehensive search – Multiple search strategies before fallback  
-- Continuous learning – Suggest creating tickets for new issues  
+- Evidence-based – Prioritize historical ticket data
+- Intelligent fallback – Use IT expertise when no matches found
+- Transparent sourcing – Clearly indicate data vs knowledge
+- Comprehensive search – Multiple search strategies before fallback
+- Continuous learning – Suggest creating tickets for new issues
+- Site-specific access – The user's site is defined in this prompt; only create or update tickets for that site unless the user has admin privileges.
 
 ━━━━━━━━ SEARCH & RESPONSE WORKFLOW ━━━━━━━━  
 


### PR DESCRIPTION
## Summary
- Clarify that a user's site is predetermined and restrict ticket creation or updates to that site unless the user has admin privileges in `aiagentprompt.txt` and `prompt.ini`.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689116f7e95c832b924d0f2f6e08a30c