### PR TITLE
Add status counts analytics support

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -996,6 +996,15 @@ async def _get_analytics_unified(
                 overdue = await mgr._get_overdue_tickets_summary()
             return {"status": "success", "data": overdue}
 
+        if type == "status_counts":
+            async with db.SessionLocal() as db_session:
+                result = await tickets_by_status(db_session)
+            if not result.success:
+                return {"status": "error", "error": result.error}
+            return {
+                "status": "success",
+                "data": [item.model_dump() for item in result.data],
+            }
 
         valid_types = {
             "overview",
@@ -1006,9 +1015,6 @@ async def _get_analytics_unified(
             "overdue_tickets",
             "status_counts",
         }
-
-        if type in {"status_counts"}:
-            return JSONResponse(status_code=404, content={"detail": "Unsupported analytics type"})
 
         return {
             "status": "error",
@@ -1565,7 +1571,6 @@ ENHANCED_TOOLS: List[Tool] = [
         inputSchema={
             "type": "object",
             "properties": {
-                "type": {"type": "string", "description": "Analytics report type"},
                 "type": {
                     "type": "string",
                     "enum": [

--- a/tests/test_additional_tools.py
+++ b/tests/test_additional_tools.py
@@ -342,6 +342,18 @@ async def test_get_analytics_sla_performance_error(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_get_analytics_status_counts_success(client: AsyncClient):
+    await _create_ticket(client)
+    await _create_ticket(client)
+    resp = await client.post("/get_analytics", json={"type": "status_counts"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("status") == "success"
+    assert isinstance(data.get("data"), list)
+    assert sum(item["count"] for item in data["data"]) >= 2
+
+
+@pytest.mark.asyncio
 async def test_bulk_update_tickets_success(client: AsyncClient):
     tid1 = await _create_ticket(client, "Bulk1")
     tid2 = await _create_ticket(client, "Bulk2")


### PR DESCRIPTION
## Summary
- handle `status_counts` in unified analytics endpoint
- document `status_counts` in `get_analytics` tool schema
- test analytics status counts reporting

## Testing
- `pytest tests/test_additional_tools.py::test_get_analytics_status_counts_success -q`
- `pytest tests/test_additional_tools.py::test_get_analytics_sla_performance_success tests/test_additional_tools.py::test_get_analytics_sla_performance_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68abc0428920832b84b03128524bf806