### PR TITLE
Remove duplicate Ticket columns and ensure schema uniqueness

### DIFF
--- a/alembic/versions/b88292336e8c_remove_duplicate_ticket_columns.py
+++ b/alembic/versions/b88292336e8c_remove_duplicate_ticket_columns.py
@@ -1,0 +1,26 @@
+"""remove duplicate ticket columns
+
+Revision ID: b88292336e8c
+Revises: a3c896922b31
+Create Date: 2025-08-06 02:14:28.494207
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b88292336e8c'
+down_revision: Union[str, None] = 'a3c896922b31'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -29,11 +29,6 @@ class Ticket(Base):
     Severity_ID = Column(Integer)
     Assigned_Vendor_ID = Column(Integer)
 
-    Most_Recent_Service_Scheduled_ID = Column(Integer)
-    Watchers = Column(Text)
-    MetaData = Column(Text)
-    ValidFrom = Column(FormattedDateTime())
-    ValidTo = Column(FormattedDateTime())
 
     Closed_Date = Column(FormattedDateTime())
     LastModified = Column(FormattedDateTime())
@@ -41,7 +36,7 @@ class Ticket(Base):
     Resolution = Column(Text)
     Most_Recent_Service_Scheduled_ID = Column(Integer, nullable=True)
     LastCreatedBy = Column(String, nullable=True)
-    Watchers = Column(String, nullable=True)
+    Watchers = Column(Text, nullable=True)
     EstimatedCompletionDate = Column(FormattedDateTime(), nullable=True)
     CustomCompletionDate = Column(FormattedDateTime(), nullable=True)
     EstimatedCompletionDateAsInt = Column(Integer, nullable=True)

--- a/tests/test_ticket_columns_unique.py
+++ b/tests/test_ticket_columns_unique.py
@@ -1,0 +1,7 @@
+from src.core.repositories.models import Ticket
+
+
+def test_ticket_columns_are_unique():
+    column_names = [col.name for col in Ticket.__table__.columns]
+    duplicates = {name for name in column_names if column_names.count(name) > 1}
+    assert len(column_names) == len(set(column_names)), f"Duplicate columns found: {duplicates}"


### PR DESCRIPTION
## Summary
- clean up repeated column definitions in the Ticket model
- generate an Alembic migration placeholder for the cleaned model
- add regression test checking Ticket columns are unique

## Testing
- `alembic upgrade heads` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*
- `pytest tests/test_ticket_columns_unique.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b957c4cc832b87883928878ab242