### PR TITLE
Log offending field in DataError during ticket creation

### DIFF
--- a/src/api/v1/tickets.py
+++ b/src/api/v1/tickets.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ast
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, List, Optional, Dict
 
@@ -55,6 +57,31 @@ class SearchBody(BaseModel):
 async def create_ticket(db: AsyncSession, obj: Dict) -> Any:
     """Wrapper around TicketManager.create_ticket for easier testing."""
     return await TicketManager().create_ticket(db, obj)
+
+
+def _extract_data_error_field(error: str) -> tuple[str, Any] | None:
+    """Attempt to pull the offending column and value from a DB error message."""
+    if not error:
+        return None
+    # Try to capture parameters dictionary from the error string
+    params: Dict[str, Any] | None = None
+    match_params = re.search(r"parameters:\s*({.*?})", error)
+    if match_params:
+        try:
+            params = ast.literal_eval(match_params.group(1))
+        except Exception:
+            params = None
+    # Look for explicit column mention first
+    match_col = re.search(r'column "([^"]+)"', error)
+    if match_col:
+        col = match_col.group(1)
+        if isinstance(params, dict) and col in params:
+            return col, params[col]
+        return col, None
+    if isinstance(params, dict) and params:
+        # Fallback to first parameter if no column found
+        return next(iter(params.items()))
+    return None
 
 
 @ticket_router.get(
@@ -228,6 +255,16 @@ async def create_ticket_endpoint(
     payload["Created_Date"] = format_db_datetime(datetime.now(timezone.utc))
     result = await create_ticket(db, payload)
     if not result.success:
+        field_val = _extract_data_error_field(result.error or "")
+        if field_val:
+            field, value = field_val
+            logger.error(
+                "Ticket creation failed for %s=%r: %s", field, value, result.error
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"{result.error} (field {field}={value})",
+            )
         logger.error("Ticket creation failed: %s", result.error)
         raise HTTPException(status_code=500, detail=result.error or "ticket create failed")
     return TicketOut.model_validate(result.data)
@@ -249,6 +286,16 @@ async def create_ticket_json(
     data["Created_Date"] = format_db_datetime(datetime.now(timezone.utc))
     result = await create_ticket(db, data)
     if not result.success:
+        field_val = _extract_data_error_field(result.error or "")
+        if field_val:
+            field, value = field_val
+            logger.error(
+                "Ticket creation failed for %s=%r: %s", field, value, result.error
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"{result.error} (field {field}={value})",
+            )
         logger.error("Ticket creation failed: %s", result.error)
         raise HTTPException(status_code=500, detail=result.error or "ticket create failed")
     ticket = await TicketManager().get_ticket(db, result.data.Ticket_ID)

--- a/tests/test_ticket_data_error.py
+++ b/tests/test_ticket_data_error.py
@@ -1,0 +1,37 @@
+import logging
+
+from fastapi.testclient import TestClient
+
+from main import app
+from src.core.services.system_utilities import OperationResult
+client = TestClient(app)
+
+
+def test_create_ticket_logs_dataerror_field(monkeypatch, caplog):
+    """Ensure DataError details include offending field and value."""
+
+    async def fail_create(db, obj):
+        err = (
+            '(psycopg2.errors.InvalidDatetimeFormat) invalid input syntax for type '
+            'timestamp: "bad" [parameters: {"ValidFrom": "bad"}]'
+        )
+        return OperationResult(success=False, error=err)
+
+    monkeypatch.setattr("src.api.v1.tickets.create_ticket", fail_create)
+
+    payload = {
+        "Subject": "Bad Date",
+        "Ticket_Body": "body",
+        "Ticket_Contact_Name": "Tester",
+        "Ticket_Contact_Email": "tester@example.com",
+    }
+
+    with caplog.at_level(logging.ERROR):
+        resp = client.post("/ticket", json=payload)
+
+    assert resp.status_code == 500
+    detail = resp.json()["detail"]
+    assert "ValidFrom" in detail
+    assert "bad" in detail
+    assert any("ValidFrom" in r.message and "bad" in r.message for r in caplog.records)
+


### PR DESCRIPTION
## Summary
- capture offending field/value from DB DataError when ticket creation fails
- log and surface those details in ticket creation endpoints
- test logging of invalid datetime during ticket creation

## Testing
- `pytest tests/test_ticket_data_error.py tests/test_ticket_lifecycle.py::test_ticket_full_lifecycle -q`


------
https://chatgpt.com/codex/tasks/task_e_6892bcdbdad4832bbc399e7ae2ce96e8