### PR TITLE
feat: add case-insensitive issue matching

### DIFF
--- a/prompt.ini
+++ b/prompt.ini
@@ -102,11 +102,12 @@ Provide accurate, data-driven support with **strict site isolation for non-admin
 ### Priority Assignment Logic
 ```python
 # Automatic priority based on keywords
-if "down" or "offline" or "can't process" in issue:
+issue_lower = issue.lower()
+if "down" in issue_lower or "offline" in issue_lower or "can't process" in issue_lower:
     severity_id = 1  # Systems Down
-elif "fuel" or "pos" or "payment" in issue and "slow" in issue:
+elif ("fuel" in issue_lower or "pos" in issue_lower or "payment" in issue_lower) and "slow" in issue_lower:
     severity_id = 2  # Important
-elif "broken" or "not working" in issue:
+elif "broken" in issue_lower or "not working" in issue_lower:
     severity_id = 3  # Average
 else:
     severity_id = 4  # Low Priority
@@ -115,18 +116,19 @@ else:
 ### Category Selection Guide
 ```python
 # Category selection based on issue context
-if "pos" or "retalix" or "verifone" in issue:
-    if "price" or "button" in issue:
+issue_lower = issue.lower()
+if "pos" in issue_lower or "retalix" in issue_lower or "verifone" in issue_lower:
+    if "price" in issue_lower or "button" in issue_lower:
         category_id = 27  # POS Configuration
     else:
         category_id = 8   # POS Equipment
-elif "caribou" in issue:
-    if "price" or "menu" in issue:
+elif "caribou" in issue_lower:
+    if "price" in issue_lower or "menu" in issue_lower:
         category_id = 20  # Caribou Config
     else:
         category_id = 15  # Caribou Equipment
-elif "fuel" or "pump" or "dispenser" in issue:
-    if "claim" in issue:
+elif "fuel" in issue_lower or "pump" in issue_lower or "dispenser" in issue_lower:
+    if "claim" in issue_lower:
         category_id = 47  # Fuel Claims
     else:
         category_id = 26  # Fuel Equipment


### PR DESCRIPTION
## Summary
- use `issue_lower` for priority assignment checks
- apply `issue_lower` in category selection guide keywords

## Testing
- `pytest --maxfail=1` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689151770710832ba99e4578728a5a7e