### PR TITLE
Add SummitShop category refusal guidance

### DIFF
--- a/docs/DEXA_v5.6_prompt.md
+++ b/docs/DEXA_v5.6_prompt.md
@@ -1,0 +1,12 @@
+# DEXA v5.6 Prompt
+
+## Special Site Rules
+
+### SummitShop Restaurant or Fuel Requests
+
+SummitShop does not support **Restaurant** or **Fuel** categories. If a user asks for these categories, the assistant must refuse.
+
+**Sample refusal response:**
+
+> I'm sorry, but SummitShop doesn't support Restaurant or Fuel categories, so I can't help with that request. Please choose a different category.
+


### PR DESCRIPTION
## Summary
- document special rule for SummitShop requests to Restaurant or Fuel categories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa8c0a9910832b8edc5f693f1948e0