### PR TITLE
Expand MCP tool verification and allow supersets

### DIFF
--- a/verify_tools.py
+++ b/verify_tools.py
@@ -6,12 +6,34 @@ from typing import Set
 # Expected tool names exposed by the server
 EXPECTED_TOOLS: Set[str] = {
     "get_ticket",
+    "create_ticket",
+    "update_ticket",
+    "bulk_update_tickets",
+    "add_ticket_message",
+    "get_ticket_messages",
+    "get_ticket_attachments",
     "search_tickets",
+    "get_analytics",
+    "get_reference_data",
+    "get_ticket_full_context",
+    "advanced_search",
+    "get_system_snapshot",
+    "get_ticket_stats",
+    "get_workload_analytics",
+    "sla_metrics",
 }
 
 
-def verify(base_url: str) -> bool:
-    """Fetch `/tools` and verify the available tool names."""
+def verify(base_url: str, *, allow_superset: bool = False) -> bool:
+    """Fetch `/tools` and verify the available tool names.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL of the server to query.
+    allow_superset:
+        If True, do not treat unexpected additional tools as an error.
+    """
     url = base_url.rstrip('/') + '/tools'
     resp = requests.get(url, timeout=10)
     resp.raise_for_status()
@@ -21,7 +43,7 @@ def verify(base_url: str) -> bool:
     reported = {t["name"] for t in tools}
 
     missing = EXPECTED_TOOLS - reported
-    unexpected = reported - EXPECTED_TOOLS
+    unexpected = set() if allow_superset else reported - EXPECTED_TOOLS
 
     ok = True
 
@@ -42,8 +64,9 @@ def verify(base_url: str) -> bool:
 
 def main(argv: list[str]) -> int:
     base_url = argv[1] if len(argv) > 1 else "http://localhost:8000"
+    allow_superset = "--allow-superset" in argv
     try:
-        success = verify(base_url)
+        success = verify(base_url, allow_superset=allow_superset)
     except Exception as exc:
         print(f"Verification failed: {exc}")
         return 1


### PR DESCRIPTION
## Summary
- track full list of supported MCP tools
- optionally allow servers to advertise extra tools via `--allow-superset`

## Testing
- `pytest -q`
- `pytest tests/test_verify_tools.py -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68915380e5e4832b8d6d80d955b15a15