### PR TITLE
Normalize datetime string storage

### DIFF
--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -1,7 +1,7 @@
 from datetime import datetime, UTC
 
 from src.core.services.system_utilities import parse_search_datetime
-from src.shared.utils.date_format import format_db_datetime
+from src.shared.utils.date_format import format_db_datetime, FormattedDateTime
 
 
 def test_parse_search_datetime_db_format():
@@ -12,3 +12,15 @@ def test_parse_search_datetime_db_format():
     expected = dt.replace(microsecond=(dt.microsecond // 1000) * 1000)
 
     assert parsed == expected
+
+
+def test_formatted_datetime_truncates_datetime_input():
+    typ = FormattedDateTime()
+    dt = datetime(2023, 1, 2, 3, 4, 5, 987654, tzinfo=UTC)
+    assert typ.process_bind_param(dt, None) == "2023-01-02 03:04:05.987"
+
+
+def test_formatted_datetime_truncates_string_input():
+    typ = FormattedDateTime()
+    text = "2023-01-02 03:04:05.987654"
+    assert typ.process_bind_param(text, None) == "2023-01-02 03:04:05.987"


### PR DESCRIPTION
## Summary
- parse string datetime values before binding to DB and normalize to UTC/millisecond precision
- add tests ensuring FormattedDateTime truncates microseconds for both datetime and string inputs

## Testing
- `pytest tests/test_date_format.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892af89cb1c832b90317cb046b40237