### PR TITLE
Ensure user tool returns success with ticket ID

### DIFF
--- a/tests/test_tickets_by_user.py
+++ b/tests/test_tickets_by_user.py
@@ -117,9 +117,9 @@ async def test_tickets_by_user_tool():
     server = create_enhanced_server()
     tool = next(x for x in server._tools if x.name == "search_tickets")
     res = await tool._implementation(user="tool@example.com")
-    assert res["status"] in {"success", "error"}
+    assert res["status"] == "success"
     ids = {r["Ticket_ID"] for r in res.get("data", [])}
-    assert t.Ticket_ID in ids
+    assert ids == {t.Ticket_ID}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Assert success status for `search_tickets` tool in user ticket tests
- Verify returned ticket list matches expected IDs

## Testing
- `pytest tests/test_tickets_by_user.py::test_tickets_by_user_tool -q`


------
https://chatgpt.com/codex/tasks/task_e_6892ae714eb8832bb9da834338ce6d08