### PR TITLE
refactor: add waiting on user status constant

### DIFF
--- a/src/core/services/analytics_reporting.py
+++ b/src/core/services/analytics_reporting.py
@@ -16,6 +16,7 @@ from src.core.repositories.models import Ticket, TicketStatus, Site
 from src.core.services.ticket_management import _OPEN_STATE_IDS
 
 _CLOSED_STATE_IDS = [3]
+WAITING_ON_USER_STATUS_ID = 4
 
 from src.shared.schemas.analytics import (
     StatusCount,
@@ -206,14 +207,14 @@ async def open_tickets_by_user(
 
 
 async def tickets_waiting_on_user(db: AsyncSession) -> List[WaitingOnUserCount]:
-    """Return counts of tickets awaiting user response (status == 4)."""
+    """Return counts of tickets awaiting user response (status == WAITING_ON_USER_STATUS_ID)."""
     logger.info("Calculating tickets waiting on user")
     result = await db.execute(
         select(
             Ticket.Ticket_Contact_Email,
             func.count(Ticket.Ticket_ID),
         )
-        .filter(Ticket.Ticket_Status_ID == 4)
+        .filter(Ticket.Ticket_Status_ID == WAITING_ON_USER_STATUS_ID)
         .group_by(Ticket.Ticket_Contact_Email)
     )
     return [


### PR DESCRIPTION
## Summary
- add `WAITING_ON_USER_STATUS_ID` constant and use it in `tickets_waiting_on_user`

## Testing
- `flake8 src/core/services/analytics_reporting.py`
- `pytest tests/test_analytics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abbc3c6154832bb64cc7bff2305c31