### PR TITLE
Add explicit Created_Date in additional tools tests

### DIFF
--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -7,6 +7,7 @@ from main import app
 from src.infrastructure.database import SessionLocal
 from src.core.repositories.models import TicketAttachment, Priority, Ticket
 from src.core.services.ticket_management import TicketManager
+from src.shared.utils.date_format import format_db_datetime
 
 
 @pytest_asyncio.fixture
@@ -22,6 +23,7 @@ def _ticket_payload(subject: str = "Tool test") -> dict:
         "Ticket_Body": "Body",
         "Ticket_Contact_Name": "Tester",
         "Ticket_Contact_Email": "tester@example.com",
+        "Created_Date": format_db_datetime(datetime.now(UTC)),
     }
 
 


### PR DESCRIPTION
## Summary
- ensure test ticket payloads include an explicit Created_Date matching production defaults

## Testing
- `pytest tests/test_additional_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892bce94c50832b88f7a0baa65e5b6d