### PR TITLE
docs: document ticket messages and analytics tools

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -80,6 +80,8 @@ JSON body matching the tool's schema. See
 - `POST /create_ticket` – Create a ticket. Example: see `TicketCreate` schema
 - `POST /update_ticket` – Update a ticket. Example: `{"ticket_id": 1, "updates": {}}`
 - `POST /add_ticket_message` – Add a message to a ticket.
+- `POST /get_ticket_messages` – Messages for a ticket. Example: `{"ticket_id": 123}`
+- `POST /get_ticket_attachments` – Attachments for a ticket. Example: `{"ticket_id": 123}`
 - `POST /search_tickets` – Search tickets. Example: `{"text": "printer", "created_after": "2024-01-01T00:00:00Z"}`. The deprecated
   `/search_tickets_advanced` route was removed.
 - `POST /update_ticket` – Update a ticket or close/assign by modifying fields.
@@ -91,6 +93,8 @@ JSON body matching the tool's schema. See
 
 - `POST /get_ticket_full_context` – Full context for a ticket without user history or nested related tickets. Example: `{"ticket_id": 123}`
 - `POST /get_system_snapshot` – System snapshot. Example: `{}`
+- `POST /get_ticket_stats` – Ticket statistics summary. Example: `{}`
+- `POST /get_workload_analytics` – Technician workload analytics. Example: `{}`
 
 - `POST /advanced_search` – Advanced ticket search. Example: `{"text_search": "printer"}`
 

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -88,6 +88,30 @@ curl -X POST http://localhost:8000/add_ticket_message \
   -d '{"ticket_id": 5, "message": "Checking the printer", "sender_name": "Alice"}'
 ```
 
+## get_ticket_messages
+Return messages for a ticket with additional metadata.
+
+Parameters:
+- `ticket_id` – integer ticket ID.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_ticket_messages \
+  -d '{"ticket_id": 5}'
+```
+
+## get_ticket_attachments
+Return attachments for a ticket with file metadata.
+
+Parameters:
+- `ticket_id` – integer ticket ID.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_ticket_attachments \
+  -d '{"ticket_id": 5}'
+```
+
 ## search_tickets
 Comprehensive ticket search with AI-optimized features and semantic filtering. Supports text queries, user filtering, date ranges, and intelligent result ranking.
 
@@ -291,6 +315,26 @@ Parameters: none.
 Example:
 ```bash
 curl -X POST http://localhost:8000/get_system_snapshot -d '{}'
+```
+
+## get_ticket_stats
+Return ticket statistics grouped by status, priority, site, and category.
+
+Parameters: none.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_ticket_stats -d '{}'
+```
+
+## get_workload_analytics
+Return workload analytics for technicians and ticket queues.
+
+Parameters: none.
+
+Example:
+```bash
+curl -X POST http://localhost:8000/get_workload_analytics -d '{}'
 ```
 
 


### PR DESCRIPTION
## Summary
- add docs for `get_ticket_messages` and `get_ticket_attachments`
- document analytics helpers `get_ticket_stats` and `get_workload_analytics`
- expose new endpoints in API guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689153850414832bad956fc15821f6cd