### PR TITLE
docs: clarify server timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ The `Tickets_Master` table stores the primary ticket data. Columns include:
 - `Site_ID`
 - `Ticket_Category_ID`
 - `Version`
-- `Created_Date`
+- `Created_Date` (set automatically by the database)
 - `Assigned_Name`
 - `Assigned_Email`
 - `Severity_ID`
 - `Assigned_Vendor_ID`
 - `Closed_Date`
-- `LastModified`
+- `LastModified` (read-only timestamp managed by the database)
 - `LastModfiedBy`
 - `Resolution`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -123,19 +123,21 @@ The underlying `Tickets_Master` table contains the following fields:
 - `Site_ID`
 - `Ticket_Category_ID`
 - `Version`
-- `Created_Date`
+- `Created_Date` (set automatically by the database)
 - `Assigned_Name`
 - `Assigned_Email`
 - `Severity_ID`
 - `Assigned_Vendor_ID`
 - `Closed_Date`
-- `LastModified`
+- `LastModified` (read-only timestamp managed by the database)
 - `LastModfiedBy`
 - `Resolution`
 
+`Created_Date` and `LastModified` are database-managed timestamps and are never accepted from client requests.
+
 ### TicketCreate
 
-Use this schema when creating a ticket. The server automatically populates `Created_Date` so it should be omitted from the payload. All other fields match the database columns and most are optional. If `Ticket_Status_ID` is not supplied it defaults to `1` (Open).
+Use this schema when creating a ticket. The server automatically populates `Created_Date` and sets `LastModified` on changes, so clients must omit both fields from the payload. All other fields match the database columns and most are optional. If `Ticket_Status_ID` is not supplied it defaults to `1` (Open).
 
 Example:
 
@@ -148,6 +150,18 @@ Example:
   "Asset_ID": 5,
   "Site_ID": 2,
   "Ticket_Category_ID": 1
+}
+```
+
+Server response:
+
+```json
+{
+  "Ticket_ID": 1,
+  "Subject": "Printer not working",
+  "Created_Date": "2024-01-01T12:00:00Z",
+  "LastModified": "2024-01-01T12:00:00Z",
+  "LastModfiedBy": "system"
 }
 ```
 
@@ -169,7 +183,7 @@ Another example showing assignment and severity:
 
 ### TicketUpdate
 
-This schema is used to partially update an existing ticket. Provide only the fields you want to change; omitted fields remain unchanged. Unknown fields are rejected and `Created_Date` cannot be updated.
+This schema is used to partially update an existing ticket. Provide only the fields you want to change; omitted fields remain unchanged. Unknown fields are rejected. `Created_Date` and `LastModified` are managed by the database and cannot be set by clients.
 
 Example payloads:
 
@@ -185,6 +199,16 @@ Example payloads:
 {"Ticket_Status_ID": 3}
 ```
 
+Server response snippet:
+
+```json
+{
+  "Ticket_ID": 1,
+  "LastModified": "2024-01-02T15:04:05Z",
+  "LastModfiedBy": "system"
+}
+```
+
 ### TicketExpandedOut
 
 `TicketExpandedOut` extends `TicketOut` with additional labels and timestamps.
@@ -197,6 +221,7 @@ Fields include:
 - `category_label` (maps to `Ticket_Category_Label`)
 - `Assigned_Vendor_Name`
 - `Priority_Level`
+- `Created_Date`
 - `Closed_Date`
 - `LastModified`
 - `LastModfiedBy`
@@ -211,8 +236,9 @@ Example:
   "Site_Label": "HQ",
   "Site_ID": 2,
   "Priority_Level": "High",
+  "Created_Date": "2024-01-01T12:00:00Z",
   "Closed_Date": null,
-  "LastModified": null,
-  "LastModfiedBy": null
+  "LastModified": "2024-01-02T09:30:00Z",
+  "LastModfiedBy": "system"
 }
 ```

--- a/docs/DATETIME_FORMAT.md
+++ b/docs/DATETIME_FORMAT.md
@@ -12,13 +12,15 @@ This repository provides helpers to ensure datetimes are handled consistently:
 - `parse_search_datetime(value)`: parses a string or `datetime`, normalizing to UTC and truncating microseconds to milliseconds.
 - `FormattedDateTime`: SQLAlchemy type that stores datetimes in the format above.
 
-## Ticket creation example
+Fields like `Created_Date` and `LastModified` are populated by the database and should **never** be sent by clients.
+
+## Filtering by creation date
 ```python
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from src.shared.utils.date_format import format_db_datetime
 
-payload = {
-    "Created_Date": format_db_datetime(datetime.now(timezone.utc)),
+params = {
+    "created_after": format_db_datetime(datetime.now(timezone.utc) - timedelta(days=7)),
 }
 ```
 


### PR DESCRIPTION
## Summary
- clarify that `Created_Date` and `LastModified` are server-generated in API docs
- update datetime guide to remove client-supplied examples
- note database-controlled timestamps in README

## Testing
- `pytest` *(fails: I/O operation on closed file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab55f5e3ac832b871f8cf342ccded5