### PR TITLE
Remove legacy tickets router

### DIFF
--- a/src/api/v1/__init__.py
+++ b/src/api/v1/__init__.py
@@ -1,14 +1,13 @@
 from fastapi import FastAPI
 
 from .deps import get_db, get_db_with_commit  # re-export for external use
-from .tickets import ticket_router, tickets_router
+from .tickets import ticket_router
 from .analytics import analytics_router
 from .auth import auth_router
 
 
 def register_routes(app: FastAPI) -> None:
     app.include_router(ticket_router)
-    app.include_router(tickets_router)
     app.include_router(analytics_router)
     app.include_router(auth_router)
 
@@ -16,7 +15,6 @@ __all__ = [
     "get_db",
     "get_db_with_commit",
     "ticket_router",
-    "tickets_router",
     "analytics_router",
     "auth_router",
     "register_routes",

--- a/src/api/v1/tickets.py
+++ b/src/api/v1/tickets.py
@@ -28,11 +28,11 @@ from .deps import get_db, get_db_with_commit, extract_filters
 
 logger = logging.getLogger(__name__)
 
-# ─── Tickets Sub-Router ───────────────────────────────────────────────────────
+# ─── Tickets Router ───────────────────────────────────────────────────────────
 
+# All ticket-related endpoints are registered under a single router. This
+# simplifies route registration and ensures each endpoint exists only once.
 ticket_router = APIRouter(prefix="/ticket", tags=["tickets"])
-# Additional router exposing the same endpoints under the legacy "/tickets" prefix
-tickets_router = APIRouter(prefix="/tickets", tags=["tickets"])
 
 
 class MessageIn(BaseModel):
@@ -379,66 +379,4 @@ async def add_ticket_message(
     return TicketMessageOut.model_validate(created)
 
 
-# ─── Legacy /tickets router with same endpoints ──────────────────────────────
-
-
-@tickets_router.get(
-    "/search",
-    response_model=List[TicketSearchOut],
-    operation_id="search_tickets_legacy",
-    response_model_by_alias=False,
-)
-async def search_tickets_legacy(
-    q: str = Query(..., min_length=1),
-    params: TicketSearchParams = Depends(),
-    limit: int = Query(10, ge=1, le=100),
-    db: AsyncSession = Depends(get_db),
-) -> List[TicketSearchOut]:
-    return await search_tickets(q, params, limit, db)
-
-
-@tickets_router.post(
-    "/search",
-    response_model=List[TicketSearchOut],
-    operation_id="search_tickets_json_legacy",
-)
-async def search_tickets_json_legacy(
-    payload: TicketSearchRequest,
-    db: AsyncSession = Depends(get_db),
-) -> List[TicketSearchOut]:
-    return await search_tickets_json(payload, db)
-
-
-@tickets_router.get(
-    "/expanded",
-    response_model=PaginatedResponse[TicketExpandedOut],
-    operation_id="list_expanded_tickets_legacy",
-    response_model_by_alias=False,
-)
-async def list_tickets_expanded_legacy(
-    request: Request,
-    skip: int = Query(0, ge=0),
-    limit: int = Query(10, ge=1),
-    db: AsyncSession = Depends(get_db),
-) -> PaginatedResponse[TicketExpandedOut]:
-    return await list_tickets(request, skip, limit, db)
-
-
-@tickets_router.get(
-    "/by_user",
-    response_model=PaginatedResponse[TicketExpandedOut],
-    operation_id="tickets_by_user_legacy",
-    response_model_by_alias=False,
-)
-async def tickets_by_user_legacy(
-    request: Request,
-    identifier: str = Query(..., min_length=1),
-    skip: int = Query(0, ge=0),
-    limit: int = Query(100, ge=1),
-    status: str | None = Query(None),
-    db: AsyncSession = Depends(get_db),
-) -> PaginatedResponse[TicketExpandedOut]:
-    return await tickets_by_user_endpoint(request, identifier, skip, limit, status, db)
-
-
-__all__ = ["ticket_router", "tickets_router"]
+__all__ = ["ticket_router"]

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -25,7 +25,7 @@ async def _add_sample_ticket():
 async def _search_worker():
     transport = ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.get("/tickets/search", params={"q": "Net"})
+        resp = await ac.get("/ticket/search", params={"q": "Net"})
         return resp.json()[0]["Subject"]
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -63,7 +63,7 @@ async def test_create_and_get_ticket(client: AsyncClient):
     assert created["Version"] == 1
     tid = created["Ticket_ID"]
 
-    list_resp = await client.get("/tickets/expanded")
+    list_resp = await client.get("/ticket/expanded")
     assert list_resp.status_code == 200
     data = list_resp.json()
     assert data["total"] == 1

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -60,7 +60,7 @@ async def test_search_endpoint_handles_long_ticket_body():
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.get("/tickets/search", params={"q": "Bad"})
+        resp = await ac.get("/ticket/search", params={"q": "Bad"})
         assert resp.status_code == 200
         data = resp.json()
         assert any(item["Ticket_ID"] == bad_id for item in data)

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -36,7 +36,7 @@ async def test_search_returns_long_ticket_body():
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.get("/tickets/search", params={"q": "Query"})
+        resp = await ac.get("/ticket/search", params={"q": "Query"})
         assert resp.status_code == 200
         data = resp.json()
         ids = {item["Ticket_ID"] for item in data}
@@ -76,14 +76,14 @@ async def test_search_filters_and_sort():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get(
-            "/tickets/search",
+            "/ticket/search",
             params={"q": "Query", "Site_ID": 1, "Ticket_Status_ID": 1, "sort": "oldest"},
         )
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1 and data[0]["Ticket_ID"] == first_id
 
-        resp = await ac.get("/tickets/search", params={"q": "Query", "sort": "oldest"})
+        resp = await ac.get("/ticket/search", params={"q": "Query", "sort": "oldest"})
         ids = [item["Ticket_ID"] for item in resp.json()]
         assert ids == [first_id, second_id]
 
@@ -105,7 +105,7 @@ async def test_search_accepts_json():
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.post("/tickets/search", json={"q": "JSON Search"})
+        resp = await ac.post("/ticket/search", json={"q": "JSON Search"})
         assert resp.status_code == 200
         ids = [item["Ticket_ID"] for item in resp.json()]
         assert tid in ids
@@ -135,7 +135,7 @@ async def test_search_created_date_filters_endpoint():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get(
-            "/tickets/search",
+            "/ticket/search",
             params={"q": "DateFilter", "created_after": "2023-01-05T00:00:00+00:00"},
         )
         assert resp.status_code == 200
@@ -143,7 +143,7 @@ async def test_search_created_date_filters_endpoint():
         assert ids == {new_id}
 
         resp = await ac.post(
-            "/tickets/search",
+            "/ticket/search",
             json={
                 "q": "DateFilter",
                 "params": {"created_before": "2023-01-05T00:00:00+00:00"},

--- a/tests/test_tickets_by_user.py
+++ b/tests/test_tickets_by_user.py
@@ -110,7 +110,7 @@ async def test_tickets_by_user_endpoint():
             )
             await TicketManager().create_ticket(db, t)
             await db.commit()
-        resp = await ac.get("/tickets/by_user", params={"identifier": "endpoint@example.com"})
+        resp = await ac.get("/ticket/by_user", params={"identifier": "endpoint@example.com"})
         assert resp.status_code == 200
         data = resp.json()
         assert data["total"] >= 1
@@ -128,7 +128,7 @@ async def test_tickets_by_user_endpoint():
             )
             await TicketManager().create_ticket(db, t_new)
             await db.commit()
-        resp = await ac.get("/tickets/by_user", params={"identifier": "endpoint@example.com"})
+        resp = await ac.get("/ticket/by_user", params={"identifier": "endpoint@example.com"})
         ids = [item["Ticket_ID"] for item in resp.json()["items"]]
         assert t_new.Ticket_ID in ids
 
@@ -202,7 +202,7 @@ async def test_status_and_filtering():
             await db.commit()
 
         resp = await ac.get(
-            "/tickets/by_user",
+            "/ticket/by_user",
             params={"identifier": "filter@example.com", "status": "closed"},
         )
         assert resp.status_code == 200
@@ -210,7 +210,7 @@ async def test_status_and_filtering():
         assert ids == [closed_t.Ticket_ID]
 
         resp = await ac.get(
-            "/tickets/by_user",
+            "/ticket/by_user",
             params={"identifier": "filter@example.com", "Site_ID": 1},
         )
         assert resp.status_code == 200

--- a/tests/test_tickets_expanded.py
+++ b/tests/test_tickets_expanded.py
@@ -41,7 +41,7 @@ async def test_tickets_expanded_endpoint(client: AsyncClient):
     assert created.status_code == 201
     tid = created.json()["Ticket_ID"]
 
-    resp = await client.get("/tickets/expanded")
+    resp = await client.get("/ticket/expanded")
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 1
@@ -98,7 +98,7 @@ async def test_ticket_filtering(client: AsyncClient):
         },
     )
 
-    resp = await client.get("/tickets/expanded", params={"Subject": "Foo"})
+    resp = await client.get("/ticket/expanded", params={"Subject": "Foo"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 1
@@ -127,7 +127,7 @@ async def test_ticket_sorting(client: AsyncClient):
         },
     )
 
-    resp = await client.get("/tickets/expanded", params={"sort": "-Ticket_ID"})
+    resp = await client.get("/ticket/expanded", params={"sort": "-Ticket_ID"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["items"][0]["Ticket_ID"] == second.json()["Ticket_ID"]


### PR DESCRIPTION
## Summary
- streamline ticket API routing by using a single `ticket_router`
- drop legacy `/tickets` router and associated duplicate endpoints
- update tests to use the unified `/ticket` routes

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68aba6b5d584832ba002d14a610b968f