### PR TITLE
Trim microseconds in search datetime

### DIFF
--- a/src/core/services/system_utilities.py
+++ b/src/core/services/system_utilities.py
@@ -46,23 +46,22 @@ def parse_search_datetime(value: datetime | str | None) -> datetime | None:
     if isinstance(value, datetime):
         dt = value
     else:
-        date_str = value
+        date_str = value.strip()
         try:
             # First attempt database-specific format
             dt = parse_db_datetime(date_str)
         except ValueError:
-            dt = None
-        if dt is None:
             try:
                 if date_str.endswith("Z"):
                     date_str = date_str[:-1] + "+00:00"
                 dt = datetime.fromisoformat(date_str)
-            except ValueError:
-                raise ValueError(f"Invalid datetime format: {date_str}")
+            except ValueError as exc:
+                raise ValueError(f"Invalid datetime format: {value}") from exc
 
     # Normalize microseconds to milliseconds precision to match DB expectations
-    if dt.microsecond % 1000:
-        dt = dt.replace(microsecond=(dt.microsecond // 1000) * 1000)
+    micro = (dt.microsecond // 1000) * 1000
+    if dt.microsecond != micro:
+        dt = dt.replace(microsecond=micro)
 
     return dt
 

--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -24,3 +24,9 @@ def test_formatted_datetime_truncates_string_input():
     typ = FormattedDateTime()
     text = "2023-01-02 03:04:05.987654"
     assert typ.process_bind_param(text, None) == "2023-01-02 03:04:05.987"
+
+
+def test_parse_search_datetime_trims_microseconds():
+    text = "2025-08-06 02:20:22.485621"
+    dt = parse_search_datetime(text)
+    assert format_db_datetime(dt) == "2025-08-06 02:20:22.485"


### PR DESCRIPTION
## Summary
- tighten parse_search_datetime to strip inputs, handle invalid formats, and truncate to millisecond precision
- test date formatting helper with microsecond trimming

## Testing
- `pytest tests/test_date_format.py -q`
- `pytest tests/test_ticket_lifecycle.py::test_ticket_full_lifecycle -q`


------
https://chatgpt.com/codex/tasks/task_e_6892bcdec910832b8f897bad7b6a199d