### PR TITLE
Default sender name to code

### DIFF
--- a/src/api/v1/tickets.py
+++ b/src/api/v1/tickets.py
@@ -37,7 +37,7 @@ tickets_router = APIRouter(prefix="/tickets", tags=["tickets"])
 class MessageIn(BaseModel):
     message: str = Field(..., example="Thanks for the update")
     sender_code: str = Field(..., example="USR123")
-    sender_name: str = Field(..., example="John Doe")
+    sender_name: Optional[str] = Field(None, example="John Doe")
 
 
 class SearchBody(BaseModel):
@@ -322,7 +322,7 @@ async def add_ticket_message(
     db: AsyncSession = Depends(get_db_with_commit),
 ) -> TicketMessageOut:
     created = await TicketManager().post_message(
-        db, ticket_id, msg.message, msg.sender_code, msg.sender_name
+        db, ticket_id, msg.message, msg.sender_code, sender_name=msg.sender_name
     )
     return TicketMessageOut.model_validate(created)
 

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -594,13 +594,13 @@ class TicketManager:
         ticket_id: int,
         message: str,
         sender_code: str,
-        sender_name: str,
+        sender_name: Optional[str] = None,
     ) -> TicketMessage:
         msg = TicketMessage(
             Ticket_ID=ticket_id,
             Message=message,
             SenderUserCode=sender_code,
-            SenderUserName=sender_name,
+            SenderUserName=sender_name if sender_name is not None else sender_code,
             DateTimeStamp=datetime.now(timezone.utc),
         )
         db.add(msg)

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -689,7 +689,7 @@ async def _update_ticket(ticket_id: int, updates: Dict[str, Any]) -> Dict[str, A
                         ticket_id,
                         message,
                         applied_updates.get("Assigned_Email", "system"),
-                        applied_updates.get("Assigned_Name", "System"),
+                        sender_name=applied_updates.get("Assigned_Name"),
                     )
 
                 await db_session.commit()
@@ -808,7 +808,7 @@ async def _add_ticket_message(
                 ticket_id,
                 message,
                 sender_code or sender_name,
-                sender_name,
+                sender_name=sender_name,
             )
             
             await db_session.commit()

--- a/tests/test_ticket_messages.py
+++ b/tests/test_ticket_messages.py
@@ -20,4 +20,13 @@ async def test_post_message_db_error(monkeypatch):
         monkeypatch.setattr(db, "rollback", dummy_rollback)
 
         with pytest.raises(DatabaseError):
-            await manager.post_message(db, 1, "oops", "u", "u")
+
+            await manager.post_message(db, 1, "oops", "u")
+
+
+@pytest.mark.asyncio
+async def test_post_message_defaults_sender_name():
+    manager = TicketManager()
+    async with SessionLocal() as db:
+        msg = await manager.post_message(db, 1, "hello", "u")
+        assert msg.SenderUserName == "u"


### PR DESCRIPTION
## Summary
- allow `post_message` to omit `sender_name`, defaulting to `sender_code`
- make ticket message API `sender_name` optional and update internal callers
- add regression test for defaulting sender name

## Testing
- `pytest tests/test_ticket_messages.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b956a210832ba9b9dc81148989f2