### PR TITLE
Use RuntimeError for ticket creation failure

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -582,7 +582,7 @@ async def _create_ticket(**payload: Any) -> Dict[str, Any]:
             result = await TicketManager().create_ticket(db_session, data_in)
             if not result.success:
                 await db_session.rollback()
-                raise Exception(result.error or "Failed to create ticket")
+                raise RuntimeError(result.error or "Failed to create ticket")
 
             await db_session.commit()
 


### PR DESCRIPTION
## Summary
- replace generic Exception with RuntimeError when ticket creation fails to surface the original message

## Testing
- `pytest tests/test_additional_tools.py::test_create_ticket_ms_precision -q` *(fails: ASGITransport.__init__() got an unexpected keyword argument 'lifespan')*

------
https://chatgpt.com/codex/tasks/task_e_689422384ddc832b88bd10939b903c82