### PR TITLE
docs: standardize ticket API examples

### DIFF
--- a/DEXA_v3.2_Agent_Guide.md
+++ b/DEXA_v3.2_Agent_Guide.md
@@ -77,8 +77,8 @@ Use `search_tickets` for all queries:
 - Priority & assignment:  
   `search_tickets(priority="high", unassigned_only=true)`
 
-- Creation date range:  
-  `search_tickets(created_after="2024-01-01", created_before="2024-01-31")`
+- Creation date range:
+  `search_tickets(created_after="2024-01-01T00:00:00Z", created_before="2024-01-31T00:00:00Z")`
 
 ---
 
@@ -124,12 +124,12 @@ search_tickets(
   priority="high",
   site_id=1,
   assigned_to="tech@email.com",
-  unassigned_only=True,
+  unassigned_only=true,
   filters={ "Asset_ID": 42 },
   limit=10,
   sort=["-Created_Date"],
-  include_relevance_score=True,
-  include_highlights=True
+  include_relevance_score=true,
+  include_highlights=true
 )
 ```
 
@@ -167,10 +167,10 @@ update_ticket(
     "status": "closed",
     "resolution": "Resolved with...",
     "priority": "high",
-    "assignee": "tech@email.com",
-    "subject": "Updated",
+    "assignee_email": "tech@email.com",
+    "Subject": "Updated",
     "Site_ID": 2,
-    "category": 3,
+    "Ticket_Category_ID": 3,
     "message": "Optional note"
   }
 )
@@ -180,7 +180,7 @@ update_ticket(
 ```python
 bulk_update_tickets(
   ticket_ids=[123, 456],
-  updates={"assignee": "tech@email.com"}
+  updates={"assignee_email": "tech@email.com"}
 )
 ```
 
@@ -306,7 +306,7 @@ analytics = get_analytics(type="ticket_counts")
 ```python
 urgent = search_tickets(priority="critical", unassigned_only=true)
 workload = get_analytics(type="workload")
-bulk_update_tickets(ticket_ids=[...], updates={"assignee": "senior@tech.com"})
+bulk_update_tickets(ticket_ids=[...], updates={"assignee_email": "senior@tech.com"})
 ```
 
 ### 3. SLA Breach Prevention

--- a/aiagentprompt.txt
+++ b/aiagentprompt.txt
@@ -118,12 +118,12 @@ search_tickets(
   priority="high",
   site_id=1,
   assigned_to="tech@email.com",
-  unassigned_only=True,
+  unassigned_only=true,
   filters={ "Asset_ID": 42 },
   limit=10,
   sort=["-Created_Date"],
-  include_relevance_score=True,
-  include_highlights=True
+  include_relevance_score=true,
+  include_highlights=true
 )
 ```
 
@@ -161,10 +161,10 @@ update_ticket(
     "status": "closed",
     "resolution": "Resolved with...",
     "priority": "high",
-    "assignee": "tech@email.com",
-    "subject": "Updated",
+    "assignee_email": "tech@email.com",
+    "Subject": "Updated",
     "Site_ID": 2,
-    "category": 3,
+    "Ticket_Category_ID": 3,
     "message": "Optional note"
   }
 )
@@ -174,7 +174,7 @@ update_ticket(
 ```python
 bulk_update_tickets(
   ticket_ids=[123, 456],
-  updates={"assignee": "tech@email.com"}
+  updates={"assignee_email": "tech@email.com"}
 )
 ```
 
@@ -300,7 +300,7 @@ analytics = get_analytics(type="ticket_counts")
 ```python
 urgent = search_tickets(priority="critical", unassigned_only=true)
 workload = get_analytics(type="workload")
-bulk_update_tickets(ticket_ids=[...], updates={"assignee": "senior@tech.com"})
+bulk_update_tickets(ticket_ids=[...], updates={"assignee_email": "senior@tech.com"})
 ```
 
 ### 3. SLA Breach Prevention

--- a/prompt.ini
+++ b/prompt.ini
@@ -173,14 +173,14 @@ if site_id == 4:  # SummitShop
 ### Creating a Ticket
 ```python
 create_ticket(
-    subject="POS Terminal 3 Not Processing Cards",
-    body="Terminal 3 at checkout is declining all cards. Started 30 min ago.",
-    contact_name=user.name,
-    contact_email=user.email,
-    asset_id="POS-VER-003",  # String format
-    site_id=1,               # Integer: Vermillion
-    category_id="8",         # String: POS Equipment
-    severity_id=1            # Integer: Systems Down
+    Subject="POS Terminal 3 Not Processing Cards",
+    Ticket_Body="Terminal 3 at checkout is declining all cards. Started 30 min ago.",
+    Ticket_Contact_Name=user.name,
+    Ticket_Contact_Email=user.email,
+    Asset_ID="POS-VER-003",  # String format
+    Site_ID=1,               # Integer: Vermillion
+    Ticket_Category_ID="8",         # String: POS Equipment
+    Severity_ID=1            # Integer: Systems Down
 )
 ```
 
@@ -188,9 +188,9 @@ create_ticket(
 ```python
 # Find all critical POS issues
 search_tickets(
-    category_id="8",         # POS Equipment
-    severity_id=1,           # Systems Down
-    status="1,2,5,6,8",     # All open statuses
+    filters={"Ticket_Category_ID": "8"},  # POS Equipment
+    priority="critical",
+    status="open",
     site_id=user.site_id if not is_admin else None
 )
 ```


### PR DESCRIPTION
## Summary
- align prompt pseudocode with API parameter casing
- refresh search, create, and update ticket examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689125eea514832bb092cee195911e56