### PR TITLE
docs: add comprehensive tool reference

### DIFF
--- a/prompt.ini
+++ b/prompt.ini
@@ -170,34 +170,150 @@ if site_id == 4:  # SummitShop
 - **Category**: 22 (IT-O365)
 - **Status**: 1 → 6 (Awaiting Service) → 3
 
-## Tool Usage with Proper IDs
+## Complete Tool Reference
 
-### Creating a Ticket
+### Ticket Operations
+#### `create_ticket`
+Creates a new help desk ticket.
+
+Parameters:
+- `Subject` *(str)* – short issue summary.
+- `Ticket_Body` *(str)* – detailed description.
+- `Ticket_Contact_Name` *(str)* – requester name.
+- `Ticket_Contact_Email` *(str)* – requester email.
+- `Site_ID` *(int)* – site identifier; required for non‑admins.
+- `Ticket_Category_ID` *(str)* – issue category ID.
+- `Severity_ID` *(int)* – priority level.
+- `Asset_ID` *(str, optional)* – associated asset tag.
+
+Example:
 ```python
 create_ticket(
     Subject="POS Terminal 3 Not Processing Cards",
-    Ticket_Body="Terminal 3 at checkout is declining all cards. Started 30 min ago.",
+    Ticket_Body="Terminal 3 at checkout is declining all cards.",
     Ticket_Contact_Name=user.name,
     Ticket_Contact_Email=user.email,
-    Asset_ID="POS-VER-003",  # String format
-    Site_ID=site_id,          # Integer: Vermillion
-    Ticket_Category_ID=ticket_category_id,  # String: POS Equipment
-    Severity_ID=severity_id   # Integer: Systems Down
-    Site_ID=1,               # Integer: Vermillion
-    Ticket_Category_ID="8",         # String: POS Equipment
-    Severity_ID=1            # Integer: Systems Down
+    Site_ID=user.site_id,
+    Ticket_Category_ID="8",
+    Severity_ID=1,
+    Asset_ID="POS-VER-003"
 )
 ```
 
-### Searching with Filters
+#### `get_ticket`
+Retrieve an existing ticket by ID.
+
+Parameters:
+- `ticket_id` *(int)* – ticket identifier.
+
+Example:
 ```python
-# Find all critical POS issues
-search_tickets(
-    filters={"Ticket_Category_ID": "8"},  # POS Equipment
-    priority="critical",
-    status="open",
-    site_id=user.site_id if not is_admin else None
+ticket = get_ticket(ticket_id=12345)
+```
+
+#### `update_ticket`
+Modify fields on an existing ticket.
+
+Parameters:
+- `ticket_id` *(int)* – ticket identifier.
+- `updates` *(dict)* – fields to change such as `Ticket_Status_ID`, `Assigned_Email`, or `Resolution`.
+
+Example:
+```python
+update_ticket(
+    ticket_id=12345,
+    updates={"Ticket_Status_ID": 3, "Resolution": "Replaced card reader"}
 )
+```
+
+### Search & Discovery
+#### `search_tickets`
+Search for tickets using keywords and filters.
+
+Common Parameters:
+- `text` *(str, optional)* – keyword query.
+- `status` *(str|int, optional)* – ticket status filter.
+- `priority` *(str, optional)* – priority filter.
+- `site_id` *(int, optional)* – restrict to a site (required for non‑admins).
+- `days` *(int, optional)* – look back this many days.
+- `created_after` *(ISO datetime, optional)* – start of date range.
+- `created_before` *(ISO datetime, optional)* – end of date range.
+- `unassigned_only` *(bool, optional)* – limit to tickets without an assignee.
+
+Example:
+```python
+results = search_tickets(text="printer", status="open", days=7, site_id=user.site_id)
+```
+
+### Analytics & Reporting
+#### `get_analytics`
+Return aggregated ticket metrics and trends.
+
+Parameters:
+- `type` *(str)* – report to run, e.g. `"overview"`, `"workload"`, `"sla_performance"`, `"overdue_tickets"`.
+- `params` *(dict, optional)* – additional options such as `{ "days": 2 }`.
+
+Example:
+```python
+stats = get_analytics(type="workload", params={"days": 2})
+```
+
+### Context & Reference
+#### `get_reference_data`
+Retrieve static reference information like sites, categories or priorities.
+
+Parameters:
+- `type` *(str)* – one of `"sites"`, `"assets"`, `"vendors"`, `"categories"`, `"priorities"`, `"statuses"`.
+- `limit` *(int, optional)* – maximum records to return.
+- `skip` *(int, optional)* – offset for pagination.
+- `filters` *(dict, optional)* – field filters.
+- `sort` *(list, optional)* – sort columns.
+- `include_counts` *(bool, optional)* – include open/total ticket counts.
+
+Example:
+```python
+sites = get_reference_data(type="sites", include_counts=True)
+```
+
+#### `get_ticket_full_context`
+Return a ticket along with messages and metadata.
+
+Parameters:
+- `ticket_id` *(int)* – ticket identifier.
+
+Example:
+```python
+context = get_ticket_full_context(ticket_id=5)
+```
+
+### Messaging
+#### `add_ticket_message`
+Append a message to the ticket conversation.
+
+Parameters:
+- `ticket_id` *(int)* – ticket identifier.
+- `message` *(str)* – message body.
+- `sender_name` *(str)* – name of poster.
+- `sender_code` *(str, optional)* – optional sender code.
+
+Example:
+```python
+add_ticket_message(
+    ticket_id=5,
+    message="Checking the printer",
+    sender_name=user.name
+)
+```
+
+#### `get_ticket_messages`
+Fetch all messages for a ticket.
+
+Parameters:
+- `ticket_id` *(int)* – ticket identifier.
+
+Example:
+```python
+messages = get_ticket_messages(ticket_id=5)
 ```
 
 ## Response Templates with Proper Labels


### PR DESCRIPTION
## Summary
- replace tool usage section with a complete tool reference grouping tools by functionality
- document parameters and example calls for ticket operations, search, analytics, reference, and messaging tools

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68915960a968832bba8ec8500d25c757