### PR TITLE
Validate days param in ticket search

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -450,10 +450,15 @@ class TicketManager:
         if created_after:
             created_after_dt = parse_search_datetime(created_after)
             stmt = stmt.filter(VTicketMasterExpanded.Created_Date >= created_after_dt)
-        elif days is not None and days >= 0:
-            cutoff = datetime.now(timezone.utc) - timedelta(days=days)
-            cutoff = parse_search_datetime(cutoff)
-            stmt = stmt.filter(VTicketMasterExpanded.Created_Date >= cutoff)
+        elif days is not None:
+            if isinstance(days, int) and days >= 0:
+                cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+                cutoff = parse_search_datetime(cutoff)
+                stmt = stmt.filter(
+                    VTicketMasterExpanded.Created_Date >= cutoff
+                )
+            else:
+                raise ValueError("days must be a non-negative integer")
 
         if created_before:
             created_before_dt = parse_search_datetime(created_before)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -196,3 +196,23 @@ async def test_search_datetime_and_days_filters():
 
         res, _ = await TicketManager().search_tickets(db, "MicroDate", days=2)
         assert {r.Ticket_ID for r in res} == {new.Ticket_ID}
+
+
+@pytest.mark.asyncio
+async def test_search_tickets_without_days_does_not_raise():
+    async with SessionLocal() as db:
+        t = Ticket(
+            Subject="NoDays",
+            Ticket_Body="body",
+            Created_Date=datetime.now(UTC),
+            Ticket_Status_ID=1,
+        )
+        await TicketManager().create_ticket(db, t)
+        await db.commit()
+
+        try:
+            res, _ = await TicketManager().search_tickets(db, "NoDays")
+        except TypeError as exc:
+            pytest.fail(f"search_tickets raised TypeError: {exc}")
+
+        assert any(r.Ticket_ID == t.Ticket_ID for r in res)


### PR DESCRIPTION
## Summary
- validate optional `days` parameter in ticket searches and raise clear errors for invalid values
- add regression test ensuring `search_tickets` handles missing `days`

## Testing
- `pytest tests/test_search.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68940d0bc958832bbfa26212e699355b