### PR TITLE
Use neutral default label for priority aggregations

### DIFF
--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -1,0 +1,5 @@
+"""Core constants for reusable default values."""
+
+DEFAULT_LABEL = "Unknown"
+
+__all__ = ["DEFAULT_LABEL"]

--- a/src/core/services/advanced_query.py
+++ b/src/core/services/advanced_query.py
@@ -7,9 +7,10 @@ from typing import List, Dict, Any, Optional
 from sqlalchemy import select, func, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.core.repositories.models import VTicketMasterExpanded, TicketMessage, TicketAttachment
+from src.core.repositories.models import VTicketMasterExpanded
 from src.shared.schemas.agent_data import AdvancedQuery, QueryResult
 from .enhanced_context import EnhancedContextManager
+from src.core.constants import DEFAULT_LABEL
 
 logger = logging.getLogger(__name__)
 
@@ -197,19 +198,19 @@ class AdvancedQueryManager:
 
         for ticket in tickets:
             # Status
-            status = ticket.Ticket_Status_Label or "Unknown"
+            status = ticket.Ticket_Status_Label or DEFAULT_LABEL
             status_counts[status] = status_counts.get(status, 0) + 1
 
             # Priority
-            priority = ticket.Priority_Level or "Medium"
+            priority = ticket.Priority_Level or DEFAULT_LABEL
             priority_counts[priority] = priority_counts.get(priority, 0) + 1
 
             # Site
-            site = ticket.Site_Label or "Unknown"
+            site = ticket.Site_Label or DEFAULT_LABEL
             site_counts[site] = site_counts.get(site, 0) + 1
 
             # Category
-            category = ticket.Ticket_Category_Label or "Unknown"
+            category = ticket.Ticket_Category_Label or DEFAULT_LABEL
             category_counts[category] = category_counts.get(category, 0) + 1
 
         return {

--- a/tests/test_query_aggregations.py
+++ b/tests/test_query_aggregations.py
@@ -1,0 +1,22 @@
+import pytest
+from types import SimpleNamespace
+
+from src.core.services.advanced_query import AdvancedQueryManager
+from src.core.constants import DEFAULT_LABEL
+
+
+@pytest.mark.asyncio
+async def test_generate_query_aggregations_uses_default_label():
+    manager = AdvancedQueryManager(db=None)
+    ticket = SimpleNamespace(
+        Ticket_Status_Label=None,
+        Priority_Level=None,
+        Site_Label=None,
+        Ticket_Category_Label=None,
+    )
+    result = await manager._generate_query_aggregations([ticket])
+    expected = {DEFAULT_LABEL: 1}
+    assert result["status_breakdown"] == expected
+    assert result["priority_breakdown"] == expected
+    assert result["site_breakdown"] == expected
+    assert result["category_breakdown"] == expected


### PR DESCRIPTION
## Summary
- centralize default label in new constant
- use neutral default label for priority breakdowns
- add test covering aggregation defaults

## Testing
- `pytest tests/test_query_aggregations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68abc92e8a0c832ba7cea363b8cc7d73