### PR TITLE
Switch ticket Y/N flags to 0/1 boolean encoding

### DIFF
--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -7,7 +7,6 @@ from sqlalchemy import (
     Boolean,
     LargeBinary,
     Computed,
-    func,
     text,
 )
 
@@ -25,8 +24,8 @@ class Base(DeclarativeBase):
     pass
 
 
-class YNBoolean(TypeDecorator):
-    """Store boolean values as single-character ``'Y'``/``'N'`` strings."""
+class BitBoolean(TypeDecorator):
+    """Store boolean values as ``'1'``/``'0'`` strings."""
 
     impl = String(1)
     cache_ok = True
@@ -34,12 +33,12 @@ class YNBoolean(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if value is None:
             return None
-        return "Y" if value else "N"
+        return "1" if value else "0"
 
     def process_result_value(self, value, dialect):
         if value is None:
             return None
-        return value == "Y"
+        return value == "1"
 
 
 class Ticket(Base):
@@ -91,8 +90,8 @@ class Ticket(Base):
     )
 
     RV = Column(String, nullable=True)
-    HasServiceRequest = Column(YNBoolean(), nullable=True)
-    Private = Column(YNBoolean(), nullable=True)
+    HasServiceRequest = Column(BitBoolean(), nullable=True)
+    Private = Column(BitBoolean(), nullable=True)
     Collab_Emails = Column(String, nullable=True)
     OrderFormHTML = Column(Text, nullable=True)
     LastModifiedAsInt = Column(

--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -35,12 +35,18 @@ class TicketBase(BaseModel):
 
 
     @field_validator("HasServiceRequest", "Private", mode="before")
-    def _parse_yn_bool(cls, v):
+    def _parse_bit_bool(cls, v):
         if isinstance(v, str):
+            v = v.strip()
+            if v == "1":
+                return True
+            if v == "0":
+                return False
             if v.upper() == "Y":
                 return True
             if v.upper() == "N":
                 return False
+        return v
 
     @field_validator("EstimatedCompletionDate", "CustomCompletionDate", mode="before")
     def _coerce_date(cls, v: Any):
@@ -128,8 +134,13 @@ class TicketUpdate(BaseModel):
         return values
 
     @field_validator("HasServiceRequest", "Private", mode="before")
-    def _parse_yn_bool(cls, v):
+    def _parse_bit_bool(cls, v):
         if isinstance(v, str):
+            v = v.strip()
+            if v == "1":
+                return True
+            if v == "0":
+                return False
             if v.upper() == "Y":
                 return True
             if v.upper() == "N":


### PR DESCRIPTION
## Summary
- use custom BitBoolean type to persist ticket flags as '1'/'0'
- parse '1'/'0' values in ticket schemas for HasServiceRequest and Private

## Testing
- `flake8`
- `flake8 src/core/repositories/models.py src/shared/schemas/ticket.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a73c3d9c2c832bbc41b0f6a42cc09e