### PR TITLE
Handle null days in ticket search

### DIFF
--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -450,7 +450,7 @@ class TicketManager:
         if created_after:
             created_after_dt = parse_search_datetime(created_after)
             stmt = stmt.filter(VTicketMasterExpanded.Created_Date >= created_after_dt)
-        elif days is not None:
+        elif isinstance(days, int) and days > 0:
             cutoff = datetime.now(timezone.utc) - timedelta(days=days)
             cutoff = parse_search_datetime(cutoff)
             stmt = stmt.filter(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -222,6 +222,29 @@ async def test_search_days_none_returns_all():
 
 
 @pytest.mark.asyncio
+async def test_search_days_zero_returns_all():
+    async with SessionLocal() as db:
+        old = Ticket(
+            Subject="DayZero",
+            Ticket_Body="old",
+            Created_Date=datetime.now(UTC) - timedelta(days=5),
+            Ticket_Status_ID=1,
+        )
+        new = Ticket(
+            Subject="DayZero",
+            Ticket_Body="new",
+            Created_Date=datetime.now(UTC),
+            Ticket_Status_ID=1,
+        )
+        await TicketManager().create_ticket(db, old)
+        await TicketManager().create_ticket(db, new)
+        await db.commit()
+
+        res, _ = await TicketManager().search_tickets(db, "DayZero", days=0)
+        assert {r.Ticket_ID for r in res} == {old.Ticket_ID, new.Ticket_ID}
+
+
+@pytest.mark.asyncio
 async def test_search_days_invalid_value():
     async with SessionLocal() as db:
         t = Ticket(


### PR DESCRIPTION
## Summary
- Avoid timedelta errors by only applying day filter when `days` is a positive integer
- Cover zero-day search case with dedicated test

## Testing
- `pytest tests/test_search.py::test_search_days_zero_returns_all -q`


------
https://chatgpt.com/codex/tasks/task_e_68a889937ea4832b97b8b87545190956