### PR TITLE
refactor: simplify open tickets filter typing

### DIFF
--- a/src/api/v1/analytics.py
+++ b/src/api/v1/analytics.py
@@ -63,7 +63,7 @@ async def open_by_assigned_user_endpoint(
     request: Request, db: AsyncSession = Depends(get_db)
 ) -> List[UserOpenCount]:
     filters = extract_filters(request)
-    return await open_tickets_by_user(db, filters or None)
+    return await open_tickets_by_user(db, filters)
 
 
 @analytics_router.get(

--- a/src/core/services/analytics_reporting.py
+++ b/src/core/services/analytics_reporting.py
@@ -177,7 +177,7 @@ async def sla_breaches(
 
 
 async def open_tickets_by_user(
-    db: AsyncSession, filters: Optional[Dict[str, Any]] | None = None
+    db: AsyncSession, filters: Optional[Dict[str, Any]] = None
 ) -> List[UserOpenCount]:
     """Return open ticket counts for assigned technicians with optional filtering."""
 


### PR DESCRIPTION
## Summary
- narrow open ticket filter type to Optional[Dict[str, Any]]
- stop passing redundant None when calling open_tickets_by_user

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abbc44707c832baff8d765a11d783c