### PR TITLE
Fix Site model state column name

### DIFF
--- a/alembic/versions/7bee13849318_initial.py
+++ b/alembic/versions/7bee13849318_initial.py
@@ -37,7 +37,8 @@ def upgrade() -> None:
         sa.Column('ID', sa.Integer(), nullable=False),
         sa.Column('Label', sa.String(), nullable=True),
         sa.Column('City', sa.String(), nullable=True),
-        sa.Column('State', sa.String(), nullable=True),
+        # Underlying column name uses lowercase to align with ORM mapping.
+        sa.Column('state', sa.String(), nullable=True),
         sa.PrimaryKeyConstraint('ID'),
     )
     op.create_index(op.f('ix_Sites_ID'), 'Sites', ['ID'], unique=False)

--- a/src/core/repositories/models.py
+++ b/src/core/repositories/models.py
@@ -171,7 +171,9 @@ class Site(Base):
     ID = Column(Integer, primary_key=True, index=True)
     Label = Column(String)
     City = Column(String)
-    State = Column(String)
+    # The underlying column name in the database is lowercase "state".
+    # Explicitly specify it to ensure proper mapping across engines.
+    State = Column("state", String)
 
 
 class TicketCategory(Base):


### PR DESCRIPTION
## Summary
- explicitly map Site.State to lowercase `state` column
- update initial migration to use lowercase column name

## Testing
- `flake8` *(fails: F401 unused imports, W391 blank line, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a73c478468832b9ebec392feb45f53