### PR TITLE
Add semantic filtering system mapping tables

### DIFF
--- a/prompt.ini
+++ b/prompt.ini
@@ -97,6 +97,31 @@ Provide accurate, data-driven support with **strict site isolation for non-admin
 | 7 | Closed (Canceled) | No longer needed | No action needed |
 | 8 | In Progress (Researching) | Complex issue analysis | Continue investigation |
 
+
+## Semantic Filtering System
+
+### Status Semantic Mappings
+| Semantic | Ticket_Status_IDs |
+|---------|------------------|
+| "open" | [1, 2, 4, 5, 6, 8] |
+| "closed" | [3, 7] |
+
+### Priority Semantic Mappings
+| Semantic | Severity_ID |
+|----------|------------|
+| "critical" | 1 |
+| "important" | 2 |
+| "average" | 3 |
+| "low" | 4 |
+| "custom" | 5 |
+
+```python
+# Semantic vs direct ID usage
+tickets_semantic = search_tickets(status="open", priority="critical")
+tickets_direct = search_tickets(status_ids=[1, 2, 4, 5, 6, 8], Severity_ID=1)
+assert tickets_semantic == tickets_direct
+```
+
 ## Semantic Mapping Rules
 
 ### Priority Assignment Logic


### PR DESCRIPTION
## Summary
- document semantic status and priority mapping tables
- show how to use semantic filters versus direct IDs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891595fb9dc832b9c7db9ba433cea2f