### PR TITLE
docs: document ticket lookup by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,13 +390,19 @@ python verify_tools.py http://localhost:8000
 
 ### Tool Reference
 
-The MCP server exposes several JSON-RPC tools. `get_tickets_by_user` returns
-expanded ticket records for a user. It accepts an `identifier`, optional
-`status` and arbitrary `filters`. Detailed descriptions for every tool are
-available in [docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md).
+The MCP server exposes several JSON-RPC tools. Use `GET /ticket/by_user` or the
+`search_tickets` tool with a `user` parameter to retrieve expanded ticket
+records for a user. The legacy `POST /get_tickets_by_user` route remains
+available for backward compatibility and should be considered deprecated.
+Detailed descriptions for every tool are available in
+[docs/MCP_TOOLS_GUIDE.md](docs/MCP_TOOLS_GUIDE.md).
 
 ```bash
-curl "http://localhost:8000/get_tickets_by_user?identifier=user@example.com&status=open"
+curl "http://localhost:8000/ticket/by_user?identifier=user@example.com&status=open"
+
+# or via the search_tickets tool
+curl -X POST http://localhost:8000/search_tickets \
+  -d '{"user": "user@example.com", "status": "open"}'
 ```
 
 Tool endpoints validate request bodies against each tool's `inputSchema` using
@@ -463,7 +469,7 @@ The server exposes ten core JSON-RPC tools. Each expects a JSON body matching it
 4. `update_ticket` – `{"ticket_id": 1, "updates": {}}` (semantic or raw fields)
 5. `add_ticket_message` – `{"ticket_id": 1, "message": "Checking", "sender_name": "Agent"}`
 6. `search_tickets` – `{"text": "printer", "status": 1, "days": 0}`
-7. `get_tickets_by_user` – `{"identifier": "user@example.com"}`
+7. `get_tickets_by_user` *(legacy – use `GET /ticket/by_user` or `search_tickets` with `user`)* – `{"identifier": "user@example.com"}`
 8. `get_open_tickets` – `{"days": 30}`
 9. `get_ticket_full_context` – `{"ticket_id": 123}` (no user history or nested related tickets)
 10. `get_system_snapshot` – `{}`
@@ -484,7 +490,7 @@ The server exposes the following JSON-RPC tools defined in `ENHANCED_TOOLS`. Eac
 - `advanced_search` – `{"text_search": "printer issue"}`
 - `search_tickets` – `{"text": "printer", "status": "open", "days": 0}`
 
-- `get_tickets_by_user` – `{"identifier": "user@example.com"}`
+- `get_tickets_by_user` *(legacy – use `GET /ticket/by_user` or `search_tickets` with `user`)* – `{"identifier": "user@example.com"}`
 - `get_ticket_full_context` – `{"ticket_id": 123}` (no user history or nested related tickets)
 - `get_system_snapshot` – `{}`
 - `get_ticket_stats` – `{}`

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,6 +27,16 @@ paths remain for backwards compatibility but are no longer documented here.
 - `GET /ticket/{ticket_id}/messages` – list ticket messages.
 - `POST /ticket/{ticket_id}/messages` – add a message to a ticket.
 
+Example:
+
+```bash
+curl "http://localhost:8000/ticket/by_user?identifier=user@example.com&status=open"
+```
+
+The `POST /get_tickets_by_user` route is retained for compatibility but is
+considered legacy; use `GET /ticket/by_user` or `POST /search_tickets` with a
+`user` parameter instead.
+
 ## Lookup Endpoints
 
 - `GET /lookup/assets` – list assets.
@@ -88,7 +98,7 @@ JSON body matching the tool's schema. See
   `/search_tickets_advanced` route was removed.
 - `POST /update_ticket` – Update, close, or assign a ticket using semantic
   fields or raw IDs as defined in the mapping table.
-- `POST /get_tickets_by_user` – Tickets for a user. Example: `{"identifier": "user@example.com"}`
+- `POST /get_tickets_by_user` *(legacy)* – Tickets for a user. Example: `{"identifier": "user@example.com"}`. Prefer `GET /ticket/by_user` or `POST /search_tickets` with a `user` parameter.
 
 - `POST /get_open_tickets` – List open tickets. Example: `{"days": 30}`
 - `POST /get_analytics` – Analytics reports. Example: `{"type": "site_counts"}`

--- a/docs/MCP_TOOLS_GUIDE.md
+++ b/docs/MCP_TOOLS_GUIDE.md
@@ -104,7 +104,7 @@ curl -X POST http://localhost:8000/get_ticket_attachments \
 ```
 
 ## search_tickets
-Comprehensive ticket search with AI-optimized features and semantic filtering. Supports text queries, user filtering, date ranges, and intelligent result ranking.
+Comprehensive ticket search with AI-optimized features and semantic filtering. Supports text queries, user filtering, date ranges, and intelligent result ranking. This tool replaces the legacy `get_tickets_by_user` route; use the `user` parameter to retrieve tickets for a specific person.
 
 ### Parameters
 
@@ -215,20 +215,29 @@ Site Reference
 | 6       | Corporate       | 1000     |
 | 7       | Heinz Retail Estate | 2000 |
 
-## get_tickets_by_user
+## get_tickets_by_user *(Legacy)*
 Retrieve tickets associated with a user.
 
-Parameters:
+> **Deprecated:** This POST endpoint is kept for backward compatibility. Use
+> `GET /ticket/by_user` or the `search_tickets` tool with a `user` parameter
+> instead.
+
+Legacy parameters:
 - `identifier` – email or other user identifier.
 - `skip` – optional offset (default 0).
 - `limit` – optional maximum number (default 100).
 - `status` – optional status filter.
 - `filters` – optional additional filters.
 
-Example:
+Legacy example:
 ```bash
 curl -X POST http://localhost:8000/get_tickets_by_user \
   -d '{"identifier": "user@example.com", "status": "open"}'
+```
+
+Current replacement:
+```bash
+curl "http://localhost:8000/ticket/by_user?identifier=user@example.com&status=open"
 ```
 
 ## get_open_tickets


### PR DESCRIPTION
## Summary
- document `GET /ticket/by_user` and `search_tickets` with `user`
- mark `POST /get_tickets_by_user` as legacy
- update examples to use the new route and parameter

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abce15ca20832bb7a4bbf09b1e6fb8