### PR TITLE
Wrap analytics results in OperationResult

### DIFF
--- a/tools/analytics_reporting.py
+++ b/tools/analytics_reporting.py
@@ -8,6 +8,7 @@ from src.core.services.analytics_reporting import (
     tickets_by_status,
     tickets_waiting_on_user,
 )
+from src.core.services.system_utilities import OperationResult
 
 __all__ = [
     "tickets_by_status",
@@ -18,4 +19,5 @@ __all__ = [
     "ticket_trend",
     "get_staff_ticket_report",
     "AnalyticsManager",
+    "OperationResult",
 ]


### PR DESCRIPTION
## Summary
- Wrap analytic helpers in `OperationResult` for consistent success/error reporting
- Propagate `OperationResult` handling through API endpoints and enhanced MCP server
- Re-export `OperationResult` from analytics tooling module

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abbc420254832b851e2ac06b2f3a58