### PR TITLE
test: ensure dynamic tools return valid data

### DIFF
--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -7,20 +7,40 @@ from main import app
 async def test_dynamic_tool_routes():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/get_ticket", json={"ticket_id": 1})
+        payload = {
+            "Subject": "Seed",
+            "Ticket_Body": "Init ticket",
+            "Ticket_Contact_Name": "Seeder",
+            "Ticket_Contact_Email": "seed@example.com",
+        }
+        created = await client.post("/create_ticket", json=payload)
+        assert created.status_code == 200
+        created_data = created.json()
+        assert created_data.get("status") == "success"
+        ticket_id = created_data["data"]["Ticket_ID"]
+
+        resp = await client.post("/get_ticket", json={"ticket_id": ticket_id})
         assert resp.status_code == 200
         data = resp.json()
-        assert data.get("status") in {"success", "error"}
+        assert data.get("status") == "success"
+        ticket = data.get("data", {})
+        assert ticket.get("Ticket_ID") == ticket_id
+        assert "Subject" in ticket
 
-        resp = await client.post("/get_ticket", json={"ticket_id": 1, "extra": 1})
+        resp = await client.post("/get_ticket", json={"ticket_id": ticket_id, "extra": 1})
         assert resp.status_code == 422
 
         resp = await client.post(
             "/get_ticket",
-            json={"ticket_id": 1, "include_full_context": True},
+            json={"ticket_id": ticket_id, "include_full_context": True},
         )
         assert resp.status_code == 200
-        assert resp.json().get("status") in {"success", "error"}
+        data = resp.json()
+        assert data.get("status") == "success"
+        assert data["data"]["Ticket_ID"] == ticket_id
+        assert isinstance(data.get("messages"), list)
+        assert isinstance(data.get("attachments"), list)
+        assert "user_history" in data
 
         resp = await client.post("/get_ticket", json={})
         assert resp.status_code == 422
@@ -114,11 +134,20 @@ async def test_removed_tools_return_404():
 async def test_new_tool_endpoints():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-
         resp = await client.post("/get_analytics", json={"type": "overview"})
         assert resp.status_code == 200
-        assert resp.json().get("status") in {"success", "error"}
+        data = resp.json()
+        assert data.get("status") == "success"
+        snapshot = data.get("data", {})
+        assert "ticket_counts_by_status" in snapshot
+        assert "system_health" in snapshot
+        assert "timestamp" in data
 
         resp = await client.post("/get_reference_data", json={"type": "sites"})
         assert resp.status_code == 200
-        assert resp.json().get("status") in {"success", "error"}
+        ref_data = resp.json()
+        assert ref_data.get("status") == "success"
+        assert ref_data.get("type") == "sites"
+        assert isinstance(ref_data.get("data"), list)
+        assert "count" in ref_data
+        assert "total_count" in ref_data


### PR DESCRIPTION
## Summary
- assert `get_ticket` route succeeds and returns expected fields
- validate analytics snapshot and reference data responses

## Testing
- `pytest tests/test_dynamic_tools.py::test_dynamic_tool_routes tests/test_dynamic_tools.py::test_new_tool_endpoints -q`


------
https://chatgpt.com/codex/tasks/task_e_6892ae705170832b907a48640dc4e648