### PR TITLE
docs: update core tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,19 +439,18 @@ Additional tools are available:
     -d '{"ticket_ids": [1,2,3], "updates": {"Assigned_Email": "tech@example.com"}}'
   ```
 
-The server exposes nine core JSON-RPC tools. Each expects a JSON body matching its schema.
+The server exposes ten core JSON-RPC tools. Each expects a JSON body matching its schema.
 
-- `get_ticket` – `{"ticket_id": 123}`
-- `list_tickets` – `{"limit": 5}`
-- `create_ticket` – see `TicketCreate` schema
-- `update_ticket` – `{"ticket_id": 1, "updates": {}}`
-- `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
-
-- `search_tickets` – `{"text": "printer", "status": 1, "days": 0}`
-
-- `get_tickets_by_user` – `{"identifier": "user@example.com"}`
-- `get_ticket_full_context` – `{"ticket_id": 123}` (no user history or nested related tickets)
-- `get_system_snapshot` – `{}`
+1. `get_ticket` – `{"ticket_id": 123}`
+2. `list_tickets` – `{"limit": 5}`
+3. `create_ticket` – see `TicketCreate` schema
+4. `update_ticket` – `{"ticket_id": 1, "updates": {}}`
+5. `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
+6. `search_tickets` – `{"text": "printer", "status": 1, "days": 0}`
+7. `get_tickets_by_user` – `{"identifier": "user@example.com"}`
+8. `get_open_tickets` – `{"days": 30}`
+9. `get_ticket_full_context` – `{"ticket_id": 123}` (no user history or nested related tickets)
+10. `get_system_snapshot` – `{}`
 
 See [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md) for detailed descriptions.
 


### PR DESCRIPTION
## Summary
- document ten core JSON-RPC tools and include get_open_tickets

## Testing
- `pytest tests/test_verify_tools.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6891537dfadc832b8d4a9731c0664b49