### PR TITLE
Ensure API examples use consistent parameter casing

### DIFF
--- a/DEXA_v3.2_Agent_Guide.md
+++ b/DEXA_v3.2_Agent_Guide.md
@@ -116,13 +116,13 @@ get_analytics(type="sla_performance")
 
 #### 1. `search_tickets`
 ```python
-search_tickets(
+  search_tickets(
   text="search",
-  user="user@email.com",
+  user=user.email,
   days=7,
   status="open",
   priority="high",
-  site_id=1,
+  site_id=site_id,
   assigned_to="tech@email.com",
   unassigned_only=True,
   filters={ "Asset_ID": 42 },
@@ -151,11 +151,11 @@ create_ticket(
   Subject="Title",
   Ticket_Body="Description",
   Ticket_Contact_Name="Name",
-  Ticket_Contact_Email="user@email.com",
-  Asset_ID=1,
-  Site_ID=2,
-  Ticket_Category_ID=3,
-  Severity_ID=2
+  Ticket_Contact_Email=user.email,
+  Asset_ID=asset_id,
+  Site_ID=site_id,
+  Ticket_Category_ID=ticket_category_id,
+  Severity_ID=severity_id
 )
 ```
 
@@ -164,14 +164,13 @@ create_ticket(
 update_ticket(
   ticket_id=123,
   updates={
-    "status": "closed",
-    "resolution": "Resolved with...",
-    "priority": "high",
-    "assignee": "tech@email.com",
-    "subject": "Updated",
-    "Site_ID": 2,
-    "category": 3,
-    "message": "Optional note"
+    "Ticket_Status_ID": 3,
+    "Resolution": "Resolved with...",
+    "Severity_ID": 2,
+    "Assigned_Email": "tech@email.com",
+    "Subject": "Updated",
+    "Site_ID": site_id,
+    "Ticket_Category_ID": ticket_category_id
   }
 )
 ```

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Additional tools are available:
   unified interface.
   ```bash
   curl -X POST http://localhost:8000/search_tickets \
-    -d '{"text": "printer", "status": 1, "days": 0}'
+    -d '{"text": "printer", "status": "open", "days": 0}'
   ```
 
   The response may include a `relevance_score` and a `highlights` object when a
@@ -447,7 +447,7 @@ The server exposes nine core JSON-RPC tools. Each expects a JSON body matching i
 - `update_ticket` – `{"ticket_id": 1, "updates": {}}`
 - `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
 
-- `search_tickets` – `{"text": "printer", "status": 1, "days": 0}`
+- `search_tickets` – `{"text": "printer", "status": "open", "days": 0}`
 
 - `get_tickets_by_user` – `{"identifier": "user@example.com"}`
 - `get_ticket_full_context` – `{"ticket_id": 123}` (no user history or nested related tickets)

--- a/aiagentprompt.txt
+++ b/aiagentprompt.txt
@@ -112,11 +112,11 @@ get_analytics(type="sla_performance")
 ```python
 search_tickets(
   text="search",
-  user="user@email.com",
+  user=user.email,
   days=7,
   status="open",
   priority="high",
-  site_id=1,
+  site_id=site_id,
   assigned_to="tech@email.com",
   unassigned_only=True,
   filters={ "Asset_ID": 42 },
@@ -145,11 +145,11 @@ create_ticket(
   Subject="Title",
   Ticket_Body="Description",
   Ticket_Contact_Name="Name",
-  Ticket_Contact_Email="user@email.com",
-  Asset_ID=1,
-  Site_ID=2,
-  Ticket_Category_ID=3,
-  Severity_ID=2
+  Ticket_Contact_Email=user.email,
+  Asset_ID=asset_id,
+  Site_ID=site_id,
+  Ticket_Category_ID=ticket_category_id,
+  Severity_ID=severity_id
 )
 ```
 
@@ -158,14 +158,13 @@ create_ticket(
 update_ticket(
   ticket_id=123,
   updates={
-    "status": "closed",
-    "resolution": "Resolved with...",
-    "priority": "high",
-    "assignee": "tech@email.com",
-    "subject": "Updated",
-    "Site_ID": 2,
-    "category": 3,
-    "message": "Optional note"
+    "Ticket_Status_ID": 3,
+    "Resolution": "Resolved with...",
+    "Severity_ID": 2,
+    "Assigned_Email": "tech@email.com",
+    "Subject": "Updated",
+    "Site_ID": site_id,
+    "Ticket_Category_ID": ticket_category_id
   }
 )
 ```

--- a/prompt.ini
+++ b/prompt.ini
@@ -173,14 +173,14 @@ if site_id == 4:  # SummitShop
 ### Creating a Ticket
 ```python
 create_ticket(
-    subject="POS Terminal 3 Not Processing Cards",
-    body="Terminal 3 at checkout is declining all cards. Started 30 min ago.",
-    contact_name=user.name,
-    contact_email=user.email,
-    asset_id="POS-VER-003",  # String format
-    site_id=1,               # Integer: Vermillion
-    category_id="8",         # String: POS Equipment
-    severity_id=1            # Integer: Systems Down
+    Subject="POS Terminal 3 Not Processing Cards",
+    Ticket_Body="Terminal 3 at checkout is declining all cards. Started 30 min ago.",
+    Ticket_Contact_Name=user.name,
+    Ticket_Contact_Email=user.email,
+    Asset_ID="POS-VER-003",  # String format
+    Site_ID=site_id,          # Integer: Vermillion
+    Ticket_Category_ID=ticket_category_id,  # String: POS Equipment
+    Severity_ID=severity_id   # Integer: Systems Down
 )
 ```
 
@@ -188,9 +188,8 @@ create_ticket(
 ```python
 # Find all critical POS issues
 search_tickets(
-    category_id="8",         # POS Equipment
-    severity_id=1,           # Systems Down
-    status="1,2,5,6,8",     # All open statuses
+    filters={"Ticket_Category_ID": ticket_category_id, "Severity_ID": severity_id},
+    status="open",
     site_id=user.site_id if not is_admin else None
 )
 ```


### PR DESCRIPTION
## Summary
- Standardized create_ticket and search_tickets examples to use exact API field casing and proper placeholders
- Updated agent prompts to align update_ticket calls with API parameters
- Corrected README ticket search samples to use the API's status format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689151773d78832b8aca53ba7c19981e