### PR TITLE
Handle date objects in FormattedDateTime result processing

### DIFF
--- a/src/shared/utils/date_format.py
+++ b/src/shared/utils/date_format.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, date, timezone
 
 DB_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
@@ -70,6 +70,8 @@ class FormattedDateTime(TypeDecorator):
             return None
         if isinstance(value, datetime):
             return value
+        if isinstance(value, date) and not isinstance(value, datetime):
+            return datetime.combine(value, datetime.min.time(), tzinfo=timezone.utc)
         if isinstance(value, str):
             return parse_db_datetime(value)
         raise TypeError(f"Unexpected DB value type: {type(value)}")

--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, date, UTC
 
 from src.core.services.system_utilities import parse_search_datetime
 from src.shared.utils.date_format import format_db_datetime, FormattedDateTime
@@ -30,3 +30,12 @@ def test_parse_search_datetime_trims_microseconds():
     text = "2025-08-06 02:20:22.485621"
     dt = parse_search_datetime(text)
     assert format_db_datetime(dt) == "2025-08-06 02:20:22.485"
+
+
+def test_process_result_value_converts_date_to_datetime():
+    typ = FormattedDateTime()
+    value = date(2024, 7, 5)
+    result = typ.process_result_value(value, None)
+    assert isinstance(result, datetime)
+    assert result == datetime(2024, 7, 5, tzinfo=UTC)
+    assert result.microsecond % 1000 == 0


### PR DESCRIPTION
## Summary
- Convert `datetime.date` DB results to UTC-aware `datetime` at midnight
- Test `FormattedDateTime.process_result_value` with `date` input

## Testing
- `pytest tests/test_date_format.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6896cbfee354832b99aebd2125d33a97