### PR TITLE
Map Y/N flags to booleans for tickets

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, Boolean, LargeBinary
+from sqlalchemy import Column, Integer, String, Text, Boolean, LargeBinary, TypeDecorator
 from src.shared.utils.date_format import FormattedDateTime
 from sqlalchemy.orm import DeclarativeBase
 
@@ -8,6 +8,23 @@ from sqlalchemy.orm import DeclarativeBase
 
 class Base(DeclarativeBase):
     pass
+
+
+class YNBoolean(TypeDecorator):
+    """Store boolean values as single-character ``'Y'``/``'N'`` strings."""
+
+    impl = String(1)
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        return "Y" if value else "N"
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        return value == "Y"
 
 
 class Ticket(Base):
@@ -41,8 +58,8 @@ class Ticket(Base):
     CustomCompletionDate = Column(FormattedDateTime(), nullable=True)
     EstimatedCompletionDateAsInt = Column(Integer, nullable=True)
     RV = Column(String, nullable=True)
-    HasServiceRequest = Column(Boolean, nullable=True)
-    Private = Column(Boolean, nullable=True)
+    HasServiceRequest = Column(YNBoolean(), nullable=True)
+    Private = Column(YNBoolean(), nullable=True)
     Collab_Emails = Column(String, nullable=True)
     OrderFormHTML = Column(Text, nullable=True)
     LastModifiedAsInt = Column(Integer, nullable=True)

--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -20,6 +20,8 @@ class TicketBase(BaseModel):
     Most_Recent_Service_Scheduled_ID: Optional[int] = None
     Watchers: Optional[str] = None
     MetaData: Optional[str] = None
+    HasServiceRequest: Optional[bool] = None
+    Private: Optional[bool] = None
     ValidFrom: Optional[datetime] = None
     ValidTo: Optional[datetime] = None
     Resolution: Optional[Annotated[str, Field()]] = None
@@ -28,6 +30,15 @@ class TicketBase(BaseModel):
     def _clean_assigned_email(cls, v):
         if isinstance(v, str) and not v.strip():
             return None
+        return v
+
+    @field_validator("HasServiceRequest", "Private", mode="before")
+    def _parse_yn_bool(cls, v):
+        if isinstance(v, str):
+            if v.upper() == "Y":
+                return True
+            if v.upper() == "N":
+                return False
         return v
 
     model_config = ConfigDict(str_max_length=None)
@@ -86,6 +97,8 @@ class TicketUpdate(BaseModel):
     Most_Recent_Service_Scheduled_ID: Optional[int] = None
     Watchers: Optional[str] = None
     MetaData: Optional[str] = None
+    HasServiceRequest: Optional[bool] = None
+    Private: Optional[bool] = None
     ValidFrom: Optional[datetime] = None
     ValidTo: Optional[datetime] = None
     Resolution: Optional[str] = None
@@ -95,6 +108,15 @@ class TicketUpdate(BaseModel):
         if not values.model_fields_set:
             raise ValueError("At least one field must be supplied")
         return values
+
+    @field_validator("HasServiceRequest", "Private", mode="before")
+    def _parse_yn_bool(cls, v):
+        if isinstance(v, str):
+            if v.upper() == "Y":
+                return True
+            if v.upper() == "N":
+                return False
+        return v
 
     model_config = ConfigDict(
         extra="forbid",


### PR DESCRIPTION
## Summary
- Map `HasServiceRequest` and `Private` columns to single-character `Y`/`N` with a SQLAlchemy type decorator
- Expose `HasServiceRequest` and `Private` on ticket schemas as booleans accepting `Y`/`N`

## Testing
- `flake8 src/core/repositories/models.py src/shared/schemas/ticket.py`
- `pytest` *(fails: ValueError I/O operation on closed file)*

------
https://chatgpt.com/codex/tasks/task_e_6896d64c5a64832b97055a373831fcd2