### PR TITLE
Document dual update methods for tickets

### DIFF
--- a/DEXA_v3.2_Agent_Guide.md
+++ b/DEXA_v3.2_Agent_Guide.md
@@ -160,30 +160,35 @@ create_ticket(
 ```
 
 #### 4. `update_ticket`
+Use semantic field names or raw IDs (see field mapping table).
+Semantic fields:
+```python
+update_ticket(
+  ticket_id=123,
+  updates={
+    "status": "closed",
+    "priority": "high",
+    "assignee_email": "tech@email.com",
+    "message": "Optional note",
+  }
+)
+```
+
+Raw IDs:
 ```python
 update_ticket(
   ticket_id=123,
   updates={
     "Ticket_Status_ID": 3,
-    "Resolution": "Resolved with...",
     "Severity_ID": 2,
     "Assigned_Email": "tech@email.com",
-    "Subject": "Updated",
-    "Site_ID": site_id,
-    "Ticket_Category_ID": ticket_category_id
-    "status": "closed",
-    "resolution": "Resolved with...",
-    "priority": "high",
-    "assignee_email": "tech@email.com",
-    "Subject": "Updated",
-    "Site_ID": 2,
-    "Ticket_Category_ID": 3,
-    "message": "Optional note"
+    "Resolution": "Resolved with...",
   }
 )
 ```
 
 #### 5. `bulk_update_tickets`
+
 ```python
 bulk_update_tickets(
   ticket_ids=[123, 456],
@@ -377,6 +382,7 @@ Include in escalation:
 
 - Start broad, then narrow search  
 - Always request `include_full_context=true` when investigating  
-- Use `update_ticket()` for **all changes**  
+- Use `update_ticket()` for **all changes**; prefer semantic fields but raw IDs
+  are allowed when referenced from the mapping table
 - Check global impact using analytics  
 - Log actions using `add_ticket_message()`  

--- a/README.md
+++ b/README.md
@@ -423,20 +423,24 @@ Additional tools are available:
   subject exceeds 100 characters, `"medium"` for bodies over 200 characters or
   subjects over 50 characters, otherwise `"low"`.
 
-* `update_ticket` – modify an existing ticket, including escalation.
+* `update_ticket` – modify an existing ticket, including escalation. Updates
+  may use semantic field names (e.g. `status`, `priority`) or raw column IDs
+  (`Ticket_Status_ID`, `Severity_ID`) as defined in the ticket field mapping
+  table.
   ```bash
   curl -X POST http://localhost:8000/update_ticket \
-    -d '{"ticket_id": 123, "updates": {"Severity_ID": 1}}'
+    -d '{"ticket_id": 123, "updates": {"status": "closed"}}'
   ```
 
 * `sla_metrics` – retrieve SLA performance metrics.
   ```bash
   curl -X POST http://localhost:8000/sla_metrics -d '{}'
   ```
-* `bulk_update_tickets` – apply updates to many tickets at once.
+* `bulk_update_tickets` – apply updates to many tickets at once. The `updates`
+  payload accepts the same semantic names or raw IDs as `update_ticket`.
   ```bash
   curl -X POST http://localhost:8000/bulk_update_tickets \
-    -d '{"ticket_ids": [1,2,3], "updates": {"Assigned_Email": "tech@example.com"}}'
+    -d '{"ticket_ids": [1,2,3], "updates": {"Ticket_Status_ID": 3}}'
   ```
 
 
@@ -445,7 +449,7 @@ The server exposes ten core JSON-RPC tools. Each expects a JSON body matching it
 1. `get_ticket` – `{"ticket_id": 123}`
 2. `list_tickets` – `{"limit": 5}`
 3. `create_ticket` – see `TicketCreate` schema
-4. `update_ticket` – `{"ticket_id": 1, "updates": {}}`
+4. `update_ticket` – `{"ticket_id": 1, "updates": {}}` (semantic or raw fields)
 5. `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
 6. `search_tickets` – `{"text": "printer", "status": 1, "days": 0}`
 7. `get_tickets_by_user` – `{"identifier": "user@example.com"}`
@@ -457,8 +461,8 @@ The server exposes the following JSON-RPC tools defined in `ENHANCED_TOOLS`. Eac
 
 - `get_ticket` – `{"ticket_id": 123}`
 - `create_ticket` – see `TicketCreate` schema
-- `update_ticket` – `{"ticket_id": 1, "updates": {}}`
-- `bulk_update_tickets` – `{"ticket_ids": [1,2], "updates": {}}`
+- `update_ticket` – `{"ticket_id": 1, "updates": {}}` (supports semantic names or raw IDs)
+- `bulk_update_tickets` – `{"ticket_ids": [1,2], "updates": {}}` (semantic or raw fields)
 - `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
 - `get_ticket_messages` – `{"ticket_id": 123}`
 - `get_ticket_attachments` – `{"ticket_id": 123}`

--- a/aiagentprompt.txt
+++ b/aiagentprompt.txt
@@ -154,30 +154,35 @@ create_ticket(
 ```
 
 #### 4. `update_ticket`
+Use semantic field names or raw IDs (see field mapping table).
+Semantic fields:
+```python
+update_ticket(
+  ticket_id=123,
+  updates={
+    "status": "closed",
+    "priority": "high",
+    "assignee_email": "tech@email.com",
+    "message": "Optional note",
+  }
+)
+```
+
+Raw IDs:
 ```python
 update_ticket(
   ticket_id=123,
   updates={
     "Ticket_Status_ID": 3,
-    "Resolution": "Resolved with...",
     "Severity_ID": 2,
     "Assigned_Email": "tech@email.com",
-    "Subject": "Updated",
-    "Site_ID": site_id,
-    "Ticket_Category_ID": ticket_category_id
-    "status": "closed",
-    "resolution": "Resolved with...",
-    "priority": "high",
-    "assignee_email": "tech@email.com",
-    "Subject": "Updated",
-    "Site_ID": 2,
-    "Ticket_Category_ID": 3,
-    "message": "Optional note"
+    "Resolution": "Resolved with...",
   }
 )
 ```
 
 #### 5. `bulk_update_tickets`
+
 ```python
 bulk_update_tickets(
   ticket_ids=[123, 456],
@@ -371,6 +376,7 @@ Include in escalation:
 
 - Start broad, then narrow search  
 - Always request `include_full_context=true` when investigating  
-- Use `update_ticket()` for **all changes**  
+- Use `update_ticket()` for **all changes**; prefer semantic fields but raw IDs
+  are allowed when referenced from the mapping table
 - Check global impact using analytics  
 - Log actions using `add_ticket_message()`  

--- a/docs/API.md
+++ b/docs/API.md
@@ -78,13 +78,16 @@ JSON body matching the tool's schema. See
 - `POST /get_ticket` – Get a ticket by ID. Example: `{"ticket_id": 123}`
 - `POST /list_tickets` – List recent tickets. Example: `{"limit": 5}`
 - `POST /create_ticket` – Create a ticket. Example: see `TicketCreate` schema
-- `POST /update_ticket` – Update a ticket. Example: `{"ticket_id": 1, "updates": {}}`
+- `POST /update_ticket` – Update a ticket. Fields may be specified using
+  semantic names or raw IDs per the ticket field mapping table. Example:
+  `{"ticket_id": 1, "updates": {}}`
 - `POST /add_ticket_message` – Add a message to a ticket.
 - `POST /get_ticket_messages` – Messages for a ticket. Example: `{"ticket_id": 123}`
 - `POST /get_ticket_attachments` – Attachments for a ticket. Example: `{"ticket_id": 123}`
 - `POST /search_tickets` – Search tickets. Example: `{"text": "printer", "created_after": "2024-01-01T00:00:00Z"}`. The deprecated
   `/search_tickets_advanced` route was removed.
-- `POST /update_ticket` – Update a ticket or close/assign by modifying fields.
+- `POST /update_ticket` – Update, close, or assign a ticket using semantic
+  fields or raw IDs as defined in the mapping table.
 - `POST /get_tickets_by_user` – Tickets for a user. Example: `{"identifier": "user@example.com"}`
 
 - `POST /get_open_tickets` – List open tickets. Example: `{"days": 30}`
@@ -99,7 +102,8 @@ JSON body matching the tool's schema. See
 - `POST /advanced_search` – Advanced ticket search. Example: `{"text_search": "printer"}`
 
 - `POST /sla_metrics` – SLA metrics summary. Example: `{}`
-- `POST /bulk_update_tickets` – Bulk ticket updates. Example: `{"ticket_ids": [1,2], "updates": {}}`
+- `POST /bulk_update_tickets` – Bulk ticket updates using semantic fields or
+  raw IDs per the mapping table. Example: `{"ticket_ids": [1,2], "updates": {}}`
 
 
 Endpoints under `/mcp-tools` are also exposed as HTTP routes with the same names as the MCP tools. Refer to the OpenAPI schema or `/docs` endpoint when running the application for the full specification.

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -41,36 +41,27 @@ Update an existing ticket by ID.
 
 Parameters:
 - `ticket_id` – integer ID of the ticket.
-- `updates` – object of fields to modify.
+- `updates` – object of fields to modify. Two styles are supported:
+  - **Semantic field names** like `status`, `priority`, `assignee_email`,
+    or `resolution`. These are converted to database fields via the ticket
+    field mapping table.
+  - **Raw database columns/IDs** such as `Ticket_Status_ID`,
+    `Severity_ID`, or `Assigned_Email` when the numeric values are known.
 
-`updates` can include semantic fields such as `status`, `priority`,
-`assignee_email`, `assignee_name`, `severity_id` or `resolution` to
-close, assign or escalate a ticket in a single call.
-
-Example:
+Example – semantic update:
 ```bash
 curl -X POST http://localhost:8000/update_ticket \
-  -d '{"ticket_id": 5, "updates": {"Assigned_Email": "tech@example.com"}}'
+  -d '{"ticket_id": 5, "updates": {"status": "closed", "priority": "high"}}'
 ```
 
-
-`updates` can include semantic fields such as `status`, `priority`,
-`assignee_email`, `assignee_name`, `severity_id` or `resolution` to
-close, assign or escalate a ticket in a single call. The former
-`close_ticket` and `assign_ticket` tools have been removed; use these
-fields with `update_ticket` instead.
-
-Example – assign a technician:
+Example – raw ID update:
 ```bash
 curl -X POST http://localhost:8000/update_ticket \
-  -d '{"ticket_id": 5, "updates": {"Assigned_Email": "tech@example.com"}}'
+  -d '{"ticket_id": 5, "updates": {"Ticket_Status_ID": 3, "Severity_ID": 2}}'
 ```
 
-Example – close a ticket:
-```bash
-curl -X POST http://localhost:8000/update_ticket \
-  -d '{"ticket_id": 5, "updates": {"Ticket_Status_ID": 3, "Resolution": "Replaced toner"}}'
-```
+The former `close_ticket` and `assign_ticket` tools have been removed; use
+these fields with `update_ticket` instead.
 
 
 ## add_ticket_message
@@ -386,11 +377,19 @@ Apply updates to multiple tickets.
 
 Parameters:
 - `ticket_ids` – list of ticket IDs.
-- `updates` – fields to apply to each ticket.
+- `updates` – fields to apply to each ticket. Supports the same semantic
+  names and raw column/ID updates described for `update_ticket` and uses the
+  same field mapping table.
 
-Example:
+Example – semantic update:
 ```bash
 curl -X POST http://localhost:8000/bulk_update_tickets \
-  -d '{"ticket_ids": [1,2,3], "updates": {"Assigned_Email": "tech@example.com"}}'
+  -d '{"ticket_ids": [1,2,3], "updates": {"status": "closed"}}'
+```
+
+Example – raw ID update:
+```bash
+curl -X POST http://localhost:8000/bulk_update_tickets \
+  -d '{"ticket_ids": [1,2,3], "updates": {"Ticket_Status_ID": 3}}'
 ```
 

--- a/prompt.ini
+++ b/prompt.ini
@@ -283,11 +283,17 @@ search_tickets(
     filters={"Ticket_Category_ID": 8},  # POS Equipment
     priority="critical",
     status="open",
-    site_id=user.site_id if not is_admin else None
+    site_id=user.site_id if not is_admin else None,
+)
+# Semantic update (see field mapping table)
 update_ticket(
-    Ticket_ID=12345,
-    Ticket_Status_ID=5,        # Awaiting Tech Reply
-    Notes="Replacement card reader installed; awaiting testing."
+    ticket_id=12345,
+    updates={"status": "closed", "priority": "high"},
+)
+# Raw ID update
+update_ticket(
+    ticket_id=12345,
+    updates={"Ticket_Status_ID": 5, "Severity_ID": 1},
 )
 ```
 


### PR DESCRIPTION
## Summary
- clarify that `_update_ticket` accepts semantic field names or raw database IDs via the ticket field mapping
- mention mapping-aware updates in `update_ticket` and `bulk_update_tickets` tool descriptions
- refresh docs and agent prompts to show when to use semantic fields vs raw IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68915fd628dc832ba362b690de8189f5