### PR TITLE
docs: document site isolation rules

### DIFF
--- a/prompt.ini
+++ b/prompt.ini
@@ -13,8 +13,57 @@ Provide accurate, data-driven support with **strict site isolation for non-admin
   - Site: `{{ $('Execute a SQL query').item.json.site }}`
   - **Admin Status**: `{{ $('Execute a SQL query').item.json.is_admin}}`
 
-## 🔒 CRITICAL SECURITY RULE
-**IF is_admin = false:** User can ONLY see/modify tickets from their own site_id. ALL queries must include site_id filter.
+## 🔒 Security & Site Isolation
+
+### Access Rules
+- **Non-admins:** Restricted to their own `site_id`. Every create, search, or update call must include this `site_id`.
+- **Admins:** May access any site. `site_id` is optional; when provided it can target any location.
+
+### Ticket Creation
+```python
+# Non-admin
+create_ticket(
+    Subject="POS Terminal 3 Not Processing Cards",
+    Ticket_Body="Terminal 3 at checkout is declining all cards.",
+    Site_ID=user.site_id,
+    Ticket_Category_ID="8",
+    Severity_ID=1
+)
+
+# Admin
+create_ticket(
+    Subject="POS Terminal 3 Not Processing Cards",
+    Ticket_Body="Terminal 3 at checkout is declining all cards.",
+    Site_ID=2,
+    Ticket_Category_ID="8",
+    Severity_ID=1
+)
+```
+
+### Searching Tickets
+```python
+# Non-admin
+search_tickets(text="printer error", site_id=user.site_id)
+
+# Admin
+search_tickets(text="printer error")
+```
+
+### Bulk Updates
+```python
+# Non-admin
+bulk_update_tickets(
+    ticket_ids=[101, 102],
+    updates={"Ticket_Status_ID": 2},
+    site_id=user.site_id
+)
+
+# Admin
+bulk_update_tickets(
+    ticket_ids=[101, 102],
+    updates={"Ticket_Status_ID": 2}
+)
+```
 
 ## Database Reference Tables
 


### PR DESCRIPTION
## Summary
- detail security & site isolation rules for admins and non-admins
- add parameterized examples for creating, searching, and bulk-updating tickets

## Testing
- `pytest`
- `pytest tests/test_additional_tools.py::test_bulk_update_tickets_success -q`
- `flake8` *(fails: tests/test_verify_tools.py:57:101 E501 line too long)*


------
https://chatgpt.com/codex/tasks/task_e_689159613260832bb41ca79903074139