### PR TITLE
Use timezone-aware timestamps in advanced query

### DIFF
--- a/src/core/services/advanced_query.py
+++ b/src/core/services/advanced_query.py
@@ -24,7 +24,7 @@ class AdvancedQueryManager:
     async def query_tickets_advanced(self, query: AdvancedQuery) -> QueryResult:
         """Execute advanced ticket query with rich results."""
 
-        start_time = datetime.now()
+        start_time = datetime.now(timezone.utc)
 
         # Build base query
         stmt = select(VTicketMasterExpanded)
@@ -155,7 +155,7 @@ class AdvancedQueryManager:
             ticket_dicts.append(ticket_dict)
 
         # Calculate execution time
-        end_time = datetime.now()
+        end_time = datetime.now(timezone.utc)
         execution_time = (end_time - start_time).total_seconds() * 1000
 
         # Generate aggregations


### PR DESCRIPTION
## Summary
- use timezone-aware `datetime.now(timezone.utc)` for start and end time tracking

## Testing
- `pytest -q` *(fails: ASGITransport.__init__() got an unexpected keyword argument 'lifespan')*


------
https://chatgpt.com/codex/tasks/task_e_6894223b1600832bb47e5f9137eeb648