### PR TITLE
Handle optional sender names in ticket messages

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -630,7 +630,7 @@ class TicketManager:
         ticket_id: int,
         message: str,
         sender_code: str,
-        sender_name: Optional[str] = None,
+        sender_name: str | None = None,
     ) -> TicketMessage:
         msg = TicketMessage(
             Ticket_ID=ticket_id,

--- a/tests/test_ticket_messages.py
+++ b/tests/test_ticket_messages.py
@@ -20,13 +20,20 @@ async def test_post_message_db_error(monkeypatch):
         monkeypatch.setattr(db, "rollback", dummy_rollback)
 
         with pytest.raises(DatabaseError):
-
-            await manager.post_message(db, 1, "oops", "u")
+            await manager.post_message(db, 1, "oops", "u", sender_name=None)
 
 
 @pytest.mark.asyncio
 async def test_post_message_defaults_sender_name():
     manager = TicketManager()
     async with SessionLocal() as db:
-        msg = await manager.post_message(db, 1, "hello", "u")
+        msg = await manager.post_message(db, 1, "hello", "u", sender_name=None)
         assert msg.SenderUserName == "u"
+
+
+@pytest.mark.asyncio
+async def test_post_message_with_sender_name():
+    manager = TicketManager()
+    async with SessionLocal() as db:
+        msg = await manager.post_message(db, 1, "hi", "u", sender_name="Alice")
+        assert msg.SenderUserName == "Alice"


### PR DESCRIPTION
## Summary
- Ensure `TicketManager.post_message` takes an optional sender name with default `None`
- Use keyword argument for `sender_name` in tests and add coverage for explicit sender names

## Testing
- `pytest tests/test_ticket_messages.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68941273d45c832baeb18863bce9539e