### PR TITLE
Use datetime objects for ticket creation

### DIFF
--- a/src/api/v1/tickets.py
+++ b/src/api/v1/tickets.py
@@ -22,7 +22,6 @@ from src.shared.schemas.search_params import TicketSearchParams
 from src.shared.schemas.basic import TicketMessageOut
 from src.shared.schemas.paginated import PaginatedResponse
 from src.core.services.ticket_management import TicketManager
-from src.shared.utils.date_format import format_db_datetime
 
 from .deps import get_db, get_db_with_commit, extract_filters
 
@@ -225,7 +224,7 @@ async def create_ticket_endpoint(
     ticket: TicketCreate, db: AsyncSession = Depends(get_db_with_commit)
 ) -> TicketOut:
     payload = ticket.model_dump()
-    payload["Created_Date"] = format_db_datetime(datetime.now(timezone.utc))
+    payload["Created_Date"] = datetime.now(timezone.utc)
     result = await create_ticket(db, payload)
     if not result.success:
         logger.error("Ticket creation failed: %s", result.error)
@@ -246,7 +245,7 @@ async def create_ticket_json(
     db: AsyncSession = Depends(get_db_with_commit),
 ) -> TicketExpandedOut:
     data = payload.model_dump()
-    data["Created_Date"] = format_db_datetime(datetime.now(timezone.utc))
+    data["Created_Date"] = datetime.now(timezone.utc)
     result = await create_ticket(db, data)
     if not result.success:
         logger.error("Ticket creation failed: %s", result.error)

--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -2,6 +2,9 @@ from sqlalchemy import Column, Integer, String, Text, Boolean
 from src.shared.utils.date_format import FormattedDateTime
 from sqlalchemy.orm import DeclarativeBase
 
+# ``FormattedDateTime`` ensures datetime values are stored with millisecond
+# precision and handles formatting transparently.
+
 
 class Base(DeclarativeBase):
     pass


### PR DESCRIPTION
## Summary
- Replace manual Created_Date string formatting with `datetime.now(timezone.utc)` and rely on SQLAlchemy's `FormattedDateTime` for serialization
- Document that `FormattedDateTime` provides millisecond precision for timestamps

## Testing
- `pytest tests/test_additional_tools.py::test_get_ticket_messages_success -q -W ignore`
- `pytest tests/test_additional_tools.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6892b59efb04832ba517529c898bf034