### PR TITLE
Use date type for ticket completion dates

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, Boolean, LargeBinary
+from sqlalchemy import Column, Integer, String, Text, Boolean, LargeBinary, Date
 from src.shared.utils.date_format import FormattedDateTime
 from sqlalchemy.orm import DeclarativeBase
 
@@ -37,8 +37,8 @@ class Ticket(Base):
     Most_Recent_Service_Scheduled_ID = Column(Integer, nullable=True)
     LastCreatedBy = Column(String, nullable=True)
     Watchers = Column(Text, nullable=True)
-    EstimatedCompletionDate = Column(FormattedDateTime(), nullable=True)
-    CustomCompletionDate = Column(FormattedDateTime(), nullable=True)
+    EstimatedCompletionDate = Column(Date(), nullable=True)
+    CustomCompletionDate = Column(Date(), nullable=True)
     EstimatedCompletionDateAsInt = Column(Integer, nullable=True)
     RV = Column(String, nullable=True)
     HasServiceRequest = Column(Boolean, nullable=True)

--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel, EmailStr, Field, ConfigDict, field_validator, model_validator
-from typing import Annotated
-from typing import Optional
-from datetime import datetime
+from typing import Annotated, Optional, Any
+from datetime import datetime, date
 
 
 class TicketBase(BaseModel):
@@ -20,6 +19,8 @@ class TicketBase(BaseModel):
     Most_Recent_Service_Scheduled_ID: Optional[int] = None
     Watchers: Optional[str] = None
     MetaData: Optional[str] = None
+    EstimatedCompletionDate: Optional[date] = None
+    CustomCompletionDate: Optional[date] = None
     ValidFrom: Optional[datetime] = None
     ValidTo: Optional[datetime] = None
     Resolution: Optional[Annotated[str, Field()]] = None
@@ -28,6 +29,20 @@ class TicketBase(BaseModel):
     def _clean_assigned_email(cls, v):
         if isinstance(v, str) and not v.strip():
             return None
+        return v
+
+    @field_validator("EstimatedCompletionDate", "CustomCompletionDate", mode="before")
+    def _coerce_date(cls, v: Any):
+        if isinstance(v, datetime):
+            return v.date()
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return None
+            if "T" in v:
+                v = v.split("T", 1)[0]
+            if " " in v:
+                v = v.split(" ", 1)[0]
         return v
 
     model_config = ConfigDict(str_max_length=None)
@@ -86,6 +101,8 @@ class TicketUpdate(BaseModel):
     Most_Recent_Service_Scheduled_ID: Optional[int] = None
     Watchers: Optional[str] = None
     MetaData: Optional[str] = None
+    EstimatedCompletionDate: Optional[date] = None
+    CustomCompletionDate: Optional[date] = None
     ValidFrom: Optional[datetime] = None
     ValidTo: Optional[datetime] = None
     Resolution: Optional[str] = None
@@ -108,6 +125,20 @@ class TicketUpdate(BaseModel):
         },
     )
 
+    @field_validator("EstimatedCompletionDate", "CustomCompletionDate", mode="before")
+    def _coerce_date(cls, v: Any):
+        if isinstance(v, datetime):
+            return v.date()
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return None
+            if "T" in v:
+                v = v.split("T", 1)[0]
+            if " " in v:
+                v = v.split(" ", 1)[0]
+        return v
+
 
 class TicketIn(TicketBase):
     Subject: Optional[Annotated[str, Field(max_length=255)]] = None
@@ -126,12 +157,28 @@ class TicketIn(TicketBase):
     Most_Recent_Service_Scheduled_ID: Optional[int] = None
     Watchers: Optional[str] = None
     MetaData: Optional[str] = None
+    EstimatedCompletionDate: Optional[date] = None
+    CustomCompletionDate: Optional[date] = None
     ValidFrom: Optional[datetime] = None
     ValidTo: Optional[datetime] = None
     Resolution: Optional[Annotated[str, Field()]] = None
     Version: Optional[int] = None
 
     model_config = ConfigDict(extra="forbid", str_max_length=None)
+
+    @field_validator("EstimatedCompletionDate", "CustomCompletionDate", mode="before")
+    def _coerce_date(cls, v: Any):
+        if isinstance(v, datetime):
+            return v.date()
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return None
+            if "T" in v:
+                v = v.split("T", 1)[0]
+            if " " in v:
+                v = v.split(" ", 1)[0]
+        return v
 
 
 class TicketOut(TicketIn):


### PR DESCRIPTION
## Summary
- store EstimatedCompletionDate and CustomCompletionDate as SQLAlchemy `Date`
- accept date-only values for completion dates in ticket schemas

## Testing
- `flake8` *(fails: F401 W391 E303 F811 E302 W391 E501)*
- `pytest -q` *(fails: TypeError: ASGITransport.__init__() got an unexpected keyword argument 'lifespan')*

------
https://chatgpt.com/codex/tasks/task_e_6896d650a2f8832b8546dc9e69965ea5