### PR TITLE
Clamp advanced search result limits

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -54,7 +54,7 @@ paths remain for backwards compatibility but are no longer documented here.
 - `GET /agent/ticket/{ticket_id}/full-context` – full context for a ticket.
 - `GET /agent/system/snapshot` – system state snapshot.
 - `GET /agent/user/{user_email}/complete-profile` – user profile information.
-- `POST /agent/tickets/query-advanced` – execute an advanced ticket query.
+- `POST /agent/tickets/query-advanced` – execute an advanced ticket query (limit capped at 1000).
 - `POST /agent/operation/validate` – validate an operation.
 - `POST /agent/ticket/{ticket_id}/execute-operation` – run a ticket operation.
 
@@ -99,7 +99,7 @@ JSON body matching the tool's schema. See
 - `POST /get_ticket_stats` – Ticket statistics summary. Example: `{}`
 - `POST /get_workload_analytics` – Technician workload analytics. Example: `{}`
 
-- `POST /advanced_search` – Advanced ticket search. Example: `{"text_search": "printer"}`
+- `POST /advanced_search` – Advanced ticket search (limit capped at 1000). Example: `{"text_search": "printer"}`
 
 - `POST /sla_metrics` – SLA metrics summary. Example: `{}`
 - `POST /bulk_update_tickets` – Bulk ticket updates using semantic fields or

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -344,7 +344,7 @@ Parameters:
 - `assigned_to` – restrict to these assignee emails or names.
 - `unassigned_only` – set to `true` to return only unassigned tickets.
 - `site_filter` – list of site IDs.
-- `limit` – maximum results to return (default 100).
+- `limit` – maximum results to return (default 100, max 1000).
 - `offset` – result offset (default 0).
 
 Example:

--- a/src/shared/schemas/agent_data.py
+++ b/src/shared/schemas/agent_data.py
@@ -2,6 +2,9 @@ from pydantic import BaseModel, field_validator
 from typing import List, Optional, Dict, Any
 from datetime import datetime
 
+# Maximum number of results that can be requested in an advanced query
+MAX_LIMIT = 1000
+
 
 class TicketFullContext(BaseModel):
     """Complete ticket data with all related information for agent analysis."""
@@ -116,9 +119,11 @@ class AdvancedQuery(BaseModel):
 
     @field_validator("limit", "offset")
     @classmethod
-    def non_negative(cls, v: int) -> int:
+    def non_negative(cls, v: int, info):
         if v < 0:
             raise ValueError("must be >= 0")
+        if info.field_name == "limit" and v > MAX_LIMIT:
+            return MAX_LIMIT
         return v
 
 

--- a/tests/test_advanced_query_limit.py
+++ b/tests/test_advanced_query_limit.py
@@ -1,0 +1,7 @@
+from src.shared.schemas.agent_data import AdvancedQuery, MAX_LIMIT
+
+
+def test_limit_clamped_to_max():
+    q = AdvancedQuery(limit=MAX_LIMIT + 1)
+    assert q.limit == MAX_LIMIT
+


### PR DESCRIPTION
## Summary
- cap advanced ticket search limit at a new MAX_LIMIT constant
- document 1000 result limit in API and MCP tool docs
- test AdvancedQuery limit clamping

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abc9327390832b8b1a21e9eb4ad8a5