### PR TITLE
Rename Priority Level column to Label

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ SELECT t.Ticket_ID,
        t.Version,
        v.Name AS Assigned_Vendor_Name,
        t.Resolution,
-       p.Level AS Priority_Level
+       p.Label AS Priority_Level
 FROM Tickets_Master t
 LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
 LEFT JOIN Assets a ON a.ID = t.Asset_ID

--- a/alembic/versions/c1b9e2b8163b_rename_priority_level_column.py
+++ b/alembic/versions/c1b9e2b8163b_rename_priority_level_column.py
@@ -1,0 +1,28 @@
+"""rename priority level column to label
+
+Revision ID: c1b9e2b8163b
+Revises: b88292336e8c, 237fcdff6dee
+Create Date: 2025-10-08 00:00:00
+"""
+
+from typing import Sequence, Union
+from alembic import op  # type: ignore[attr-defined]
+import sqlalchemy as sa
+
+
+revision: str = "c1b9e2b8163b"
+down_revision: Union[str, Sequence[str], None] = (
+    "b88292336e8c",
+    "237fcdff6dee",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("Priority_Levels", "Level", new_column_name="Label")
+
+
+def downgrade() -> None:
+    op.alter_column("Priority_Levels", "Label", new_column_name="Level")
+

--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -117,7 +117,7 @@ class TicketStatus(Base):
 class Priority(Base):
     __tablename__ = "Priority_Levels"
     ID = Column(Integer, primary_key=True, index=True)
-    Level = Column(String)
+    Label = Column(String)
 
 
 class OnCallShift(Base):

--- a/src/core/repositories/sql.py
+++ b/src/core/repositories/sql.py
@@ -24,7 +24,7 @@ SELECT t.Ticket_ID,
        t.LastModfiedBy,
        v.Name AS Assigned_Vendor_Name,
        t.Resolution,
-       p.Level AS Priority_Level
+       p.Label AS Priority_Level
 FROM Tickets_Master t
 LEFT JOIN Ticket_Status ts ON ts.ID = t.Ticket_Status_ID
 LEFT JOIN Assets a ON a.ID = t.Asset_ID

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -1137,7 +1137,7 @@ async def _get_reference_data_unified(
                 if limit:
                     records = records[:limit]
                 field = "Priority_Level"
-                ids = [r.Level for r in records]
+                ids = [r.Label for r in records]
             elif type == "statuses":
                 result = await db_session.execute(select(TicketStatus).order_by(TicketStatus.ID))
                 records = result.scalars().all()
@@ -1165,10 +1165,10 @@ async def _get_reference_data_unified(
                 if type == "priorities":
                     item = {
                         "id": r.ID,
-                        "level": r.Level,
-                        "semantic_name": _PRIORITY_MAP.get(r.Level.lower(), r.Level) if r.Level else None,
+                        "level": r.Label,
+                        "semantic_name": _PRIORITY_MAP.get(r.Label.lower(), r.Label) if r.Label else None,
                     }
-                    key = r.Level
+                    key = r.Label
                 else:
                     key = r.ID
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,8 +71,8 @@ def clear_analytics_cache():
 @pytest_asyncio.fixture
 async def sample_priorities():
     async with mssql.SessionLocal() as db:
-        low = Priority(Level="Low")
-        high = Priority(Level="High")
+        low = Priority(Label="Low")
+        high = Priority(Label="High")
         db.add_all([low, high])
         await db.commit()
         await db.refresh(low)

--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -207,8 +207,8 @@ async def test_escalate_ticket_error(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_get_reference_data_priorities_success(client: AsyncClient):
     async with SessionLocal() as db:
-        p1 = Priority(Level="Low")
-        p2 = Priority(Level="High")
+        p1 = Priority(Label="Low")
+        p2 = Priority(Label="High")
         db.add_all([p1, p2])
         await db.commit()
     resp = await client.post("/get_reference_data", json={"type": "priorities"})

--- a/tests/test_priority_model.py
+++ b/tests/test_priority_model.py
@@ -1,0 +1,15 @@
+import pytest
+from sqlalchemy import select
+import src.infrastructure.database as mssql
+from src.core.repositories.models import Priority
+
+
+@pytest.mark.asyncio
+async def test_priority_insert_select():
+    async with mssql.SessionLocal() as db:
+        urgent = Priority(Label="Urgent")
+        db.add(urgent)
+        await db.commit()
+        result = await db.execute(select(Priority).where(Priority.Label == "Urgent"))
+        fetched = result.scalar_one()
+        assert fetched.Label == "Urgent"


### PR DESCRIPTION
## Summary
- rename Priority ORM column to match actual `Priority_Levels.Label` field
- adjust queries, services, and seeds to use `Label`
- add migration and tests verifying priority insert/select

## Testing
- `alembic upgrade head` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*
- `pytest tests/test_priority_model.py tests/test_additional_tools.py::test_get_reference_data_priorities_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68940d114e58832b82507ea8dae322ef