### PR TITLE
Batch apply advanced query order expressions

### DIFF
--- a/src/core/services/advanced_query.py
+++ b/src/core/services/advanced_query.py
@@ -111,6 +111,7 @@ class AdvancedQueryManager:
         total_count = await self.db.scalar(count_stmt) or 0
 
         # Apply sorting
+        order_exprs = []
         for sort_spec in query.sort_by:
             field = sort_spec.get("field", "Created_Date")
             direction = sort_spec.get("direction", "desc")
@@ -118,9 +119,12 @@ class AdvancedQueryManager:
             if hasattr(VTicketMasterExpanded, field):
                 attr = getattr(VTicketMasterExpanded, field)
                 if direction.lower() == "desc":
-                    stmt = stmt.order_by(attr.desc())
+                    order_exprs.append(attr.desc())
                 else:
-                    stmt = stmt.order_by(attr.asc())
+                    order_exprs.append(attr.asc())
+
+        if order_exprs:
+            stmt = stmt.order_by(*order_exprs)
 
         # Apply pagination
         stmt = stmt.offset(query.offset).limit(query.limit)

--- a/tests/test_advanced_query_sorting.py
+++ b/tests/test_advanced_query_sorting.py
@@ -1,0 +1,60 @@
+import pytest
+from datetime import datetime, UTC
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.infrastructure.database import SessionLocal
+from src.core.repositories.models import Ticket
+from src.core.services.ticket_management import TicketManager
+from src.core.services.advanced_query import AdvancedQueryManager
+from src.shared.schemas.agent_data import AdvancedQuery
+
+
+@pytest.mark.asyncio
+async def test_multiple_sort_fields_honored(monkeypatch):
+    async with SessionLocal() as db:
+        t1 = Ticket(
+            Subject="A",
+            Ticket_Body="b",
+            Ticket_Contact_Name="n",
+            Ticket_Contact_Email="e@example.com",
+            Created_Date=datetime(2023, 1, 1, tzinfo=UTC),
+        )
+        t2 = Ticket(
+            Subject="B",
+            Ticket_Body="b",
+            Ticket_Contact_Name="n",
+            Ticket_Contact_Email="e@example.com",
+            Created_Date=datetime(2023, 1, 1, tzinfo=UTC),
+        )
+        tm = TicketManager()
+        r1 = await tm.create_ticket(db, t1)
+        r2 = await tm.create_ticket(db, t2)
+        await db.commit()
+        t1_id, t2_id = r1.data.Ticket_ID, r2.data.Ticket_ID
+
+        executed = []
+        orig_execute = AsyncSession.execute
+
+        async def spy(self, statement, *args, **kwargs):
+            executed.append(statement)
+            return await orig_execute(self, statement, *args, **kwargs)
+
+        monkeypatch.setattr(AsyncSession, "execute", spy)
+
+        query = AdvancedQuery(
+            sort_by=[
+                {"field": "Created_Date", "direction": "asc"},
+                {"field": "Ticket_ID", "direction": "desc"},
+            ]
+        )
+        manager = AdvancedQueryManager(db)
+        result = await manager.query_tickets_advanced(query)
+
+        ids = [t["Ticket_ID"] for t in result.tickets]
+        assert ids == [t2_id, t1_id]
+
+        sql = str(executed[-1].compile(compile_kwargs={"literal_binds": True}))
+        assert (
+            'ORDER BY "V_Ticket_Master_Expanded"."Created_Date" ASC, '
+            '"V_Ticket_Master_Expanded"."Ticket_ID" DESC' in sql
+        )


### PR DESCRIPTION
## Summary
- accumulate sort expressions and apply all at once in `query_tickets_advanced`
- test that multiple sort fields generate combined ORDER BY

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abc934fa3c832bac9e25d36b6a1fdb