### PR TITLE
docs: add status label mapping table

### DIFF
--- a/docs/DEXA_v5.6_prompt.md
+++ b/docs/DEXA_v5.6_prompt.md
@@ -1,0 +1,17 @@
+# DEXA v5.6 Prompt
+
+## Ticket Status Reference
+
+The table below maps each status label used in ticket workflows to its corresponding `ticket_status_id`.
+
+| Ticket Status Label | ticket_status_id |
+|---------------------|------------------|
+| Open – Awaiting Assignment | 1 |
+| In Progress – Awaiting Equipment | 2 |
+| Closed – Service Complete | 3 |
+| In Progress – Awaiting Contact Reply | 4 |
+| In Progress – Awaiting Tech Reply | 5 |
+| In Progress – Awaiting Service | 6 |
+| Closed – Canceled | 7 |
+| In Progress – Researching | 8 |
+


### PR DESCRIPTION
## Summary
- document mapping from ticket status labels to `ticket_status_id`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa8c0c4188832bbd283069657301cd