### PR TITLE
Remove LastModified from ticket creation input

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ The `Tickets_Master` table stores the primary ticket data. Columns include:
 - `LastModfiedBy`
 - `Resolution`
 
+The `LastModified` and `LastModfiedBy` fields are maintained by the system and
+should not be supplied when creating new tickets.
+
 ### V_Ticket_Master_Expanded
 
 The API uses the `V_Ticket_Master_Expanded` view to join tickets with

--- a/docs/API.md
+++ b/docs/API.md
@@ -133,9 +133,15 @@ The underlying `Tickets_Master` table contains the following fields:
 - `LastModfiedBy`
 - `Resolution`
 
+The `LastModified` and `LastModfiedBy` fields are managed by the system and
+are not accepted when creating new tickets.
+
 ### TicketCreate
 
-Use this schema when creating a ticket. The server automatically populates `Created_Date` so it should be omitted from the payload. All other fields match the database columns and most are optional. If `Ticket_Status_ID` is not supplied it defaults to `1` (Open).
+Use this schema when creating a ticket. The server automatically populates
+`Created_Date` so it should be omitted from the payload. Fields such as
+`LastModified` and `LastModfiedBy` are system-managed and cannot be provided in
+the request. If `Ticket_Status_ID` is not supplied it defaults to `1` (Open).
 
 Example:
 

--- a/src/core/services/ticket_management.py
+++ b/src/core/services/ticket_management.py
@@ -209,11 +209,12 @@ class TicketManager:
     ) -> OperationResult[Ticket]:
         if isinstance(ticket_obj, dict):
             ticket_obj = Ticket(**ticket_obj)
+        if getattr(ticket_obj, "LastModfiedBy", None) is None:
+            ticket_obj.LastModified = None
         # Ensure datetime fields are formatted for DB storage before flushing
         datetime_fields = [
             "Created_Date",
             "Closed_Date",
-            "LastModified",
             "EstimatedCompletionDate",
             "CustomCompletionDate",
             "LastMetaDataUpdateDate",

--- a/src/shared/schemas/ticket.py
+++ b/src/shared/schemas/ticket.py
@@ -67,7 +67,6 @@ class TicketBase(BaseModel):
 class TicketCreate(TicketBase):
     """Schema used when creating a new ticket."""
 
-    LastModified: Optional[datetime] = None
     Version: Optional[int] = 1
 
     model_config = ConfigDict(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -65,3 +65,14 @@ def test_long_body_allowed():
     )
     assert obj.Ticket_Body == long_text
     assert obj.Resolution == long_text
+
+
+def test_last_modified_ignored():
+    obj = TicketCreate(
+        Subject="Test",
+        Ticket_Body="Body",
+        Ticket_Contact_Name="Name",
+        Ticket_Contact_Email="test@example.com",
+        **{"LastModified": "2024-01-01T00:00:00Z"},
+    )
+    assert "LastModified" not in obj.model_dump()


### PR DESCRIPTION
## Summary
- drop LastModified field from TicketCreate schema
- clarify in docs that LastModified/LastModfiedBy are system-managed
- ensure service sets LastModified only when modified by user and test that field is ignored

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab55f2123c832bac1e1f2ce463ef83