### PR TITLE
refactor: use integer ticket status and category IDs

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -47,12 +47,12 @@ class Ticket(Base):
     Ticket_ID = Column(Integer, primary_key=True, index=True)
     Subject = Column(String)
     Ticket_Body = Column(Text)
-    Ticket_Status_ID = Column(String(50))
+    Ticket_Status_ID = Column(Integer)
     Ticket_Contact_Name = Column(String)
     Ticket_Contact_Email = Column(String)
     Asset_ID = Column(String(50))
     Site_ID = Column(Integer)
-    Ticket_Category_ID = Column(String(50))
+    Ticket_Category_ID = Column(Integer)
     Version = Column(Integer, default=1, nullable=False)
 
     Created_Date = Column(
@@ -176,13 +176,13 @@ class Site(Base):
 
 class TicketCategory(Base):
     __tablename__ = "Ticket_Categories"
-    ID = Column(String(50), primary_key=True, index=True)
+    ID = Column(Integer, primary_key=True, index=True)
     Label = Column(String)
 
 
 class TicketStatus(Base):
     __tablename__ = "Ticket_Status"
-    ID = Column(String(50), primary_key=True, index=True)
+    ID = Column(Integer, primary_key=True, index=True)
     Label = Column(String)
 
 
@@ -215,7 +215,7 @@ class VTicketMasterExpanded(ViewBase):
     Ticket_ID = Column(Integer, primary_key=True, index=True)
     Subject = Column(String)
     Ticket_Body = Column(Text)
-    Ticket_Status_ID = Column(String(50))
+    Ticket_Status_ID = Column(Integer)
     Ticket_Status_Label = Column(String)
     Ticket_Contact_Name = Column(String)
     Ticket_Contact_Email = Column(String)
@@ -223,7 +223,7 @@ class VTicketMasterExpanded(ViewBase):
     Asset_Label = Column(String)
     Site_ID = Column(Integer)
     Site_Label = Column(String)
-    Ticket_Category_ID = Column(String(50))
+    Ticket_Category_ID = Column(Integer)
     Ticket_Category_Label = Column(String)
     Created_Date = Column(FormattedDateTime())
     Version = Column(Integer)

--- a/src/core/services/advanced_query.py
+++ b/src/core/services/advanced_query.py
@@ -62,7 +62,7 @@ class AdvancedQueryManager:
             status_conditions = []
             for status in query.status_filter:
                 if isinstance(status, int):
-                    status_conditions.append(VTicketMasterExpanded.Ticket_Status_ID == str(status))
+                    status_conditions.append(VTicketMasterExpanded.Ticket_Status_ID == status)
                 else:
                     status_conditions.append(VTicketMasterExpanded.Ticket_Status_Label.ilike(f"%{status}%"))
             conditions.append(or_(*status_conditions))

--- a/src/core/services/analytics_reporting.py
+++ b/src/core/services/analytics_reporting.py
@@ -15,7 +15,7 @@ from sqlalchemy import func, select, or_
 from src.core.repositories.models import Ticket, TicketStatus, Site
 from src.core.services.ticket_management import _OPEN_STATE_IDS
 
-_CLOSED_STATE_IDS = ["3"]
+_CLOSED_STATE_IDS = [3]
 
 from src.shared.schemas.analytics import (
     StatusCount,
@@ -143,7 +143,7 @@ async def sla_breaches(
     db: AsyncSession,
     sla_days: int = 2,
     filters: Optional[Dict[str, Any]] = None,
-    status_ids: Optional[Union[List[str], str]] = None,
+    status_ids: Optional[Union[List[int], int]] = None,
 ) -> int:
     """Count tickets older than `sla_days` with optional filtering."""
     logger.info(
@@ -157,7 +157,7 @@ async def sla_breaches(
     query = select(func.count(Ticket.Ticket_ID)).filter(Ticket.Created_Date < cutoff)
 
     if status_ids is not None:
-        if isinstance(status_ids, str):
+        if isinstance(status_ids, int):
             status_ids = [status_ids]
         query = query.filter(Ticket.Ticket_Status_ID.in_(status_ids))
     else:
@@ -213,7 +213,7 @@ async def tickets_waiting_on_user(db: AsyncSession) -> List[WaitingOnUserCount]:
             Ticket.Ticket_Contact_Email,
             func.count(Ticket.Ticket_ID),
         )
-        .filter(Ticket.Ticket_Status_ID == "4")
+        .filter(Ticket.Ticket_Status_ID == 4)
         .group_by(Ticket.Ticket_Contact_Email)
     )
     return [

--- a/src/core/services/enhanced_operations.py
+++ b/src/core/services/enhanced_operations.py
@@ -319,7 +319,7 @@ class EnhancedOperationsManager:
                 estimated_impact={"risk": "high", "reason": "ticket_not_found"},
             )
 
-        status_id = str(parameters.get("status_id", "4"))
+        status_id = int(parameters.get("status_id", 4))
         resolution = parameters.get("resolution")
         try:
             TicketUpdate(Ticket_Status_ID=status_id, Resolution=resolution)
@@ -335,7 +335,7 @@ class EnhancedOperationsManager:
                 estimated_impact={"risk": "high", "reason": "invalid_parameters"},
             )
 
-        if str(ticket.Ticket_Status_ID) == status_id:
+        if ticket.Ticket_Status_ID == status_id:
             warnings.append("ticket already closed")
 
         if not resolution:
@@ -384,7 +384,7 @@ class EnhancedOperationsManager:
     async def _execute_ticket_closure(self, ticket_id: int, parameters: Dict[str, Any]) -> Dict[str, Any]:
         """Execute ticket closure."""
         resolution = parameters.get("resolution", "Resolved")
-        status_id = str(parameters.get("status_id", "4"))  # Assuming 4 = Closed
+        status_id = int(parameters.get("status_id", 4))  # Assuming 4 = Closed
 
         update_data = TicketUpdate(
             Ticket_Status_ID=status_id,

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 # Closed states currently map to the single "Closed" status
 # Defined before _STATUS_MAP so the mapping can reference it
-_CLOSED_STATE_IDS = ["3"]
+_CLOSED_STATE_IDS = [3]
 
 _STATUS_MAP = {
 
@@ -47,16 +47,16 @@ _STATUS_MAP = {
     "closed": _CLOSED_STATE_IDS,
     "resolved": _CLOSED_STATE_IDS,
     # Tickets actively being worked may fall under multiple progress states
-    "in_progress": ["2", "5"],
-    "progress": ["2", "5"],
+    "in_progress": [2, 5],
+    "progress": [2, 5],
     # Waiting on user response
-    "waiting": "4",
+    "waiting": 4,
     # Pending/queued tickets
-    "pending": "6",
+    "pending": 6,
 
 }
 
-_OPEN_STATE_IDS = ["1", "2", "4", "5", "6", "8"]
+_OPEN_STATE_IDS = [1, 2, 4, 5, 6, 8]
 
 _PRIORITY_MAP = {
     "critical": "Critical",
@@ -127,10 +127,10 @@ def apply_semantic_filters(filters: Dict[str, Any]) -> Dict[str, Any]:
                             else:
                                 ids.append(mapped)
                     else:
-                        ids.append(str(item))
+                        ids.append(int(item))
                 translated["Ticket_Status_ID"] = ids
             else:
-                translated["Ticket_Status_ID"] = str(value)
+                translated["Ticket_Status_ID"] = int(value)
 
         elif k in {"priority", "priority_level"}:
             if isinstance(value, list):
@@ -562,7 +562,7 @@ class TicketManager:
                 )
             elif s == "closed":
 
-                query = query.filter(VTicketMasterExpanded.Ticket_Status_ID.in_(["3", "7"]))
+                query = query.filter(VTicketMasterExpanded.Ticket_Status_ID.in_([3, 7]))
 
             elif s in {"in_progress", "progress"}:
                 query = query.filter(
@@ -607,7 +607,7 @@ class TicketManager:
                 )
             elif s == "closed":
 
-                query = query.filter(VTicketMasterExpanded.Ticket_Status_ID.in_(["3", "7"]))
+                query = query.filter(VTicketMasterExpanded.Ticket_Status_ID.in_([3, 7]))
             elif s in {"in_progress", "progress"}:
                 query = query.filter(
                     VTicketMasterExpanded.Ticket_Status_ID.in_(
@@ -779,7 +779,7 @@ class TicketTools:
             Ticket_Body=description,
             Ticket_Contact_Name=contact.get("name"),
             Ticket_Contact_Email=contact.get("email"),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         db_ticket = await TicketManager().create_ticket(self.db, ticket)
         return db_ticket

--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -660,7 +660,7 @@ async def _update_ticket(ticket_id: int, updates: Dict[str, Any]) -> Dict[str, A
 
             applied_updates = validated.model_dump(exclude_unset=True)
 
-            if applied_updates.get("Ticket_Status_ID") == "3" and "Closed_Date" not in applied_updates:
+            if applied_updates.get("Ticket_Status_ID") == 3 and "Closed_Date" not in applied_updates:
                 applied_updates["Closed_Date"] = datetime.now(timezone.utc)
 
             if "Assigned_Email" in applied_updates and "Assigned_Name" not in applied_updates:

--- a/src/shared/schemas/analytics.py
+++ b/src/shared/schemas/analytics.py
@@ -4,7 +4,7 @@ from datetime import date
 
 
 class StatusCount(BaseModel):
-    status_id: Optional[str]
+    status_id: Optional[int]
     status_label: Optional[str]
     count: int
 

--- a/src/shared/schemas/filters.py
+++ b/src/shared/schemas/filters.py
@@ -13,7 +13,7 @@ class AdvancedFilters:
 
     created_from: Optional[datetime] = None
     created_to: Optional[datetime] = None
-    status_ids: Optional[List[str]] = None
+    status_ids: Optional[List[int]] = None
     site_ids: Optional[List[int]] = None
     assigned: Optional[bool] = None
     sort: Optional[Sequence[str]] = None

--- a/src/shared/schemas/search_params.py
+++ b/src/shared/schemas/search_params.py
@@ -12,7 +12,7 @@ class TicketSearchParams(BaseModel):
     Ticket_ID: Optional[int] = None
     Subject: Optional[str] = None
     Ticket_Body: Optional[str] = None
-    Ticket_Status_ID: Optional[str] = None
+    Ticket_Status_ID: Optional[int] = None
     Ticket_Status_Label: Optional[str] = None
     Ticket_Contact_Name: Optional[str] = None
     Ticket_Contact_Email: Optional[str] = None
@@ -20,7 +20,7 @@ class TicketSearchParams(BaseModel):
     Asset_Label: Optional[str] = None
     Site_ID: Optional[int] = None
     Site_Label: Optional[str] = None
-    Ticket_Category_ID: Optional[str] = None
+    Ticket_Category_ID: Optional[int] = None
     Ticket_Category_Label: Optional[str] = None
     Created_Date: Optional[datetime] = None
     Assigned_Name: Optional[str] = None

--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -6,12 +6,12 @@ from datetime import datetime, date
 class TicketBase(BaseModel):
     Subject: Annotated[str, Field(max_length=255)]
     Ticket_Body: Annotated[str, Field()]
-    Ticket_Status_ID: Optional[str] = "1"
+    Ticket_Status_ID: Optional[int] = 1
     Ticket_Contact_Name: Annotated[str, Field(max_length=255)]
     Ticket_Contact_Email: EmailStr
     Asset_ID: Optional[str] = None
     Site_ID: Optional[int] = None
-    Ticket_Category_ID: Optional[str] = None
+    Ticket_Category_ID: Optional[int] = None
     Assigned_Name: Optional[Annotated[str, Field(max_length=255)]] = None
     Assigned_Email: Optional[EmailStr] = None
     Severity_ID: Optional[int] = None
@@ -77,7 +77,7 @@ class TicketCreate(TicketBase):
                     "Ticket_Contact_Email": "jane@example.com",
                     "Asset_ID": "5",
                     "Site_ID": 2,
-                    "Ticket_Category_ID": "1",
+                    "Ticket_Category_ID": 1,
                 },
                 {
                     "Subject": "Website down",
@@ -86,7 +86,7 @@ class TicketCreate(TicketBase):
                     "Ticket_Contact_Email": "alice@example.com",
                     "Assigned_Name": "Bob Ops",
                     "Assigned_Email": "bob.ops@example.com",
-                    "Ticket_Status_ID": "1",
+                    "Ticket_Status_ID": 1,
                     "Site_ID": 3,
                     "Severity_ID": 3,
                 },
@@ -100,12 +100,12 @@ class TicketUpdate(BaseModel):
 
     Subject: Optional[str] = None
     Ticket_Body: Optional[str] = None
-    Ticket_Status_ID: Optional[str] = None
+    Ticket_Status_ID: Optional[int] = None
     Ticket_Contact_Name: Optional[str] = None
     Ticket_Contact_Email: Optional[EmailStr] = None
     Asset_ID: Optional[str] = None
     Site_ID: Optional[int] = None
-    Ticket_Category_ID: Optional[str] = None
+    Ticket_Category_ID: Optional[int] = None
     Assigned_Name: Optional[str] = None
     Assigned_Email: Optional[EmailStr] = None
     Severity_ID: Optional[int] = None
@@ -142,8 +142,8 @@ class TicketUpdate(BaseModel):
         json_schema_extra={
             "examples": [
                 {"Subject": "Updated"},
-                {"Assigned_Name": "Agent", "Ticket_Status_ID": "2"},
-                {"Ticket_Status_ID": "3"},
+                {"Assigned_Name": "Agent", "Ticket_Status_ID": 2},
+                {"Ticket_Status_ID": 3},
             ]
         },
     )
@@ -166,12 +166,12 @@ class TicketUpdate(BaseModel):
 class TicketIn(TicketBase):
     Subject: Optional[Annotated[str, Field(max_length=255)]] = None
     Ticket_Body: Optional[Annotated[str, Field()]] = None
-    Ticket_Status_ID: Optional[str] = None
+    Ticket_Status_ID: Optional[int] = None
     Ticket_Contact_Name: Optional[Annotated[str, Field(max_length=255)]] = None
     Ticket_Contact_Email: Optional[EmailStr] = None
     Asset_ID: Optional[str] = None
     Site_ID: Optional[int] = None
-    Ticket_Category_ID: Optional[str] = None
+    Ticket_Category_ID: Optional[int] = None
     Created_Date: Optional[datetime] = None
     Assigned_Name: Optional[Annotated[str, Field(max_length=255)]] = None
     Assigned_Email: Optional[EmailStr] = None
@@ -222,7 +222,7 @@ class TicketOut(TicketIn):
                 "Ticket_ID": 1,
                 "Subject": "Printer not working",
                 "Ticket_Body": "The office printer is jammed",
-                "Ticket_Status_ID": "1",
+                "Ticket_Status_ID": 1,
                 "Ticket_Contact_Name": "Jane Doe",
                 "Ticket_Contact_Email": "jane@example.com",
                 "Created_Date": "2024-01-01T12:00:00Z",

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -32,12 +32,12 @@ async def client():
 
 async def _add_ticket(**kwargs):
     async with SessionLocal() as db:
-        status_id = kwargs.get("Ticket_Status_ID", "1")
+        status_id = kwargs.get("Ticket_Status_ID", 1)
         label_map = {
-            "1": "Open",
-            "2": "In Progress",
-            "3": "Closed",
-            "4": "Waiting Open",
+            1: "Open",
+            2: "In Progress",
+            3: "Closed",
+            4: "Waiting Open",
         }
         if not await db.get(TicketStatus, status_id):
             db.add(TicketStatus(ID=status_id, Label=label_map.get(
@@ -49,7 +49,7 @@ async def _add_ticket(**kwargs):
             Ticket_Body="body",
             Ticket_Contact_Name="name",
             Ticket_Contact_Email=kwargs.get("Ticket_Contact_Email", "c@example.com"),
-            Ticket_Status_ID=kwargs.get("Ticket_Status_ID", "1"),
+            Ticket_Status_ID=kwargs.get("Ticket_Status_ID", 1),
             Site_ID=kwargs.get("Site_ID"),
             Assigned_Email=kwargs.get("Assigned_Email"),
             Assigned_Name=kwargs.get("Assigned_Name"),
@@ -64,23 +64,23 @@ async def _add_ticket(**kwargs):
 
 @pytest.mark.asyncio
 async def test_analytics_status(client: AsyncClient):
-    await _add_ticket(Ticket_Status_ID="1")
-    await _add_ticket(Ticket_Status_ID="1")
-    await _add_ticket(Ticket_Status_ID="2")
+    await _add_ticket(Ticket_Status_ID=1)
+    await _add_ticket(Ticket_Status_ID=1)
+    await _add_ticket(Ticket_Status_ID=2)
 
     resp = await client.get("/analytics/status")
     assert resp.status_code == 200
     data = {item["status_id"]: item["count"] for item in resp.json()}
-    assert data == {"1": 2, "2": 1}
+    assert data == {1: 2, 2: 1}
     assert all("status_label" in item for item in resp.json())
 
 
 @pytest.mark.asyncio
 async def test_analytics_open_by_site(client: AsyncClient):
-    await _add_ticket(Site_ID=1, Ticket_Status_ID="1")
-    await _add_ticket(Site_ID=1, Ticket_Status_ID="2")
-    await _add_ticket(Site_ID=2, Ticket_Status_ID="1")
-    await _add_ticket(Site_ID=2, Ticket_Status_ID="3")  # closed
+    await _add_ticket(Site_ID=1, Ticket_Status_ID=1)
+    await _add_ticket(Site_ID=1, Ticket_Status_ID=2)
+    await _add_ticket(Site_ID=2, Ticket_Status_ID=1)
+    await _add_ticket(Site_ID=2, Ticket_Status_ID=3)  # closed
 
     resp = await client.get("/analytics/open_by_site")
     assert resp.status_code == 200
@@ -104,22 +104,22 @@ async def test_analytics_open_by_assigned_user(client: AsyncClient):
     await _add_ticket(
         Assigned_Email="tech@example.com",
         Assigned_Name="Tech",
-        Ticket_Status_ID="1",
+        Ticket_Status_ID=1,
     )
     await _add_ticket(
         Assigned_Email="tech@example.com",
         Assigned_Name="Tech",
-        Ticket_Status_ID="1",
+        Ticket_Status_ID=1,
     )
     await _add_ticket(
         Assigned_Email="other@example.com",
         Assigned_Name="Other",
-        Ticket_Status_ID="1",
+        Ticket_Status_ID=1,
     )
     await _add_ticket(
         Assigned_Email="tech@example.com",
         Assigned_Name="Tech",
-        Ticket_Status_ID="3",
+        Ticket_Status_ID=3,
     )
 
     resp = await client.get("/analytics/open_by_assigned_user")
@@ -138,10 +138,10 @@ async def test_analytics_open_by_assigned_user(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_analytics_waiting_on_user(client: AsyncClient):
-    await _add_ticket(Ticket_Status_ID="4", Ticket_Contact_Email="user1@example.com")
-    await _add_ticket(Ticket_Status_ID="4", Ticket_Contact_Email="user1@example.com")
-    await _add_ticket(Ticket_Status_ID="4", Ticket_Contact_Email="user2@example.com")
-    await _add_ticket(Ticket_Status_ID="1", Ticket_Contact_Email="user1@example.com")
+    await _add_ticket(Ticket_Status_ID=4, Ticket_Contact_Email="user1@example.com")
+    await _add_ticket(Ticket_Status_ID=4, Ticket_Contact_Email="user1@example.com")
+    await _add_ticket(Ticket_Status_ID=4, Ticket_Contact_Email="user2@example.com")
+    await _add_ticket(Ticket_Status_ID=1, Ticket_Contact_Email="user1@example.com")
 
     resp = await client.get("/analytics/waiting_on_user")
     assert resp.status_code == 200
@@ -155,14 +155,14 @@ async def test_sla_breaches_with_filters(client: AsyncClient):
     await _add_ticket(
         Created_Date=old,
         Assigned_Email="tech@example.com",
-        Ticket_Status_ID="1",
+        Ticket_Status_ID=1,
     )
     await _add_ticket(
         Created_Date=old,
         Assigned_Email="other@example.com",
-        Ticket_Status_ID="1",
+        Ticket_Status_ID=1,
     )
-    await _add_ticket(Created_Date=old, Ticket_Status_ID="3")
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=3)
 
     resp = await client.get(
         "/analytics/sla_breaches",
@@ -183,9 +183,9 @@ async def test_sla_breaches_with_filters(client: AsyncClient):
 async def test_sla_breaches_excludes_non_open(client: AsyncClient):
     """Closed or waiting tickets should not count towards SLA breaches."""
     old = datetime.now(UTC) - timedelta(days=5)
-    await _add_ticket(Created_Date=old, Ticket_Status_ID="1")
-    await _add_ticket(Created_Date=old, Ticket_Status_ID="4")
-    await _add_ticket(Created_Date=old, Ticket_Status_ID="3")
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=1)
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=4)
+    await _add_ticket(Created_Date=old, Ticket_Status_ID=3)
 
     resp = await client.get("/analytics/sla_breaches", params={"sla_days": 2})
     assert resp.status_code == 200
@@ -209,10 +209,10 @@ async def test_ticket_trend(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_staff_ticket_report(client: AsyncClient):
-    t1 = await _add_ticket(Assigned_Email="tech@example.com", Ticket_Status_ID="1")
-    t2 = await _add_ticket(Assigned_Email="tech@example.com", Ticket_Status_ID="3")
-    t3 = await _add_ticket(Assigned_Email="tech@example.com", Ticket_Status_ID="1")
-    await _add_ticket(Assigned_Email="other@example.com", Ticket_Status_ID="1")
+    t1 = await _add_ticket(Assigned_Email="tech@example.com", Ticket_Status_ID=1)
+    t2 = await _add_ticket(Assigned_Email="tech@example.com", Ticket_Status_ID=3)
+    t3 = await _add_ticket(Assigned_Email="tech@example.com", Ticket_Status_ID=1)
+    await _add_ticket(Assigned_Email="other@example.com", Ticket_Status_ID=1)
 
     resp = await client.get(
         "/analytics/staff_report", params={"assigned_email": "tech@example.com"}

--- a/tests/test_analytics_cache_lock.py
+++ b/tests/test_analytics_cache_lock.py
@@ -18,7 +18,7 @@ async def _add_sample_ticket():
             Ticket_Contact_Name="C",
             Ticket_Contact_Email="c@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(session, t)
         await session.commit()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -16,7 +16,7 @@ async def _add_sample_ticket():
             Ticket_Contact_Name="T",
             Ticket_Contact_Email="t@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(session, t)
         await session.commit()

--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -94,13 +94,13 @@ async def test_dynamic_create_ticket():
             "Ticket_Body": "Created via tool",
             "Ticket_Contact_Name": "Tester",
             "Ticket_Contact_Email": "tester@example.com",
-            "Ticket_Status_ID": "2",
+            "Ticket_Status_ID": 2,
         }
         resp = await client.post("/create_ticket", json=payload)
         assert resp.status_code == 200
         data = resp.json()
         assert data.get("status") == "success"
-        assert data["data"]["Ticket_Status_ID"] == "2"
+        assert data["data"]["Ticket_Status_ID"] == 2
         assert data["data"]["LastModified"] is not None
         assert data["data"]["LastModfiedBy"] == "Gil AI"
 

--- a/tests/test_enhanced_operations.py
+++ b/tests/test_enhanced_operations.py
@@ -15,7 +15,7 @@ async def test_validate_ticket_update_success():
             Ticket_Contact_Name="n",
             Ticket_Contact_Email="e@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, ticket)
         await db.commit()
@@ -36,7 +36,7 @@ async def test_validate_ticket_update_invalid_field():
             Ticket_Contact_Name="n",
             Ticket_Contact_Email="e@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, ticket)
         await db.commit()

--- a/tests/test_enhanced_search.py
+++ b/tests/test_enhanced_search.py
@@ -16,7 +16,7 @@ async def test_enhanced_search_direct_parameters():
             Ticket_Body="HP printer shows error code 42",
             Ticket_Contact_Name="User1",
             Ticket_Contact_Email="user1@example.com",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Severity_ID=2,
             Site_ID=1,
             Created_Date=datetime.now(UTC),
@@ -26,7 +26,7 @@ async def test_enhanced_search_direct_parameters():
             Ticket_Body="Cannot connect to email server",
             Ticket_Contact_Name="User2",
             Ticket_Contact_Email="user2@example.com",
-            Ticket_Status_ID="2",
+            Ticket_Status_ID=2,
             Severity_ID=1,
             Site_ID=2,
             Assigned_Email="tech@example.com",
@@ -75,7 +75,7 @@ async def test_enhanced_search_ai_features():
             Ticket_Body="The main email server is not responding to requests",
             Ticket_Contact_Name="Admin",
             Ticket_Contact_Email="admin@example.com",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Created_Date=datetime.now(UTC),
         )
         await TicketManager().create_ticket(db, t)
@@ -112,7 +112,7 @@ async def test_backward_compatibility_aliases():
             Ticket_Body="Test body content",
             Ticket_Contact_Name="TestUser",
             Ticket_Contact_Email="test@example.com",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Created_Date=datetime.now(UTC),
         )
         await TicketManager().create_ticket(db, t)
@@ -137,7 +137,7 @@ async def test_enhanced_search_date_filtering():
             Ticket_Body="Old problem",
             Ticket_Contact_Name="User",
             Ticket_Contact_Email="user@example.com",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Created_Date=datetime(2024, 1, 1, tzinfo=UTC),
         )
         new_ticket = Ticket(
@@ -145,7 +145,7 @@ async def test_enhanced_search_date_filtering():
             Ticket_Body="Recent problem",
             Ticket_Contact_Name="User",
             Ticket_Contact_Email="user@example.com",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Created_Date=datetime.now(UTC),
         )
         await TicketManager().create_ticket(db, old_ticket)

--- a/tests/test_operation_result.py
+++ b/tests/test_operation_result.py
@@ -17,7 +17,7 @@ async def test_create_ticket_returns_operation_result():
             Ticket_Contact_Name="n",
             Ticket_Contact_Email="e@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         result = await TicketManager().create_ticket(db, ticket)
         await db.commit()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -121,12 +121,12 @@ async def test_update_ticket_multiple_fields(client: AsyncClient):
     ticket = resp.json()
     tid = ticket["Ticket_ID"]
 
-    payload = {"Assigned_Name": "Agent Smith", "Ticket_Status_ID": "2", "Severity_ID": 3}
+    payload = {"Assigned_Name": "Agent Smith", "Ticket_Status_ID": 2, "Severity_ID": 3}
     resp = await client.put(f"/ticket/{tid}", json=payload)
     assert resp.status_code == 200
     data = resp.json()
     assert data["Assigned_Name"] == "Agent Smith"
-    assert data["Ticket_Status_ID"] == "2"
+    assert data["Ticket_Status_ID"] == 2
     assert data["Severity_ID"] == 3
 
 
@@ -136,19 +136,19 @@ async def test_update_ticket_multiple_fields_persisted(client: AsyncClient):
     assert resp.status_code == 201
     tid = resp.json()["Ticket_ID"]
 
-    payload = {"Assigned_Name": "Neo", "Ticket_Status_ID": "2", "Severity_ID": 4}
+    payload = {"Assigned_Name": "Neo", "Ticket_Status_ID": 2, "Severity_ID": 4}
     update_resp = await client.put(f"/ticket/{tid}", json=payload)
     assert update_resp.status_code == 200
     updated = update_resp.json()
     assert updated["Assigned_Name"] == "Neo"
-    assert updated["Ticket_Status_ID"] == "2"
+    assert updated["Ticket_Status_ID"] == 2
     assert updated["Severity_ID"] == 4
 
     get_resp = await client.get(f"/ticket/{tid}")
     assert get_resp.status_code == 200
     fetched = get_resp.json()
     assert fetched["Assigned_Name"] == "Neo"
-    assert fetched["Ticket_Status_ID"] == "2"
+    assert fetched["Ticket_Status_ID"] == 2
     assert fetched["Severity_ID"] == 4
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -52,7 +52,7 @@ async def test_search_endpoint_handles_long_ticket_body():
             Ticket_Contact_Name="n",
             Ticket_Contact_Email="e@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, bad)
         await db.commit()
@@ -109,13 +109,13 @@ async def test_search_created_date_filters():
             Subject="DateFilter",
             Ticket_Body="old",
             Created_Date=datetime(2023, 1, 1, tzinfo=UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         new = Ticket(
             Subject="DateFilter",
             Ticket_Body="new",
             Created_Date=datetime(2023, 1, 10, tzinfo=UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, old)
         await TicketManager().create_ticket(db, new)
@@ -139,13 +139,13 @@ async def test_search_created_after_string_precision():
             Subject="DatePrecision",
             Ticket_Body="old",
             Created_Date=datetime(2023, 1, 1, tzinfo=UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         new = Ticket(
             Subject="DatePrecision",
             Ticket_Body="new",
             Created_Date=datetime(2023, 1, 10, tzinfo=UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, old)
         await TicketManager().create_ticket(db, new)
@@ -174,13 +174,13 @@ async def test_search_datetime_and_days_filters():
             Subject="MicroDate",
             Ticket_Body="old",
             Created_Date=datetime.now(UTC) - timedelta(days=5),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         new = Ticket(
             Subject="MicroDate",
             Ticket_Body="new",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, old)
         await TicketManager().create_ticket(db, new)
@@ -205,13 +205,13 @@ async def test_search_days_none_returns_all():
             Subject="DayNone",
             Ticket_Body="old",
             Created_Date=datetime.now(UTC) - timedelta(days=5),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         new = Ticket(
             Subject="DayNone",
             Ticket_Body="new",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, old)
         await TicketManager().create_ticket(db, new)
@@ -228,7 +228,7 @@ async def test_search_days_invalid_value():
             Subject="BadDays",
             Ticket_Body="body",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, t)
         await db.commit()

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -18,7 +18,7 @@ async def test_search_returns_long_ticket_body():
             Ticket_Contact_Name="T",
             Ticket_Contact_Email="t@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         invalid = Ticket(
             Subject="Query",
@@ -26,7 +26,7 @@ async def test_search_returns_long_ticket_body():
             Ticket_Contact_Name="T",
             Ticket_Contact_Email="t@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, valid)
         await TicketManager().create_ticket(db, invalid)
@@ -55,7 +55,7 @@ async def test_search_filters_and_sort():
             Ticket_Contact_Name="T",
             Ticket_Contact_Email="t@example.com",
             Created_Date=datetime(2023, 1, 1, tzinfo=UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Site_ID=1,
         )
         second = Ticket(
@@ -64,7 +64,7 @@ async def test_search_filters_and_sort():
             Ticket_Contact_Name="T",
             Ticket_Contact_Email="t@example.com",
             Created_Date=datetime(2023, 1, 2, tzinfo=UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Site_ID=2,
         )
         await TicketManager().create_ticket(db, first)
@@ -77,7 +77,7 @@ async def test_search_filters_and_sort():
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get(
             "/tickets/search",
-            params={"q": "Query", "Site_ID": 1, "Ticket_Status_ID": "1", "sort": "oldest"},
+            params={"q": "Query", "Site_ID": 1, "Ticket_Status_ID": 1, "sort": "oldest"},
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -97,7 +97,7 @@ async def test_search_accepts_json():
             Ticket_Contact_Name="T",
             Ticket_Contact_Email="t@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, t)
         await db.commit()
@@ -118,13 +118,13 @@ async def test_search_created_date_filters_endpoint():
             Subject="DateFilter",
             Ticket_Body="old",
             Created_Date=datetime(2023, 1, 1, tzinfo=UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         new = Ticket(
             Subject="DateFilter",
             Ticket_Body="new",
             Created_Date=datetime(2023, 1, 10, tzinfo=UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, old)
         await TicketManager().create_ticket(db, new)

--- a/tests/test_semantic_filters.py
+++ b/tests/test_semantic_filters.py
@@ -19,20 +19,20 @@ async def test_open_status_filter_matches_multiple_states():
     async with SessionLocal() as db:
         now = datetime.now(UTC)
         statuses = [
-            ("1", "Open"),
-            ("2", "In Progress"),
-            ("3", "Closed"),
-            ("4", "Waiting"),
+            (1, "Open"),
+            (2, "In Progress"),
+            (3, "Closed"),
+            (4, "Waiting"),
         ]
         for sid, label in statuses:
             if not await db.get(TicketStatus, sid):
                 db.add(TicketStatus(ID=sid, Label=label))
         await db.commit()
 
-        t1 = Ticket(Subject="A", Ticket_Body="b", Created_Date=now, Ticket_Status_ID="1")
-        t2 = Ticket(Subject="B", Ticket_Body="b", Created_Date=now, Ticket_Status_ID="2")
-        t3 = Ticket(Subject="C", Ticket_Body="b", Created_Date=now, Ticket_Status_ID="3")
-        t4 = Ticket(Subject="D", Ticket_Body="b", Created_Date=now, Ticket_Status_ID="4")
+        t1 = Ticket(Subject="A", Ticket_Body="b", Created_Date=now, Ticket_Status_ID=1)
+        t2 = Ticket(Subject="B", Ticket_Body="b", Created_Date=now, Ticket_Status_ID=2)
+        t3 = Ticket(Subject="C", Ticket_Body="b", Created_Date=now, Ticket_Status_ID=3)
+        t4 = Ticket(Subject="D", Ticket_Body="b", Created_Date=now, Ticket_Status_ID=4)
 
         for t in (t1, t2, t3, t4):
             await TicketManager().create_ticket(db, t)
@@ -81,7 +81,7 @@ async def test_assignee_email_and_name_filters():
             Ticket_Contact_Email="e",
             Assigned_Email="tech@example.com",
             Assigned_Name="Tech",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Created_Date=now,
         )
         t2 = Ticket(
@@ -91,7 +91,7 @@ async def test_assignee_email_and_name_filters():
             Ticket_Contact_Email="e",
             Assigned_Email="other@example.com",
             Assigned_Name="Other",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Created_Date=now,
         )
         await TicketManager().create_ticket(db, t1)
@@ -115,9 +115,9 @@ def test_status_string_mappings():
     mapping_expectations = {
         "open": _OPEN_STATE_IDS,
         "closed": _CLOSED_STATE_IDS,
-        "in_progress": ["2", "5"],
-        "progress": ["2", "5"],
-        "pending": "6",
+        "in_progress": [2, 5],
+        "progress": [2, 5],
+        "pending": 6,
         "resolved": _STATUS_MAP["resolved"],
     }
     for status, expected in mapping_expectations.items():
@@ -126,8 +126,8 @@ def test_status_string_mappings():
 
 
 def test_open_closed_constants():
-    assert _OPEN_STATE_IDS == ["1", "2", "4", "5", "6", "8"]
-    assert _CLOSED_STATE_IDS == ["3"]
+    assert _OPEN_STATE_IDS == [1, 2, 4, 5, 6, 8]
+    assert _CLOSED_STATE_IDS == [3]
 
 
 def test_status_filter_unknown_value():

--- a/tests/test_ticket_commits.py
+++ b/tests/test_ticket_commits.py
@@ -84,7 +84,7 @@ async def test_close_ticket_commits_once(monkeypatch):
     await _patched_session(monkeypatch, counter)
     result = await _update_ticket(tid, {"resolution": "done", "status": "closed"})
     assert result["status"] == "success"
-    assert result["data"]["Ticket_Status_ID"] == "3"
+    assert result["data"]["Ticket_Status_ID"] == 3
     assert counter[0] == 1
 
 

--- a/tests/test_ticket_lifecycle.py
+++ b/tests/test_ticket_lifecycle.py
@@ -24,7 +24,7 @@ def test_ticket_full_lifecycle():
 
     update_resp = client.put(
         f"/ticket/{tid}",
-        json={"Assigned_Name": "Agent", "Ticket_Status_ID": "2"},
+        json={"Assigned_Name": "Agent", "Ticket_Status_ID": 2},
     )
     assert update_resp.status_code == 200
     assert update_resp.json()["Assigned_Name"] == "Agent"
@@ -38,9 +38,9 @@ def test_ticket_full_lifecycle():
     assert msgs.status_code == 200
     assert msgs.json()[0]["Message"] == "hello"
 
-    close_resp = client.put(f"/ticket/{tid}", json={"Ticket_Status_ID": "3"})
+    close_resp = client.put(f"/ticket/{tid}", json={"Ticket_Status_ID": 3})
     assert close_resp.status_code == 200
-    assert close_resp.json()["Ticket_Status_ID"] == "3"
+    assert close_resp.json()["Ticket_Status_ID"] == 3
 
 
 def test_update_ticket_not_found():

--- a/tests/test_ticket_search_endpoint.py
+++ b/tests/test_ticket_search_endpoint.py
@@ -17,7 +17,7 @@ async def test_ticket_search_route_returns_results():
             Ticket_Contact_Name="Tester",
             Ticket_Contact_Email="tester@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, t)
         await db.commit()
@@ -40,7 +40,7 @@ async def test_ticket_search_route_accepts_json():
             Ticket_Contact_Name="Tester",
             Ticket_Contact_Email="tester@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, t)
         await db.commit()

--- a/tests/test_ticket_version.py
+++ b/tests/test_ticket_version.py
@@ -26,7 +26,7 @@ async def test_version_increments_on_update():
             Ticket_Contact_Name="User",
             Ticket_Contact_Email="user@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         result = await TicketManager().create_ticket(db, ticket)
         await db.commit()
@@ -47,7 +47,7 @@ async def test_version_unchanged_when_no_real_update():
             Ticket_Contact_Name="User",
             Ticket_Contact_Email="user@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         result = await TicketManager().create_ticket(db, ticket)
         await db.commit()
@@ -69,7 +69,7 @@ async def test_assigned_name_not_email_after_mcp_update(client: AsyncClient):
             Ticket_Contact_Name="User",
             Ticket_Contact_Email="user@example.com",
             Created_Date=datetime.now(UTC),
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
         )
         await TicketManager().create_ticket(db, ticket)
         await db.commit()

--- a/tests/test_tickets_by_user.py
+++ b/tests/test_tickets_by_user.py
@@ -13,14 +13,14 @@ from src.mcp_server import create_enhanced_server
 async def test_get_tickets_by_user_function():
     async with SessionLocal() as db:
         now = datetime.now(UTC)
-        for sid, label in [("1", "Open"), ("3", "Closed")]:
+        for sid, label in [(1, "Open"), (3, "Closed")]:
             if not await db.get(TicketStatus, sid):
                 db.add(TicketStatus(ID=sid, Label=label))
         await db.commit()
         t1 = Ticket(
             Subject="A",
             Ticket_Body="b",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Ticket_Contact_Name="X",
             Ticket_Contact_Email="user@example.com",
             Created_Date=now,
@@ -28,7 +28,7 @@ async def test_get_tickets_by_user_function():
         t2 = Ticket(
             Subject="B",
             Ticket_Body="b",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Ticket_Contact_Name="Y",
             Ticket_Contact_Email="y@example.com",
             Assigned_Email="user@example.com",
@@ -37,7 +37,7 @@ async def test_get_tickets_by_user_function():
         t3 = Ticket(
             Subject="C",
             Ticket_Body="b",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Ticket_Contact_Name="Z",
             Ticket_Contact_Email="z@example.com",
             Created_Date=now,
@@ -48,7 +48,7 @@ async def test_get_tickets_by_user_function():
         t4 = Ticket(
             Subject="D",
             Ticket_Body="b",
-            Ticket_Status_ID="3",
+            Ticket_Status_ID=3,
             Ticket_Contact_Email="user@example.com",
             Created_Date=now,
         )
@@ -70,7 +70,7 @@ async def test_get_tickets_by_user_function():
         t5 = Ticket(
             Subject="E",
             Ticket_Body="b",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Ticket_Contact_Email="user@example.com",
             Created_Date=now,
         )
@@ -104,7 +104,7 @@ async def test_tickets_by_user_endpoint():
             t = Ticket(
                 Subject="E",
                 Ticket_Body="b",
-                Ticket_Status_ID="1",
+                Ticket_Status_ID=1,
                 Ticket_Contact_Name="U",
                 Ticket_Contact_Email="endpoint@example.com",
                 Created_Date=now,
@@ -122,7 +122,7 @@ async def test_tickets_by_user_endpoint():
             t_new = Ticket(
                 Subject="E2",
                 Ticket_Body="b",
-                Ticket_Status_ID="1",
+                Ticket_Status_ID=1,
                 Ticket_Contact_Name="U2",
                 Ticket_Contact_Email="endpoint@example.com",
                 Created_Date=now,
@@ -141,7 +141,7 @@ async def test_tickets_by_user_tool():
         t = Ticket(
             Subject="Tool",
             Ticket_Body="b",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Ticket_Contact_Name="T",
             Ticket_Contact_Email="tool@example.com",
             Created_Date=now,
@@ -160,7 +160,7 @@ async def test_tickets_by_user_tool():
         t2 = Ticket(
             Subject="Tool2",
             Ticket_Body="b",
-            Ticket_Status_ID="1",
+            Ticket_Status_ID=1,
             Ticket_Contact_Name="T2",
             Ticket_Contact_Email="tool@example.com",
             Created_Date=now,
@@ -178,14 +178,14 @@ async def test_status_and_filtering():
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         now = datetime.now(UTC)
         async with SessionLocal() as db:
-            for sid, label in [("1", "Open"), ("3", "Closed")]:
+            for sid, label in [(1, "Open"), (3, "Closed")]:
                 if not await db.get(TicketStatus, sid):
                     db.add(TicketStatus(ID=sid, Label=label))
             await db.commit()
             open_t = Ticket(
                 Subject="OpenF",
                 Ticket_Body="b",
-                Ticket_Status_ID="1",
+                Ticket_Status_ID=1,
                 Ticket_Contact_Email="filter@example.com",
                 Site_ID=1,
                 Created_Date=now,
@@ -193,7 +193,7 @@ async def test_status_and_filtering():
             closed_t = Ticket(
                 Subject="ClosedF",
                 Ticket_Body="b",
-                Ticket_Status_ID="3",
+                Ticket_Status_ID=3,
                 Ticket_Contact_Email="filter@example.com",
                 Site_ID=2,
                 Created_Date=now,


### PR DESCRIPTION
## Summary
- switch Ticket table, TicketCategory, and TicketStatus models to integer primary keys
- align schemas, filters, and services to handle integer IDs
- update tests for integer-based status handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a73c3a23ac832ba28295c2fab97dad