### PR TITLE
Use DB default for ticket message timestamp

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -160,7 +160,10 @@ class TicketMessage(Base):
     SenderUserCode = Column(String)
     SenderUserName = Column(String)
 
-    DateTimeStamp = Column(FormattedDateTime())
+    DateTimeStamp = Column(
+        FormattedDateTime(),
+        server_default=text("(strftime('%Y-%m-%d %H:%M:%f', 'now'))"),
+    )
 
 
 class Site(Base):

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -651,7 +651,6 @@ class TicketManager:
             Message=message,
             SenderUserCode=sender_code,
             SenderUserName=sender_name if sender_name is not None else sender_code,
-            DateTimeStamp=format_db_datetime(datetime.now(timezone.utc)),
         )
         db.add(msg)
         try:


### PR DESCRIPTION
## Summary
- stop manually setting DateTimeStamp when posting ticket messages
- define server-side default on Ticket_Messages.DateTimeStamp so inserts auto-populate

## Testing
- `pytest tests/test_additional_tools.py::test_ticket_message_stores_millisecond_precision -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a73913d810832bb79a21dcb47c394c