### PR TITLE
Allow null status filter in search_tickets tool

### DIFF
--- a/src/enhanced_mcp_server.py
+++ b/src/enhanced_mcp_server.py
@@ -1358,7 +1358,11 @@ ENHANCED_TOOLS: List[Tool] = [
                 },
                 "created_after": {"type": "string", "format": "date-time", "description": "ISO 8601 datetime inclusive"},
                 "created_before": {"type": "string", "format": "date-time", "description": "ISO 8601 datetime inclusive"},
-                "status": {"type": "string", "enum": ["open", "in_progress", "resolved", "closed"], "description": "Ticket status"},
+                "status": {
+                    "type": ["string", "null"],
+                    "enum": ["open", "in_progress", "resolved", "closed", None],
+                    "description": "Ticket status",
+                },
                 "priority": {"type": "string", "enum": ["critical", "high", "medium", "low"], "description": "Priority level"},
                 "site_id": {"type": "integer", "description": "Filter by specific site ID"},
                 "assigned_to": {"type": "string", "description": "Filter by assignee email"},


### PR DESCRIPTION
## Summary
- allow `status` parameter in `search_tickets` tool to accept `null`
- test that providing `null` status performs search without filtering

## Testing
- `pre-commit run --files src/enhanced_mcp_server.py tests/test_enhanced_search.py` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest tests/test_enhanced_search.py::test_search_tickets_accepts_null_status -q`


------
https://chatgpt.com/codex/tasks/task_e_68abce1903c4832b9ae4282045e269f4