### PR TITLE
Fix missing TypeDecorator import in models

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -11,6 +11,8 @@ from sqlalchemy import (
     text,
 )
 
+from sqlalchemy.types import TypeDecorator
+
 
 from src.shared.utils.date_format import FormattedDateTime
 from sqlalchemy.orm import DeclarativeBase


### PR DESCRIPTION
## Summary
- import TypeDecorator for custom YNBoolean type

## Testing
- `python - <<'PY'\nfrom src.core.repositories.models import YNBoolean\nprint(YNBoolean)\nPY`
- `pytest -q`
- `docker-compose build` *(fails: Couldn't find env file: /workspace/HelpDeskAiAgent/.env)*

------
https://chatgpt.com/codex/tasks/task_e_6897e4e25e80832b985279bdc821e699