### PR TITLE
Use database defaults for ticket message timestamps

### DIFF
--- a/tests/test_tickets_by_user.py
+++ b/tests/test_tickets_by_user.py
@@ -59,7 +59,6 @@ async def test_get_tickets_by_user_function():
             Message="hi",
             SenderUserCode="user@example.com",
             SenderUserName="User",
-            DateTimeStamp=now,
         )
         db.add(msg)
         await db.commit()


### PR DESCRIPTION
## Summary
- Remove explicit `DateTimeStamp` assignment when creating test ticket messages
- Ensure ticket message timestamps rely on database defaults

## Testing
- `rg 'DateTimeStamp=' -n`
- `pytest tests/test_ticket_messages.py -q`
- `alembic upgrade heads` *(fails: `sqlite3.OperationalError: near "ALTER": syntax error`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab893a4068832b8747274acacdc703