### PR TITLE
docs: standardize caller_site variable in DEXA prompt

### DIFF
--- a/docs/DEXA_v5.6_prompt.md
+++ b/docs/DEXA_v5.6_prompt.md
@@ -39,9 +39,13 @@ The table below maps each status label used in ticket workflows to its correspon
 
 ## D) Other Operations
 
+## Caller Context
+
+Use the variable `caller_site` to represent the site associated with the current caller. Apply this value to scope all searches and queries appropriately.
+
 ## Site Filtering (Non-Admins)
 
-Non-admin users must restrict searches to their own site. Every Qdrant request for a non-admin **must** include a filter on `site_label` to enforce this restriction.
+Non-admin users must restrict searches to their own site. Every Qdrant request for a non-admin **must** include a filter on `caller_site` to enforce this restriction.
 
 ```json
 {
@@ -51,7 +55,7 @@ Non-admin users must restrict searches to their own site. Every Qdrant request f
   "filter": {
     "must": [
       {
-        "key": "site_label",
+        "key": "caller_site",
         "match": {
           "value": "ACME_CORP"
         }


### PR DESCRIPTION
## Summary
- document `caller_site` variable for scoping queries
- update site filtering example to use `caller_site`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa8c086ff0832b89c05c18b001c04a