### PR TITLE
chore: remove unused sqlalchemy text import

### DIFF
--- a/src/core/services/advanced_query.py
+++ b/src/core/services/advanced_query.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
 
-from sqlalchemy import select, func, and_, or_, text
+from sqlalchemy import select, func, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.repositories.models import VTicketMasterExpanded, TicketMessage, TicketAttachment


### PR DESCRIPTION
## Summary
- tidy advanced query service by removing unused `text` import from SQLAlchemy

## Testing
- `pytest -q --maxfail=1` *(fails: TypeError: ASGITransport.__init__() got an unexpected keyword argument 'lifespan')*

------
https://chatgpt.com/codex/tasks/task_e_689422381488832bb0204a7f97a0fe08