### PR TITLE
Use DB defaults for ticket timestamps

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -55,7 +55,11 @@ class Ticket(Base):
     Ticket_Category_ID = Column(String(50))
     Version = Column(Integer, default=1, nullable=False)
 
-    Created_Date = Column(FormattedDateTime())
+    Created_Date = Column(
+        FormattedDateTime(),
+        nullable=False,
+        server_default=text("STRFTIME('%Y-%m-%d %H:%M:%f', 'now')"),
+    )
     Assigned_Name = Column(String)
     Assigned_Email = Column(String)
     Severity_ID = Column(Integer)
@@ -63,7 +67,12 @@ class Ticket(Base):
 
 
     Closed_Date = Column(FormattedDateTime())
-    LastModified = Column(FormattedDateTime())
+    LastModified = Column(
+        FormattedDateTime(),
+        nullable=False,
+        server_default=text("STRFTIME('%Y-%m-%d %H:%M:%f', 'now')"),
+        onupdate=text("STRFTIME('%Y-%m-%d %H:%M:%f', 'now')"),
+    )
     LastModfiedBy = Column(String)
     Resolution = Column(Text)
     Most_Recent_Service_Scheduled_ID = Column(String(50), nullable=True)

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -780,7 +780,6 @@ class TicketTools:
             Ticket_Body=description,
             Ticket_Contact_Name=contact.get("name"),
             Ticket_Contact_Email=contact.get("email"),
-            Created_Date=format_db_datetime(datetime.now(timezone.utc)),
             Ticket_Status_ID="1",
         )
         db_ticket = await TicketManager().create_ticket(self.db, ticket)

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -54,7 +54,6 @@ from src.core.services.ticket_management import _OPEN_STATE_IDS
 from src.core.services.enhanced_context import EnhancedContextManager
 from src.core.services.advanced_query import AdvancedQueryManager
 from src.shared.schemas.agent_data import AdvancedQuery
-from src.shared.utils.date_format import format_db_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -573,10 +572,6 @@ async def _create_ticket(**payload: Any) -> Dict[str, Any]:
 
         data_in = validated.model_dump()
         async with db.SessionLocal() as db_session:
-            now = datetime.now(timezone.utc)
-            formatted_now = format_db_datetime(now)
-            data_in["Created_Date"] = data_in.get("Created_Date") or formatted_now
-            data_in["LastModified"] = data_in.get("LastModified") or formatted_now
             data_in["LastModfiedBy"] = data_in.get("LastModfiedBy") or "Gil AI"
 
             result = await TicketManager().create_ticket(db_session, data_in)


### PR DESCRIPTION
## Summary
- remove manual Created_Date population in ticket creation paths
- rely on database defaults for Created_Date, LastModified, ValidFrom, and ValidTo

## Testing
- `pytest`
- `python - <<'PY'
from sqlalchemy import create_engine, text
from src.core.repositories.models import Base
engine = create_engine('sqlite:///:memory:')
Base.metadata.create_all(engine)
with engine.connect() as conn:
    rows = conn.execute(text("PRAGMA table_info('Tickets_Master')")).fetchall()
    for row in rows:
        print(row)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a731ad5a18832b8f02dfc5c42ac280