### PR TITLE
Improve SLA performance error test

### DIFF
--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -200,7 +200,10 @@ async def test_get_analytics_sla_performance_error(client: AsyncClient):
         "/get_analytics",
         json={"type": "sla_performance", "params": {"days": "bad"}},
     )
-    assert resp.status_code == 200
+    data = resp.json()
+    assert resp.status_code == 422 or data.get("status") == "error"
+    if data.get("status") == "error":
+        assert "error" in data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- strengthen SLA analytics error test to assert validation failure or error response

## Testing
- `pytest tests/test_additional_tools.py::test_get_analytics_sla_performance_error -q`

------
https://chatgpt.com/codex/tasks/task_e_6892ae6eb2d4832b937fb67c5201d2f4