### PR TITLE
docs: add common issues section to prompt

### DIFF
--- a/prompt.ini
+++ b/prompt.ini
@@ -235,3 +235,76 @@ search_tickets(
 
 ---
 *Always use exact IDs from reference tables. When in doubt, ask for clarification.*
+
+## Common Issues & Solutions
+
+### Validation Errors
+
+| Issue | Example | Solution |
+|------|---------|----------|
+| Wrong type | `Severity_ID="high"` | Use integer `1-5` |
+| Unknown semantic | `Ticket_Category_ID="Coffee"` | Use valid ID such as `15` (Caribou Equipment) |
+
+```python
+# Basic type validation
+def validate_types(severity_id: int, category_id: str) -> None:
+    if not isinstance(severity_id, int):
+        raise TypeError("Severity_ID must be int")
+    if category_id not in {"8", "15", "27"}:
+        raise ValueError("Unknown Ticket_Category_ID")
+```
+
+### Site Isolation Mistakes
+
+| Mistake | Consequence | Fix |
+|---------|-------------|-----|
+| Query without `site_id` filter | Exposes cross-site data | Always include caller's `site_id` unless admin |
+| Using another site's `site_id` | Unauthorized access | Reject or re-ask for correct site |
+
+```python
+def enforce_site_isolation(site_id: int, user_site: int, is_admin: bool) -> None:
+    if not is_admin and site_id != user_site:
+        raise PermissionError("Cross-site access denied")
+```
+
+### Semantic/ID Usage
+
+| Field | Incorrect | Correct |
+|-------|-----------|---------|
+| `Asset_ID` | `123` (int) | `"POS-VER-003"` (string) |
+| `Site_ID` | `"1"` (string) | `1` (int) |
+| `Ticket_Status_ID` | `3` (int) | `"3"` (string) |
+
+```python
+# Semantic check example
+def create_ticket(*, Site_ID: int, Ticket_Status_ID: str) -> None:
+    assert isinstance(Site_ID, int)
+    assert isinstance(Ticket_Status_ID, str)
+    # proceed with creation...
+```
+
+## Implementation Checklist
+
+- [ ] Validate parameter types before executing operations
+- [ ] Confirm `site_id` aligns with caller profile when non-admin
+- [ ] Use only IDs defined in reference tables
+- [ ] Follow status progression rules
+
+## Basic Validation Tests
+
+```python
+def test_validation():
+    try:
+        validate_types("1", "8")
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("Type validation failed")
+
+    try:
+        enforce_site_isolation(2, user_site=1, is_admin=False)
+    except PermissionError:
+        pass
+    else:
+        raise AssertionError("Site isolation check failed")
+```


### PR DESCRIPTION
## Summary
- document validation errors, site isolation, and semantic ID guidance in new `Common Issues & Solutions` section
- provide an implementation checklist and sample validation tests for easier debugging

## Testing
- `pytest tests/test_health.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689159640d6c832b8459678a71c1199d