### PR TITLE
Ensure ticket creation uses formatted timestamps

### DIFF
--- a/src/api/v1/tickets.py
+++ b/src/api/v1/tickets.py
@@ -22,6 +22,7 @@ from src.shared.schemas.search_params import TicketSearchParams
 from src.shared.schemas.basic import TicketMessageOut
 from src.shared.schemas.paginated import PaginatedResponse
 from src.core.services.ticket_management import TicketManager
+from src.shared.utils.date_format import format_db_datetime
 
 from .deps import get_db, get_db_with_commit, extract_filters
 
@@ -224,7 +225,7 @@ async def create_ticket_endpoint(
     ticket: TicketCreate, db: AsyncSession = Depends(get_db_with_commit)
 ) -> TicketOut:
     payload = ticket.model_dump()
-    payload["Created_Date"] = datetime.now(timezone.utc)
+    payload["Created_Date"] = format_db_datetime(datetime.now(timezone.utc))
     result = await create_ticket(db, payload)
     if not result.success:
         logger.error("Ticket creation failed: %s", result.error)
@@ -245,7 +246,7 @@ async def create_ticket_json(
     db: AsyncSession = Depends(get_db_with_commit),
 ) -> TicketExpandedOut:
     data = payload.model_dump()
-    data["Created_Date"] = datetime.now(timezone.utc)
+    data["Created_Date"] = format_db_datetime(datetime.now(timezone.utc))
     result = await create_ticket(db, data)
     if not result.success:
         logger.error("Ticket creation failed: %s", result.error)

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -53,6 +53,7 @@ from src.core.services.ticket_management import _OPEN_STATE_IDS
 from src.core.services.enhanced_context import EnhancedContextManager
 from src.core.services.advanced_query import AdvancedQueryManager
 from src.shared.schemas.agent_data import AdvancedQuery
+from src.shared.utils.date_format import format_db_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -572,8 +573,9 @@ async def _create_ticket(**payload: Any) -> Dict[str, Any]:
         data_in = validated.model_dump()
         async with db.SessionLocal() as db_session:
             now = datetime.now(timezone.utc)
-            data_in["Created_Date"] = data_in.get("Created_Date") or now
-            data_in["LastModified"] = data_in.get("LastModified") or now
+            formatted_now = format_db_datetime(now)
+            data_in["Created_Date"] = data_in.get("Created_Date") or formatted_now
+            data_in["LastModified"] = data_in.get("LastModified") or formatted_now
             data_in["LastModfiedBy"] = data_in.get("LastModfiedBy") or "Gil AI"
 
             result = await TicketManager().create_ticket(db_session, data_in)

--- a/tests/test_ticket_date_regression.py
+++ b/tests/test_ticket_date_regression.py
@@ -1,0 +1,38 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import text
+
+from main import app
+from src.infrastructure.database import SessionLocal
+from src.shared.utils.date_format import parse_db_datetime
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_stores_formatted_date(client: AsyncClient):
+    payload = {
+        "Subject": "Date regression",
+        "Ticket_Body": "ensure date formatting",
+        "Ticket_Contact_Name": "Tester",
+        "Ticket_Contact_Email": "tester@example.com",
+    }
+    resp = await client.post("/ticket", json=payload)
+    assert resp.status_code == 201
+    tid = resp.json()["Ticket_ID"]
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            text("SELECT Created_Date FROM Tickets_Master WHERE Ticket_ID=:id"),
+            {"id": tid},
+        )
+        created_raw = result.scalar_one()
+
+    # Should be parseable without raising
+    parse_db_datetime(created_raw)


### PR DESCRIPTION
## Summary
- format Created_Date when creating tickets via API or JSON routes
- apply same timestamp formatting in Enhanced MCP server ticket creation
- add regression test covering ticket creation date formatting

## Testing
- `pytest tests/test_ticket_date_regression.py tests/test_routes.py::test_create_and_get_ticket -q`


------
https://chatgpt.com/codex/tasks/task_e_6892af8934d4832b911aa9d2a3d99125